### PR TITLE
Publish branches to GH Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,47 @@ jobs:
         with:
           package_name: ${{ matrix.package }}
 
+  preview:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    if: ${{ needs.build.outputs.any-workspace == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.build.outputs.packages) }}
+        exclude:
+          - package: global
+          - package: any-workspace
+    name: Test ${{ matrix.package }}
+    steps:
+      - name: Determine GitHub Pages directory name
+        id: branch_dir_name
+        run: |
+          if [ "$GITHUB_REF_NAME" == "develop" ]; then
+            echo "result=."
+          else
+            echo "result=${GITHUB_REF_NAME//[^A-Za-z0-9._-]/_}"
+          fi | tee --append "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: build
+          path: packages
+      - name: Deploy ${{ matrix.package }} testing playground to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./packages/${{ matrix.package }}/playground
+          destination_dir: "${{steps.branch_dir_name.outputs.result}}/${{ matrix.package }}"
+          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
+
   results:
     name: Results
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - preview
     if: ${{ always() }}
     steps:
       - run: |
@@ -106,6 +143,22 @@ jobs:
               ;;
             *)
               echo "Tests failed."
+              exit 1
+              ;;
+          esac
+      - run: |
+          case "${{ needs.preview.result }}" in
+            success)
+              echo "GitHub Pages previews published successfully."
+              exit 0
+              ;;
+            skipped)
+              echo "Previews were unnecessary for these changes, so they were skipped."
+              echo "If this is unexpected, check the path filters."
+              exit 0
+              ;;
+            *)
+              echo "Publishing GitHub Pages previews failed."
               exit 1
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,18 +89,9 @@ jobs:
 
   preview:
     runs-on: ubuntu-latest
-    needs:
-      - build
-      - test
+    needs: build
     if: ${{ needs.build.outputs.any-workspace == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.build.outputs.packages) }}
-        exclude:
-          - package: global
-          - package: any-workspace
-    name: Test ${{ matrix.package }}
+    name: Publish preview playgrounds to GitHub Pages
     steps:
       - name: Determine GitHub Pages directory name
         id: branch_dir_name
@@ -114,21 +105,35 @@ jobs:
         with:
           name: build
           path: packages
-      - name: Deploy ${{ matrix.package }} testing playground to GitHub Pages
+      - name: Prepare playgrounds for GitHub Pages
+        working-directory: ./packages
+        run: |
+          mkdir -p ../pages/
+          for pkg in *; do
+            if [ -d "${pkg}/playground" ]; then
+              # using symlinks is quick and artifact generation will dereference them
+              # if the GitHub Pages action stops dereferencing these links, we'll need to copy the files instead
+              ln -s "../packages/${pkg}/playground" "../pages/${pkg}"
+            fi
+          done
+
+          # scratch-gui doesn't follow the pattern above
+          ln -s "../packages/scratch-gui/build" "../pages/scratch-gui"
+
+          ls -l ../pages/
+      - name: Deploy playgrounds to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/${{ matrix.package }}/playground
-          destination_dir: "${{steps.branch_dir_name.outputs.result}}/${{ matrix.package }}"
+          publish_dir: ./pages
+          destination_dir: "${{steps.branch_dir_name.outputs.result}}"
           full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
 
   results:
-    name: Results
+    name: Test Results
     runs-on: ubuntu-latest
-    needs:
-      - test
-      - preview
-    if: ${{ always() }}
+    needs: test
+    if: ${{ !cancelled() }}
     steps:
       - run: |
           case "${{ needs.test.result }}" in
@@ -143,22 +148,6 @@ jobs:
               ;;
             *)
               echo "Tests failed."
-              exit 1
-              ;;
-          esac
-      - run: |
-          case "${{ needs.preview.result }}" in
-            success)
-              echo "GitHub Pages previews published successfully."
-              exit 0
-              ;;
-            skipped)
-              echo "Previews were unnecessary for these changes, so they were skipped."
-              echo "If this is unexpected, check the path filters."
-              exit 0
-              ;;
-            *)
-              echo "Publishing GitHub Pages previews failed."
               exit 1
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,18 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ needs.build.outputs.any-workspace == 'true' }}
+    # We don't want to give forks free reign to publish to our GitHub Pages, so run this job only if both:
+    # - any workspace changed (otherwise there's no work to do)
+    # - and either
+    #   - this is not a PR (so it's some other event that happened in our fork, like a push or merge group)
+    #   - or it's a PR from our fork (not some other fork)
+    if: ${{
+        (needs.build.outputs.any-workspace == 'true') &&
+        (
+          (!github.event.pull_request) ||
+          (github.event.pull_request.head.repo.full_name == github.repository)
+        )
+      }}
     name: Publish preview playgrounds to GitHub Pages
     steps:
       - name: Determine GitHub Pages directory name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,14 @@ jobs:
       - name: Debug info
         # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
         env:
-          GH_HEAD_REF: ${{ github.head_ref }}
+          # `env:` values are printed to the log even without using them in `run:`
+          GH_CONTEXT: ${{ toJson(github) }}
         run: |
           cat <<EOF
-          Scratch environment: ${{ vars.SCRATCH_ENV || '<none>' }}
+          Working directory: $(pwd)
           Node version: $(node --version)
           NPM version: $(npm --version)
-          GitHub ref: ${{ github.ref }}
-          GitHub head ref: ${GH_HEAD_REF}
-          Working directory: $(pwd)
+          Scratch environment: ${{ vars.SCRATCH_ENV || '<none>' }}
           EOF
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3

--- a/.github/workflows/ghpages-cleanup.yml
+++ b/.github/workflows/ghpages-cleanup.yml
@@ -1,3 +1,5 @@
+name: GitHub Pages Cleanup
+
 on:
   schedule:
     - cron: 0 0 * * 6 # midnight on Saturdays
@@ -7,7 +9,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out GH Pages branch
+      - name: Check out GitHub Pages branch
         uses: actions/checkout@v4
         with:
           # replace `fetch-depth` with `shallow-since` if and when actions/checkout#619 (or an equivalent) gets merged
@@ -22,6 +24,6 @@ jobs:
           done
           git status
       - name: Commit
-        run: "git commit -m 'chore: remove stale GH Pages branches'"
+        run: "git commit -m 'chore: remove stale GitHub Pages branches'"
       - name: Push
         run: "git push"

--- a/.github/workflows/ghpages-cleanup.yml
+++ b/.github/workflows/ghpages-cleanup.yml
@@ -1,0 +1,27 @@
+on:
+  schedule:
+    - cron: 0 0 * * 6 # midnight on Saturdays
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out GH Pages branch
+        uses: actions/checkout
+        with:
+          # replace `fetch-depth` with `shallow-since` if and when actions/checkout#619 (or an equivalent) gets merged
+          fetch-depth: 0
+          ref: gh-pages
+      - name: Mark stale directories for removal
+        run: |
+          for dir in */; do
+            if [ -z "$(git log -n 1 --since "1 month ago" -- "$dir")" ]; then
+              git rm -r "$dir"
+            fi
+          done
+          git status
+      - name: Commit
+        run: "git commit -m 'chore: remove stale GH Pages branches'"
+      - name: Push
+        run: "git push"

--- a/.github/workflows/ghpages-cleanup.yml
+++ b/.github/workflows/ghpages-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out GH Pages branch
-        uses: actions/checkout
+        uses: actions/checkout@v4
         with:
           # replace `fetch-depth` with `shallow-since` if and when actions/checkout#619 (or an equivalent) gets merged
           fetch-depth: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,35 +145,3 @@ jobs:
         run: |
           git tag -f "${{github.event.release.tag_name}}" HEAD
           git push -f origin "refs/tags/${{github.event.release.tag_name}}"
-
-      - name: Deploy scratch-svg-renderer to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/scratch-svg-renderer/playground
-          destination_dir: scratch-svg-renderer
-          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
-
-      - name: Deploy scratch-render to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/scratch-render/playground
-          destination_dir: scratch-render
-          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
-
-      - name: Deploy scratch-vm to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/scratch-vm/playground
-          destination_dir: scratch-vm
-          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
-
-      - name: Deploy scratch-gui to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/scratch-gui/build
-          destination_dir: scratch-gui
-          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"


### PR DESCRIPTION
### Resolves

This was built in support of #214, but I separated it out since it's useful by itself and #214 is big enough without this sort of thing in the mix.

### Proposed Changes

Branches of this fork will now be published to subdirectories in GitHub Pages. To support this, the GitHub Pages publishing step has been moved from the "publish" workflow (which is associated only with real releases on npm) to the "ci" workflow. I also slightly optimized it so that all the playgrounds are published together, in one commit, instead of one each.

### Reason for Changes

This makes it so we can test the spork changes before merging them into develop, and might be useful for other branches as well. Maybe it would have been nice for React 18, for example. :sweat_smile:

### Test Coverage

It's working for the spork branch, and should be visible for this branch as well, shortly after I press this button here...
