### PR TITLE
fix: correct 'this' context when calling `saveProjectThumbnail`

### DIFF
--- a/packages/scratch-gui/src/lib/project-saver-hoc.jsx
+++ b/packages/scratch-gui/src/lib/project-saver-hoc.jsx
@@ -427,8 +427,9 @@ const ProjectSaverHOC = function (WrappedComponent) {
             isManualUpdating: getIsManualUpdating(loadingState),
             loadingState: loadingState,
             locale: state.locales.locale,
-            onUpdateProjectThumbnail: ownProps.onUpdateProjectThumbnail ??
-                ((projectId, thumbnail) => storage.saveProjectThumbnail(projectId, thumbnail)),
+            onUpdateProjectThumbnail:
+                ownProps.onUpdateProjectThumbnail ??
+                storage.saveProjectThumbnail?.bind(storage),
             projectChanged: state.scratchGui.projectChanged,
             reduxProjectId: state.scratchGui.projectState.projectId,
             reduxProjectTitle: state.scratchGui.projectTitle,

--- a/packages/scratch-gui/src/lib/project-saver-hoc.jsx
+++ b/packages/scratch-gui/src/lib/project-saver-hoc.jsx
@@ -427,7 +427,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
             isManualUpdating: getIsManualUpdating(loadingState),
             loadingState: loadingState,
             locale: state.locales.locale,
-            onUpdateProjectThumbnail: ownProps.onUpdateProjectThumbnail ?? storage.saveProjectThumbnail,
+            onUpdateProjectThumbnail: ownProps.onUpdateProjectThumbnail ??
+                ((projectId, thumbnail) => storage.saveProjectThumbnail(projectId, thumbnail)),
             projectChanged: state.scratchGui.projectChanged,
             reduxProjectId: state.scratchGui.projectState.projectId,
             reduxProjectTitle: state.scratchGui.projectTitle,


### PR DESCRIPTION
### Proposed Changes

Wrap the `storage.saveProject` function in an arrow function when passing to `onUpdateProjectThumbnail`

### Reason for Changes
We need to preserve the correct `this` binding when invoking the `saveProjectThumbnail`. Wrapping in an arrow function ensures we invoke the function from the correct object (storage)

