### PR TITLE
Track asset provenance when using the paint editor

### DIFF
--- a/packages/scratch-gui/src/containers/paint-editor-wrapper.jsx
+++ b/packages/scratch-gui/src/containers/paint-editor-wrapper.jsx
@@ -24,19 +24,28 @@ class PaintEditorWrapper extends React.Component {
         this.props.vm.renameCostume(this.props.selectedCostumeIndex, name);
     }
     handleUpdateImage (isVector, image, rotationCenterX, rotationCenterY) {
+        const currentCostume = this.props.vm.editingTarget.getCostumes()[this.props.selectedCostumeIndex];
+        const currentAsset = currentCostume.asset;
+
+        const provenance = currentAsset.clean ? currentAsset.assetId : currentAsset.provenance;
+
         if (isVector) {
             this.props.vm.updateSvg(
                 this.props.selectedCostumeIndex,
                 image,
                 rotationCenterX,
-                rotationCenterY);
+                rotationCenterY,
+                provenance,
+            );
         } else {
             this.props.vm.updateBitmap(
                 this.props.selectedCostumeIndex,
                 image,
                 rotationCenterX,
                 rotationCenterY,
-                2 /* bitmapResolution */);
+                2 /* bitmapResolution */,
+                provenance,
+            );
         }
     }
     render () {

--- a/packages/scratch-gui/src/lib/project-saver-hoc.jsx
+++ b/packages/scratch-gui/src/lib/project-saver-hoc.jsx
@@ -236,7 +236,8 @@ const ProjectSaverHOC = function (WrappedComponent) {
                         asset.assetType,
                         asset.dataFormat,
                         asset.data,
-                        asset.assetId
+                        asset.assetId,
+                        { provenance: asset.provenance }
                     ).then(response => {
                         // Asset servers respond with {status: ok} for successful POSTs
                         if (response.status !== 'ok') {

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -891,8 +891,9 @@ class VirtualMachine extends EventEmitter {
      * @param {!number} rotationCenterY y of point about which the costume rotates, relative to its upper left corner
      * @param {!number} bitmapResolution 1 for bitmaps that have 1 pixel per unit of stage,
      *     2 for double-resolution bitmaps
+     * @param {?string} provenance - an assetId of an asset that this one was based on
      */
-    updateBitmap (costumeIndex, bitmap, rotationCenterX, rotationCenterY, bitmapResolution) {
+    updateBitmap (costumeIndex, bitmap, rotationCenterX, rotationCenterY, bitmapResolution, provenance) {
         const costume = this.editingTarget.getCostumes()[costumeIndex];
         if (!(costume && this.runtime && this.runtime.renderer)) return;
         if (costume && costume.broken) delete costume.broken;
@@ -934,6 +935,7 @@ class VirtualMachine extends EventEmitter {
                     null, // id
                     true // generate md5
                 );
+                costume.asset.setProvenance(provenance);
                 costume.assetId = costume.asset.assetId;
                 costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
                 this.emitTargetsUpdate();
@@ -951,8 +953,9 @@ class VirtualMachine extends EventEmitter {
      * @param {string} svg - new SVG for the renderer.
      * @param {number} rotationCenterX x of point about which the costume rotates, relative to its upper left corner
      * @param {number} rotationCenterY y of point about which the costume rotates, relative to its upper left corner
+     * @param {?string} provenance - an assetId of an asset that this one was based on
      */
-    updateSvg (costumeIndex, svg, rotationCenterX, rotationCenterY) {
+    updateSvg (costumeIndex, svg, rotationCenterX, rotationCenterY, provenance) {
         const costume = this.editingTarget.getCostumes()[costumeIndex];
         if (costume && costume.broken) delete costume.broken;
         if (costume && this.runtime && this.runtime.renderer) {
@@ -973,6 +976,7 @@ class VirtualMachine extends EventEmitter {
             null,
             true // generate md5
         );
+        costume.asset.setProvenance(provenance);
         costume.assetId = costume.asset.assetId;
         costume.md5 = `${costume.assetId}.${costume.dataFormat}`;
         this.emitTargetsUpdate();


### PR DESCRIPTION
### Resolves

Something we talked about on the NGP planning

### Proposed Changes

_Describe what this Pull Request does_

Tracks which asset id an asset edited through the paint editor is based on. Tries to only track uploaded (clean) ones. That's what clean means, right?

Requires the change from https://github.com/scratchfoundation/scratch-storage/pull/754

Note on the unused `store` parameter - in NGP we're not using the webHelper for storing (as it doesn't support async functions), so we can just utilize that parameter there to send to the server together with the rest of the asset.

### Reason for Changes

_Explain why these changes should be made_

@cwillisf was talking about it and I just opened the code to see how hard it would be, and there you have it - this PR 😄 I haven't tested it and there is no test coverage, so it's left in a Draft state.

### Test Coverage

_Please show how you have added tests to cover your changes_

I didn't 😅 