### PR TITLE
refactor(test): adjust test scripts to just test, not also build

### DIFF
--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -34,7 +34,7 @@
     "i18n:push": "tx-push-src scratch-editor interface translations/en.json",
     "i18n:src": "rimraf ./translations/messages/src && babel src > tmp.js && rimraf tmp.js && build-i18n-src ./translations/messages/src ./translations/",
     "start": "webpack serve",
-    "test": "npm run test:lint && npm run test:unit && npm run build && npm run test:integration",
+    "test": "npm run test:lint && npm run test:unit && npm run test:integration",
     "test:integration": "cross-env JEST_JUNIT_OUTPUT_NAME=integration-tests-results.xml jest --maxWorkers=4 test[\\\\/]integration",
     "test:lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test:unit": "cross-env JEST_JUNIT_OUTPUT_NAME=unit-tests-results.xml jest test[\\\\/]unit",

--- a/packages/scratch-render/package.json
+++ b/packages/scratch-render/package.json
@@ -21,14 +21,14 @@
     "src"
   ],
   "scripts": {
-    "build": "webpack --progress",
+    "build": "webpack --progress && npm run docs",
     "docs": "jsdoc -c .jsdoc.json",
     "lint": "eslint .",
     "prepublish": "npm run build",
     "prepublish-watch": "npm run watch",
     "start": "webpack-dev-server",
     "tap": "tap test/unit test/integration",
-    "test": "npm run lint && npm run docs && npm run build && npm run tap",
+    "test": "npm run lint && npm run tap",
     "watch": "webpack --progress --watch --watch-poll"
   },
   "tap": {


### PR DESCRIPTION
### Proposed Changes

Before: In `scratch-gui` and `scratch-render`, `npm test` included `npm run build` as one of its steps. In `scratch-svg-renderer` and `scratch-vm`, `npm test` would not build.

After: All workspaces in this repo are consistent: `npm test` does not cause a build, and does not modify any files other than test output (logs, etc.). You should `npm run build` before running `npm test`.

### Reason for Changes

This allows faster iteration on tests, skips redundant builds in CI workflows, and opens the door to repeatable, independent test workflows in CI. I'd argue it's also more correct this way, but that's open to debate :)

### Test Coverage

Tested locally and by the CI workflows associated with this PR.