### PR TITLE
[IPR-979] Omit multiple unnecessary project title update calls

### DIFF
--- a/packages/scratch-gui/src/lib/titled-hoc.jsx
+++ b/packages/scratch-gui/src/lib/titled-hoc.jsx
@@ -31,14 +31,15 @@ const TitledHOC = function (WrappedComponent) {
                 this.handleReceivedProjectTitle(this.props.projectTitle);
             }
             // if project is a new default project, and has loaded,
-            if (this.props.isShowingWithoutId && prevProps.isAnyCreatingNewState) {
+            if (this.props.isShowingWithoutId && !this.props.isAnyCreatingNewState && prevProps.isAnyCreatingNewState) {
                 // reset title to default
-                const defaultProjectTitle = this.handleReceivedProjectTitle();
-                this.props.onUpdateProjectTitle(defaultProjectTitle);
+                this.handleReceivedProjectTitle();
             }
             // if the projectTitle hasn't changed, but the reduxProjectTitle
             // HAS changed, we need to report that change to the projectTitle's owner
-            if (this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
+            if (!this.props.isShowingWithoutId &&
+                !this.props.isAnyCreatingNewState &&
+                this.props.reduxProjectTitle !== prevProps.reduxProjectTitle &&
                 this.props.reduxProjectTitle !== this.props.projectTitle) {
                 this.props.onUpdateProjectTitle(this.props.reduxProjectTitle);
             }


### PR DESCRIPTION
### Proposed Changes

- only handle default project title update once, and do not invoke `onUpdateProjectTitle` to avoid title updates for nonexistent project
- only call `onUpdateProjectTitle` if the title has changed AND the project has loaded

### Reason for Changes

There are multiple calls to `onUpdateProjectTitle` while a project isn't actually loaded (e.g. the editor is in some "creating new" state). This causes multiple unnecessary and currently failing requests in WWW and side effects in other projects that integrate the editor.