### PR TITLE
fixed SVG effects

### DIFF
--- a/packages/scratch-svg-renderer/src/sanitize-svg.js
+++ b/packages/scratch-svg-renderer/src/sanitize-svg.js
@@ -130,6 +130,8 @@ sanitizeSvg.sanitizeSvgText = function (rawSvgText) {
     let sanitizedText = DOMPurify.sanitize(rawSvgText, {
         USE_PROFILES: {svg: true},
         FORBID_TAGS: ['a', 'audio', 'canvas', 'video'],
+        // Allow SVG filter elements (used for shadows, blur)
+        ADD_TAGS: ['filter'],
         // Allow data URI in image tags (e.g. SVGs converted from bitmap)
         ADD_DATA_URI_TAGS: ['image']
     });


### PR DESCRIPTION
### Resolves

https://github.com/scratchfoundation/scratch-editor/issues/269

### Proposed Changes

Allows filter elements inside SVGs, such as those used for shadow effects

### Reason for Changes

Fixes previously functional SVG costumes

