### PR TITLE
fix(gui typing): make params optional

### DIFF
--- a/packages/scratch-gui/src/gui-config.ts
+++ b/packages/scratch-gui/src/gui-config.ts
@@ -23,10 +23,10 @@ export interface GUIStorage {
         projectId: ProjectId | null | undefined,
         vmState: string,
         params: {
-            originalId: ProjectId;
-            isCopy: boolean | 1;
-            isRemix: boolean | 1;
-            title: string;
+            originalId?: ProjectId;
+            isCopy?: boolean | 1;
+            isRemix?: boolean | 1;
+            title?: string;
         }
     ): Promise<{ id: ProjectId }>;
 


### PR DESCRIPTION
### Proposed Changes
Changes the fields in `params` object argument inside `saveProject` func to be optional 

### Reason for Changes
Linked to NGP - when we are not remixing, we receive an empty `params` object (so the fields are actually optional) and we need to reflect that in `GUIStorage` so that we have correct typing