### PR TITLE
[IPR-350] Added no-global-reset to modal component

### DIFF
--- a/packages/scratch-gui/src/components/modal/modal.jsx
+++ b/packages/scratch-gui/src/components/modal/modal.jsx
@@ -17,7 +17,8 @@ const ModalComponent = props => (
     <ReactModal
         isOpen
         className={classNames(styles.modalContent, props.className, {
-            [styles.fullScreen]: props.fullScreen
+            [styles.fullScreen]: props.fullScreen,
+            'no-global-reset': true
         })}
         contentLabel={props.contentLabel}
         overlayClassName={styles.modalOverlay}

--- a/packages/scratch-gui/src/components/modal/modal.jsx
+++ b/packages/scratch-gui/src/components/modal/modal.jsx
@@ -18,7 +18,8 @@ const ModalComponent = props => (
         isOpen
         className={classNames(styles.modalContent, props.className, {
             [styles.fullScreen]: props.fullScreen,
-            'no-global-reset': true
+            // Used by scratch-platorm to distinguish between editor modals and other modals
+            'scratch-editor-modal': true
         })}
         contentLabel={props.contentLabel}
         overlayClassName={styles.modalOverlay}


### PR DESCRIPTION
**Ticket:**
[IPR-350](https://scratchfoundation.atlassian.net/jira/software/projects/IPR/boards/90?selectedIssue=IPR-350)

Changes:
А small change to the `ModalComponent` in the `modal.jsx` file - adds a new class `'no-global-reset'` to the modal's class names to ensure the modal is not affected by any global CSS resets in relation to Tailwind CSS reset for scratch-platform.


[IPR-350]: https://scratchfoundation.atlassian.net/browse/IPR-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ