### PR TITLE
fix: missing dist outputs in published packages

### DIFF
--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -21,6 +21,7 @@
       "default": "./dist/scratch-gui-standalone.js"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build": "npm run clean && BUILD_TYPE=dev webpack && BUILD_TYPE=dist webpack && BUILD_TYPE=dist-standalone webpack",
     "clean": "rimraf ./build ./dist",
@@ -31,7 +32,7 @@
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
     "start": "webpack serve",
     "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
-    "test:integration": "cross-env JEST_JUNIT_OUTPUT_NAME=integration-tests-results.xml jest --maxWorkers=2 test[\\\\/]integration",
+    "test:integration": "cross-env JEST_JUNIT_OUTPUT_NAME=integration-tests-results.xml jest --maxWorkers=4 test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test:unit": "cross-env JEST_JUNIT_OUTPUT_NAME=unit-tests-results.xml jest test[\\\\/]unit",
     "test:smoke": "jest --runInBand test[\\\\/]smoke",

--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -21,7 +21,7 @@
       "default": "./dist/scratch-gui-standalone.js"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "scripts": {
     "build": "npm run clean && BUILD_TYPE=dev webpack && BUILD_TYPE=dist webpack && BUILD_TYPE=dist-standalone webpack",
     "clean": "rimraf ./build ./dist",

--- a/packages/scratch-render/package.json
+++ b/packages/scratch-render/package.json
@@ -15,6 +15,7 @@
     "node": "./dist/node/scratch-render.js",
     "default": "./src/index.js"
   },
+  "files": ["dist"],
   "scripts": {
     "build": "webpack --progress",
     "docs": "jsdoc -c .jsdoc.json",

--- a/packages/scratch-render/package.json
+++ b/packages/scratch-render/package.json
@@ -16,7 +16,7 @@
     "node": "./dist/node/scratch-render.js",
     "default": "./src/index.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "scripts": {
     "build": "webpack --progress",
     "docs": "jsdoc -c .jsdoc.json",

--- a/packages/scratch-render/package.json
+++ b/packages/scratch-render/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/scratchfoundation/scratch-editor.git"
   },
+  "main": "./dist/node/scratch-render.js",
   "exports": {
     "webpack": "./src/index.js",
     "browser": "./dist/web/scratch-render.js",

--- a/packages/scratch-svg-renderer/package.json
+++ b/packages/scratch-svg-renderer/package.json
@@ -10,6 +10,7 @@
     "node": "./dist/node/scratch-svg-renderer.js",
     "default": "./src/index.js"
   },
+  "files": ["dist"],
   "scripts": {
     "build": "npm run clean && webpack",
     "clean": "rimraf ./dist",

--- a/packages/scratch-svg-renderer/package.json
+++ b/packages/scratch-svg-renderer/package.json
@@ -10,7 +10,7 @@
     "node": "./dist/node/scratch-svg-renderer.js",
     "default": "./src/index.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "scripts": {
     "build": "npm run clean && webpack",
     "clean": "rimraf ./dist",

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -17,6 +17,7 @@
     "node": "./dist/node/scratch-vm.js",
     "default": "./src/index.js"
   },
+  "files": ["dist"],
   "scripts": {
     "build": "npm run docs && webpack --progress",
     "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -17,7 +17,7 @@
     "node": "./dist/node/scratch-vm.js",
     "default": "./src/index.js"
   },
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "scripts": {
     "build": "npm run docs && webpack --progress",
     "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",


### PR DESCRIPTION
### Resolves

Executing `npm publish --access=public --workspace={package-name}` packs and publishes a package in the context of a workspace but it doesn't ignore only the files in the `.npmignore` in the workspace but looks into the root as well. Because `.npmignore` file is missing in the root of the editor npm uses the `.gitignore` one. This leads to publishing wrong files and directories.
In addition the standalone repositories publish unnecessary content for the functioning of the package. Setting `files` in package.jsons allows to list what we want to be included in the published package. Current packages will contain only:
- dist output
- package.json
- README
- LICENSE