### PR TITLE
Deploy to npm tag from branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
-      - uses: wagoid/commitlint-github-action@9763196e10f27aef304c9b8b660d31d97fce0f99 # v5
       - name: Debug info
         run: |
           cat <<EOF

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,9 @@
+name: Lint commit messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: wagoid/commitlint-github-action@5ce82f5d814d4010519d15f0552aec4f17a1e1fe # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,11 @@ on:
     types: [published]
 
 jobs:
-  # ci:
-  #   uses: ./.github/workflows/ci.yml
+  ci:
+    uses: ./.github/workflows/ci.yml
   cd:
-  #   needs:
-  #     - ci
+    needs:
+      - ci
     runs-on: ubuntu-latest
     steps:
       - name: Debug info
@@ -75,25 +75,25 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      # - name: Publish scratch-svg-renderer
-      #   run: npm publish --access=public --workspace=@scratch/scratch-svg-renderer
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish scratch-svg-renderer
+        run: npm publish --access=public --workspace=@scratch/scratch-svg-renderer
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      # - name: Publish scratch-render
-      #   run: npm publish --access=public --workspace=@scratch/scratch-render
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish scratch-render
+        run: npm publish --access=public --workspace=@scratch/scratch-render
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      # - name: Publish scratch-vm
-      #   run: npm publish --access=public --workspace=@scratch/scratch-vm
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish scratch-vm
+        run: npm publish --access=public --workspace=@scratch/scratch-vm
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      # - name: Publish scratch-gui
-      #   run: npm publish --access=public --workspace=@scratch/scratch-gui
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: Publish scratch-gui
+        run: npm publish --access=public --workspace=@scratch/scratch-gui
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Push to develop
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,25 +40,25 @@ jobs:
       - name: Build packages
         run: npm run build
 
-      - name: Publish scratch-svg-renderer
-        run: npm publish --access=public --workspace=@scratch/scratch-svg-renderer
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      # - name: Publish scratch-svg-renderer
+      #   run: npm publish --access=public --workspace=@scratch/scratch-svg-renderer
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Publish scratch-render
-        run: npm publish --access=public --workspace=@scratch/scratch-render
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      # - name: Publish scratch-render
+      #   run: npm publish --access=public --workspace=@scratch/scratch-render
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Publish scratch-vm
-        run: npm publish --access=public --workspace=@scratch/scratch-vm
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      # - name: Publish scratch-vm
+      #   run: npm publish --access=public --workspace=@scratch/scratch-vm
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Publish scratch-gui
-        run: npm publish --access=public --workspace=@scratch/scratch-gui
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      # - name: Publish scratch-gui
+      #   run: npm publish --access=public --workspace=@scratch/scratch-gui
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Push to develop
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
           NEW_VERSION="${GIT_TAG/v/}"
 
           npm version "$NEW_VERSION" --no-git-tag-version
-          git add package* && git commit -m "Release $NEW_VERSION"
+          git add package* && git commit -m "chore(release): $NEW_VERSION [skip ci]"
 
       - name: Build packages
         run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,39 @@ jobs:
   #     - ci
     runs-on: ubuntu-latest
     steps:
+      - name: Debug info
+        run: |
+          cat <<EOF
+          Release tag name: ${{ github.event.release.tag_name }}
+          Release target commit-ish: ${{ github.event.release.target_commitish }}
+          EOF
+
+      - name: Determine NPM tag
+        id: npm_tag
+        shell: bash
+        run: |
+          case ${{ github.event.release.target_commitish }} in
+            develop | main | master)
+              if [[ ${{ github.event.release.prerelease }} == true ]]; then
+                npm_tag=beta
+              else
+                npm_tag=latest
+              fi
+              ;;
+            *)
+              # use the branch name
+              npm_tag="${{ github.event.release.target_commitish }}"
+              ;;
+          esac
+          echo "Determined NPM tag: [$npm_tag]"
+          echo "npm_tag=${npm_tag}" >> "$GITHUB_OUTPUT"
+      - name: Check NPM tag
+        run: |
+          if [ -z "${{ steps.npm_tag.outputs.npm_tag }}" ]; then
+            echo "Refusing to publish with empty NPM tag."
+            exit 1
+          fi
+
       - name: Config GitHub user
         shell: bash
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,22 +76,22 @@ jobs:
         run: npm run build
 
       - name: Publish scratch-svg-renderer
-        run: npm publish --access=public --workspace=@scratch/scratch-svg-renderer
+        run: npm publish --access=public --tag="${{steps.npm_tag.outputs.npm_tag}}" --workspace=@scratch/scratch-svg-renderer
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Publish scratch-render
-        run: npm publish --access=public --workspace=@scratch/scratch-render
+        run: npm publish --access=public --tag="${{steps.npm_tag.outputs.npm_tag}}" --workspace=@scratch/scratch-render
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Publish scratch-vm
-        run: npm publish --access=public --workspace=@scratch/scratch-vm
+        run: npm publish --access=public --tag="${{steps.npm_tag.outputs.npm_tag}}" --workspace=@scratch/scratch-vm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Publish scratch-gui
-        run: npm publish --access=public --workspace=@scratch/scratch-gui
+        run: npm publish --access=public --tag="${{steps.npm_tag.outputs.npm_tag}}" --workspace=@scratch/scratch-gui
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,11 @@ on:
     types: [published]
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
+  # ci:
+  #   uses: ./.github/workflows/ci.yml
   cd:
+  #   needs:
+  #     - ci
     runs-on: ubuntu-latest
     steps:
       - name: Config GitHub user
@@ -113,5 +115,3 @@ jobs:
           publish_dir: ./packages/scratch-gui/build
           destination_dir: scratch-gui
           full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
-    needs:
-      - ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          token: ${{ secrets.PAT_RELEASE_PUSH }} # persists the token for pushing to the repo later
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,20 +10,21 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          token: ${{ secrets.PAT_RELEASE_PUSH }} # persists the token for pushing to the repo later
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
-        with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-
       - name: Config GitHub user
         shell: bash
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'github-actions@localhost'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          token: ${{ secrets.PAT_RELEASE_PUSH }} # persists the token for pushing to the repo later
+
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
       - uses: ./.github/actions/install-dependencies
 


### PR DESCRIPTION
### Proposed Changes

Main change: allow the "Publish" workflow to publish to a tag other than `latest`, depending on the branch name and the state of the "Prerelease" checkbox in GitHub's release UI.

Additional changes:

- `commitlint` now runs as a separate workflow instead of as part of the CI workflow, so you can tell the difference between a `commitlint` failure vs. a build/test failure.
- the release commit message now follows Conventional Commit style.

### Reason for Changes

This allows the `spork` branch to publish to the `spork` tag on npm, making it easier to test on staging. Other branches are likely to want this soon, so I pulled this out of the `spork` branch so we don't need to wait for all the `spork` QA to finish before those other branches can use this change.

### Test Coverage

I've already used this workflow from the `spork` branch.