### PR TITLE
fix: accept application/x-scratch3-sprite for sprite uploads

### DIFF
--- a/packages/scratch-gui/src/lib/file-uploader.js
+++ b/packages/scratch-gui/src/lib/file-uploader.js
@@ -211,6 +211,7 @@ const soundUpload = function (fileData, fileType, storage, handleSound, handleEr
 const spriteUpload = function (fileData, fileType, spriteName, storage, handleSprite, handleError = () => {}) {
     switch (fileType) {
     case '':
+    case 'application/x-scratch3-sprite': // Some builds, such as from the AUR, cause browsers to report this MIME type
     case 'application/zip': { // We think this is a .sprite2 or .sprite3 file
         handleSprite(new Uint8Array(fileData));
         return;


### PR DESCRIPTION
### Resolves

It seems likely that this issue was already filed, maybe years ago, but I couldn't find it. I found several issues suggesting that we do something about our MIME types, just... not this particular issue :sweat_smile:

### Proposed Changes

Add `application/x-scratch3-sprite` to the list of accepted "file types" for sprite upload.

### Reason for Changes

Installing <https://aur.archlinux.org/packages/scratch3> (or the `-bin` version) registers the `application/x-scratch3-sprite` type with the system (see `/usr/share/mime/scratch3.xml`), which is kinda cool, but it also causes certain browsers to report `sprite3` files with that MIME type during file upload. So, if you have one of those two applications installed, sprite upload fails. That includes the copy of Chromium that I use for integration tests. Fun!

### Test Coverage

Tested locally after investigating why integration tests were failing for me but passing on CI...