### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Config GitHub user
         shell: bash


### PR DESCRIPTION
### Resolves

Addresses the need auth errors when trying to publish a package with `NODE_AUTH_TOKEN`
