### PR TITLE
fix: uepr-65: show delete modal only for sprites

### DIFF
--- a/packages/scratch-gui/src/components/asset-panel/selector.jsx
+++ b/packages/scratch-gui/src/components/asset-panel/selector.jsx
@@ -81,8 +81,6 @@ const Selector = props => {
                             onDeleteButtonClick={onDeleteClick}
                             onDuplicateButtonClick={onDuplicateClick}
                             onExportButtonClick={onExportClick}
-                            withDeleteConfirmation
-                            deleteConfirmationModalPosition={'right'}
                         />
                     </SortableAsset>
                 ))}

--- a/packages/scratch-gui/test/integration/sounds.test.js
+++ b/packages/scratch-gui/test/integration/sounds.test.js
@@ -35,7 +35,6 @@ describe('Working with sounds', () => {
         await rightClickText('Meow', scope.soundsTab);
         await driver.sleep(500); // Wait a moment for context menu; only needed for local testing
         await clickText('delete', scope.soundsTab);
-        await clickText('yes', scope.modal);
 
         // Add it back
         await clickXpath('//button[@aria-label="Choose a Sound"]');


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-65?focusedCommentId=14270&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14270

### Proposed Changes

Show modal only on sprites

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
