### PR TITLE
fix: allow SVG filter elements

### DIFF
--- a/packages/scratch-svg-renderer/src/sanitize-svg.js
+++ b/packages/scratch-svg-renderer/src/sanitize-svg.js
@@ -130,6 +130,8 @@ sanitizeSvg.sanitizeSvgText = function (rawSvgText) {
     let sanitizedText = DOMPurify.sanitize(rawSvgText, {
         USE_PROFILES: {svg: true},
         FORBID_TAGS: ['a', 'audio', 'canvas', 'video'],
+        // Allow SVG filter elements (used for shadows, blur)
+        ADD_TAGS: ['filter'],
         // Allow data URI in image tags (e.g. SVGs converted from bitmap)
         ADD_DATA_URI_TAGS: ['image']
     });

--- a/packages/scratch-svg-renderer/src/sanitize-svg.js
+++ b/packages/scratch-svg-renderer/src/sanitize-svg.js
@@ -128,10 +128,8 @@ sanitizeSvg.sanitizeByteStream = function (rawData) {
  */
 sanitizeSvg.sanitizeSvgText = function (rawSvgText) {
     let sanitizedText = DOMPurify.sanitize(rawSvgText, {
-        USE_PROFILES: {svg: true},
+        USE_PROFILES: {svg: true, svgFilters: true},
         FORBID_TAGS: ['a', 'audio', 'canvas', 'video'],
-        // Allow SVG filter elements (used for shadows, blur)
-        ADD_TAGS: ['filter'],
         // Allow data URI in image tags (e.g. SVGs converted from bitmap)
         ADD_DATA_URI_TAGS: ['image']
     });


### PR DESCRIPTION
Adds a rule to allow the SVG filter tag, when sanitizing SVGs, so that effects such as shadows and blur do not lead to SVGs which don't diplay on the project stage

### Resolves

Fixes this issue: https://github.com/scratchfoundation/scratch-editor/issues/269

### Proposed Changes

Adds a rule to allow the SVG filter tag

### Reason for Changes

Stops the SVG sanitizer from removing filter tags from SVGs, so that SVGs with shadows/blur display correctly on the stage
