### PR TITLE
[UEPR-262] fix: add install before building packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,9 @@ jobs:
           npm version "$NEW_VERSION" --no-git-tag-version
           git add package* && git commit -m "chore(release): $NEW_VERSION [skip ci]"
 
+      - name: Install packages
+        run: npm install
+
       - name: Build packages
         run: npm run build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,9 @@ jobs:
           npm version "$NEW_VERSION" --no-git-tag-version
           git add package* && git commit -m "chore(release): $NEW_VERSION [skip ci]"
 
-      - name: Install packages
-        run: npm install
+      # Install dependencies after the version update so that
+      # the build outputs refer to the newest version of inner packages 
+      - uses: ./.github/actions/install-dependencies
 
       - name: Build packages
         run: npm run build


### PR DESCRIPTION
[UEPR-262](https://scratchfoundation.atlassian.net/browse/UEPR-262)
### Proposed Changes
Add install packages step in the publish workflow after the version update to avoid build outputs to refer to old version of the inner packages

[UEPR-262]: https://scratchfoundation.atlassian.net/browse/UEPR-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ