### PR TITLE
feat: add flag to skip setting onbeforeunload handler

### DIFF
--- a/packages/scratch-gui/src/lib/project-saver-hoc.jsx
+++ b/packages/scratch-gui/src/lib/project-saver-hoc.jsx
@@ -53,12 +53,11 @@ const ProjectSaverHOC = function (WrappedComponent) {
             ]);
         }
         componentWillMount () {
-            if (typeof window === 'object') {
+            if (!this.props.noBeforeUnloadHandler && typeof window === 'object') {
                 // Note: it might be better to use a listener instead of assigning onbeforeunload;
                 // but then it'd be hard to turn this listening off in our tests
                 window.onbeforeunload = e => this.leavePageConfirm(e);
             }
-
             // Allow the GUI consumer to pass in a function to receive a trigger
             // for triggering thumbnail or whole project saves.
             // These functions are called with null on unmount to prevent stale references.
@@ -343,6 +342,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
                 onUpdatedProject,
                 onUpdateProjectData,
                 onUpdateProjectThumbnail,
+                noBeforeUnloadHandler,
                 reduxProjectId,
                 reduxProjectTitle,
                 setAutoSaveTimeoutId: setAutoSaveTimeoutIdProp,
@@ -395,6 +395,7 @@ const ProjectSaverHOC = function (WrappedComponent) {
         onUpdateProjectData: PropTypes.func,
         onUpdateProjectThumbnail: PropTypes.func,
         onUpdatedProject: PropTypes.func,
+        noBeforeUnloadHandler: PropTypes.bool.required,
         projectChanged: PropTypes.bool,
         reduxProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         reduxProjectTitle: PropTypes.string,
@@ -406,7 +407,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
         autoSaveIntervalSecs: 600, // 10 minutes = 600 seconds
         onRemixing: () => {},
         onSetProjectThumbnailer: () => {},
-        onSetProjectSaver: () => {}
+        onSetProjectSaver: () => {},
+        noBeforeUnloadHandler: false
     };
     const mapStateToProps = (state, ownProps) => {
         const loadingState = state.scratchGui.projectState.loadingState;


### PR DESCRIPTION
### Proposed Changes

Add flag that skips setting an `onbeforeunload` handler if the behavior is not desired.