### PR TITLE
chore: change mumber of workers for running integration tests in gui

### DIFF
--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -31,7 +31,7 @@
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
     "start": "webpack serve",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
-    "test:integration": "cross-env JEST_JUNIT_OUTPUT_NAME=integration-tests-results.xml jest --maxWorkers=4 test[\\\\/]integration",
+    "test:integration": "cross-env JEST_JUNIT_OUTPUT_NAME=integration-tests-results.xml jest --maxWorkers=2 test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test:unit": "cross-env JEST_JUNIT_OUTPUT_NAME=unit-tests-results.xml jest test[\\\\/]unit",
     "test:smoke": "jest --runInBand test[\\\\/]smoke",


### PR DESCRIPTION
### Proposed Changes
Because `scratch-editor` is private repository the runners github uses for executing the workflows have 2 cores thus some spec timeout. This requires decreasing the number of workers
