### PR TITLE
chore: enable Renovate with scratch-renovate-config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "packageRules": [
+    {
+      // JS packages we want to treat as apps
+      "matchCategories": ["js"],
+      "matchPackageNames": [
+        // scratch-gui is kind of a lib (wrapped by www, desktop, etc.) but kind of an app (esp. standalone)
+        // treating it as an app is slightly safer, so let's do that
+        "@scratch/scratch-gui"
+      ],
+      "extends": [
+        "github>scratchfoundation/scratch-renovate-config:js-app"
+      ]
+    },
+    {
+      // JS packages we want to treat as libs (should cover all JS except apps handled above)
+      "matchCategories": ["js"],
+      "matchPackageNames": [
+        "!@scratch/scratch-gui"
+      ],
+      "extends": [
+        "github>scratchfoundation/scratch-renovate-config:js-lib"
+      ]
+    },
+    {
+      // Non-JS updates use default Scratch config
+      "matchCategories": ["!js"],
+      "extends": [
+        "github>scratchfoundation/scratch-renovate-config"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Resolves

- Closes #1
- [UEPR-138](https://scratchfoundation.atlassian.net/browse/UEPR-138)

### Proposed Changes

Configure Renovate to use different `scratch-renovate-config` rule sets for different packages:
- `scratch-gui` uses Scratch's `js-app` rule set
- JavaScript packages other than `scratch-gui` use Scratch's `js-lib` rule set
- non-JavaScript packages use Scratch's default rule set

### Reason for Changes

See [here](https://github.com/scratchfoundation/scratch-renovate-config?tab=readme-ov-file#about-pinning) for too much detail about `js-app` vs. `js-lib` pinning.

The goal with this configuration is to cover all possible updates with exactly one Scratch rule set: `js-app`, `js-lib`, or default. I _think_ this configuration will do that, but I'd appreciate careful scrutiny and thinking. Thanks!


[UEPR-138]: https://scratchfoundation.atlassian.net/browse/UEPR-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ