### PR TITLE
[UEPR-302] Rename face sensing block to nose

### DIFF
--- a/packages/scratch-vm/src/extensions/scratch3_face_sensing/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_face_sensing/index.js
@@ -361,7 +361,7 @@ class Scratch3FaceSensingBlocks {
             ],
             menus: {
                 PART: [
-                    {text: 'noseTip', value: '2'},
+                    {text: 'nose', value: '2'},
                     {text: 'mouth', value: '3'},
                     {text: 'left eye', value: '0'},
                     {text: 'right eye', value: '1'},


### PR DESCRIPTION
### Resolves

[UEPR-302 ](https://scratchfoundation.atlassian.net/browse/UEPR-302)

### Proposed Changes

Rename face sensing block to nose, instead of noseTip

### Test Coverage

Not required