### PR TITLE
Improve GHA workflows

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -33,7 +33,7 @@ runs:
           packages/*/node_modules
           packages/*/src/generated
           packages/scratch-gui/static/microbit
-        key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-npm-${{ hashFiles('.nvmrc', 'package-lock.json') }}
     - if: steps.restore-node-modules-cache.outputs.cache-hit != 'true'
       name: Install NPM dependencies
       working-directory: .
@@ -47,4 +47,4 @@ runs:
           packages/*/node_modules
           packages/*/src/generated
           packages/scratch-gui/static/microbit
-        key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-npm-${{ hashFiles('.nvmrc', 'package-lock.json') }}

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,0 +1,26 @@
+# Files in the `global` filter affect all workspaces, even if workspace-specific files have not changed.
+global:
+  - ".github/path-filters.yml"
+  - ".github/workflows/ci.yml"
+  - ".nvmrc"
+  - "package.json"
+  - "package-lock.json"
+  - "scripts/**"
+
+any-workspace:
+  - "packages/**"
+
+scratch-svg-renderer:
+  - "packages/scratch-svg-renderer/**"
+scratch-render:
+  - "packages/scratch-render/**"
+  - "packages/scratch-svg-renderer/**"
+scratch-vm:
+  - "packages/scratch-render/**"
+  - "packages/scratch-svg-renderer/**"
+  - "packages/scratch-vm/**"
+scratch-gui:
+  - "packages/scratch-gui/**"
+  - "packages/scratch-render/**"
+  - "packages/scratch-svg-renderer/**"
+  - "packages/scratch-vm/**"

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,5 +1,5 @@
-# Files in the `global` filter affect all workspaces, even if workspace-specific files have not changed.
-global:
+# The `&global` anchor defines a set of common paths to include by reference in the other filters.
+global: &global
   - ".github/path-filters.yml"
   - ".github/workflows/ci.yml"
   - ".nvmrc"
@@ -8,18 +8,23 @@ global:
   - "scripts/**"
 
 any-workspace:
+  - *global
   - "packages/**"
 
 scratch-svg-renderer:
+  - *global
   - "packages/scratch-svg-renderer/**"
 scratch-render:
+  - *global
   - "packages/scratch-render/**"
   - "packages/scratch-svg-renderer/**"
 scratch-vm:
+  - *global
   - "packages/scratch-render/**"
   - "packages/scratch-svg-renderer/**"
   - "packages/scratch-vm/**"
 scratch-gui:
+  - *global
   - "packages/scratch-gui/**"
   - "packages/scratch-render/**"
   - "packages/scratch-svg-renderer/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,30 +36,7 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
-          # Files in the `global` filter affect all workspaces, even if workspace-specific files have not changed.
-          filters: |
-            global:
-              - ".github/workflows/ci.yml"
-              - ".nvmrc"
-              - "package.json"
-              - "package-lock.json"
-              - "scripts/**"
-            any-workspace:
-              - "packages/**"
-            scratch-svg-renderer:
-              - "packages/scratch-svg-renderer/**"
-            scratch-render:
-              - "packages/scratch-render/**"
-              - "packages/scratch-svg-renderer/**"
-            scratch-vm:
-              - "packages/scratch-render/**"
-              - "packages/scratch-svg-renderer/**"
-              - "packages/scratch-vm/**"
-            scratch-gui:
-              - "packages/scratch-gui/**"
-              - "packages/scratch-render/**"
-              - "packages/scratch-svg-renderer/**"
-              - "packages/scratch-vm/**"
+          filters: ./.github/path-filters.yml
 
       - if: ${{ steps.filter.outputs.global == 'true' || steps.filter.outputs.any-workspace == 'true' }}
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
-      - uses: wagoid/commitlint-github-action@9763196e10f27aef304c9b8b660d31d97fce0f99 # v5
       - name: Debug info
         run: |
           cat <<EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: Detect affected packages, build and test
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
@@ -37,30 +38,45 @@ jobs:
         with:
           filters: ./.github/path-filters.yml
 
-      - if: ${{ steps.filter.outputs.global == 'true' || steps.filter.outputs.any-workspace == 'true' }}
+      - if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         uses: ./.github/actions/install-dependencies
 
       - name: Build packages
-        if: ${{ steps.filter.outputs.global == 'true' || steps.filter.outputs.any-workspace == 'true' }}
+        if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         run: npm run build
 
-      - name: Test scratch-svg-renderer
-        if: ${{ !cancelled() && (steps.filter.outputs.global == 'true' || steps.filter.outputs.scratch-svg-renderer == 'true') }}
-        uses: ./.github/actions/test-package
+      - name: Store build artifacts
+        if: ${{ steps.filter.outputs.any-workspace == 'true' }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          package_name: scratch-svg-renderer
-      - name: Test scratch-render
-        if: ${{ !cancelled() && (steps.filter.outputs.global == 'true' || steps.filter.outputs.scratch-render == 'true') }}
-        uses: ./.github/actions/test-package
+          name: build
+          path: |
+            packages/**/build
+            packages/**/dist
+            packages/**/playground
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.build.outputs.packages) }}
+        exclude:
+          - package: global
+          - package: any-workspace
+    name: Test ${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
-          package_name: scratch-render
-      - name: Test scratch-vm
-        if: ${{ !cancelled() && (steps.filter.outputs.global == 'true' || steps.filter.outputs.scratch-vm == 'true') }}
-        uses: ./.github/actions/test-package
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - uses: ./.github/actions/install-dependencies
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
-          package_name: scratch-vm
-      - name: Test scratch-gui
-        if: ${{ !cancelled() && (steps.filter.outputs.global == 'true' || steps.filter.outputs.scratch-gui == 'true') }}
-        uses: ./.github/actions/test-package
+          name: build
+          path: packages
+      - uses: ./.github/actions/test-package
         with:
-          package_name: scratch-gui
+          package_name: ${{ matrix.package }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
+      any-workspace: ${{ steps.filter.outputs.any-workspace }}
       packages: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -58,6 +59,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ needs.build.outputs.any-workspace == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           filters: |
             global:
               - ".github/workflows/ci.yml"
+              - ".nvmrc"
               - "package.json"
               - "package-lock.json"
               - "scripts/**"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,12 @@
+name: Lint commit messages
+on: [pull_request]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.sha }}"
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: wagoid/commitlint-github-action@9763196e10f27aef304c9b8b660d31d97fce0f99 # v5


### PR DESCRIPTION
### Proposed Changes

Various improvements to the GHA workflows, especially for the build-and-test workflow.

- Consider `.nvmrc` when caching `node_modules`, so we don't (for example) load Node 20 modules when we switch to Node 22
- Move `commitlint` to its own separate workflow, so it doesn't block the build-and-test workflow
- Move tests into a separate job matrix so it's easier to tell what fails and re-run them if necessary
- Move path filters out of `ci.yml` (where the YAML must be embedded in a string) and into a separate YAML file (where they can be actual YAML and your editor can provide proper syntax highlighting)

At some point in the future, it'd be nice to matrix out the builds as well, but we'll need to eliminate cases where the build output of one package is an input to another.

### Test Coverage

Runs existing tests