### PR TITLE
Fix dragging monitors on small stage

### DIFF
--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -22,6 +22,7 @@ const MonitorList = props => (
                 .map(monitorData => (
                     <Monitor
                         draggable={props.draggable}
+                        scale={props.stageSize.scale}
                         height={monitorData.height}
                         id={monitorData.id}
                         isDiscrete={monitorData.isDiscrete}
@@ -51,7 +52,8 @@ MonitorList.propTypes = {
         width: PropTypes.number,
         height: PropTypes.number,
         widthDefault: PropTypes.number,
-        heightDefault: PropTypes.number
+        heightDefault: PropTypes.number,
+        scale: PropTypes.number
     }).isRequired
 };
 

--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -11,16 +11,13 @@ import styles from './monitor-list.css';
 const MonitorList = props => (
     <Box
         // Use static `monitor-overlay` class for bounds of draggables
-        className={classNames(styles.monitorList, 'monitor-overlay')}
+        className={classNames(styles.monitorList, styles.monitorListScaler, 'monitor-overlay')}
         style={{
-            width: props.stageSize.width,
-            height: props.stageSize.height
+            width: props.stageSize.widthDefault,
+            height: props.stageSize.heightDefault,
+            ...stageSizeToTransform(props.stageSize)
         }}
     >
-        <Box
-            className={styles.monitorListScaler}
-            style={stageSizeToTransform(props.stageSize)}
-        >
             {props.monitors.valueSeq().filter(m => m.visible)
                 .map(monitorData => (
                     <Monitor
@@ -43,7 +40,6 @@ const MonitorList = props => (
                         onDragEnd={props.onMonitorChange}
                     />
                 ))}
-        </Box>
     </Box>
 );
 

--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -18,29 +18,29 @@ const MonitorList = props => (
             ...stageSizeToTransform(props.stageSize)
         }}
     >
-            {props.monitors.valueSeq().filter(m => m.visible)
-                .map(monitorData => (
-                    <Monitor
-                        draggable={props.draggable}
-                        scale={props.stageSize.scale}
-                        height={monitorData.height}
-                        id={monitorData.id}
-                        isDiscrete={monitorData.isDiscrete}
-                        key={monitorData.id}
-                        max={monitorData.sliderMax}
-                        min={monitorData.sliderMin}
-                        mode={monitorData.mode}
-                        opcode={monitorData.opcode}
-                        params={monitorData.params}
-                        spriteName={monitorData.spriteName}
-                        targetId={monitorData.targetId}
-                        value={monitorData.value}
-                        width={monitorData.width}
-                        x={monitorData.x}
-                        y={monitorData.y}
-                        onDragEnd={props.onMonitorChange}
-                    />
-                ))}
+        {props.monitors.valueSeq().filter(m => m.visible)
+            .map(monitorData => (
+                <Monitor
+                    draggable={props.draggable}
+                    scale={props.stageSize.scale}
+                    height={monitorData.height}
+                    id={monitorData.id}
+                    isDiscrete={monitorData.isDiscrete}
+                    key={monitorData.id}
+                    max={monitorData.sliderMax}
+                    min={monitorData.sliderMin}
+                    mode={monitorData.mode}
+                    opcode={monitorData.opcode}
+                    params={monitorData.params}
+                    spriteName={monitorData.spriteName}
+                    targetId={monitorData.targetId}
+                    value={monitorData.value}
+                    width={monitorData.width}
+                    x={monitorData.x}
+                    y={monitorData.y}
+                    onDragEnd={props.onMonitorChange}
+                />
+            ))}
     </Box>
 );
 

--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -52,6 +52,7 @@ const MonitorComponent = props => (
             defaultClassNameDragging={styles.dragging}
             disabled={!props.draggable}
             onStop={props.onDragEnd}
+            scale={props.scale}
         >
             <Box
                 className={styles.monitorContainer}
@@ -138,6 +139,7 @@ MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categoryColorMap)),
     componentRef: PropTypes.func.isRequired,
     draggable: PropTypes.bool.isRequired,
+    scale: PropTypes.number,
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -53,6 +53,7 @@ const MonitorComponent = props => (
             disabled={!props.draggable}
             onStop={props.onDragEnd}
             scale={props.scale}
+            grid={[1*props.scale,1*props.scale]} // Prevent going to fractional coordinates
         >
             <Box
                 className={styles.monitorContainer}

--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -53,7 +53,7 @@ const MonitorComponent = props => (
             disabled={!props.draggable}
             onStop={props.onDragEnd}
             scale={props.scale}
-            grid={[1*props.scale,1*props.scale]} // Prevent going to fractional coordinates
+            grid={[1 * props.scale, 1 * props.scale]} // Prevent going to fractional coordinates
         >
             <Box
                 className={styles.monitorContainer}

--- a/packages/scratch-gui/src/containers/monitor.jsx
+++ b/packages/scratch-gui/src/containers/monitor.jsx
@@ -208,6 +208,7 @@ class Monitor extends React.Component {
                     componentRef={this.setElement}
                     {...monitorProps}
                     draggable={this.props.draggable}
+                    scale={this.props.scale}
                     height={this.props.height}
                     isDiscrete={this.props.isDiscrete}
                     max={this.props.max}
@@ -234,6 +235,7 @@ class Monitor extends React.Component {
 Monitor.propTypes = {
     addMonitorRect: PropTypes.func.isRequired,
     draggable: PropTypes.bool,
+    scale: PropTypes.number,
     height: PropTypes.number,
     id: PropTypes.string.isRequired,
     intl: intlShape,

--- a/packages/scratch-gui/src/containers/monitor.jsx
+++ b/packages/scratch-gui/src/containers/monitor.jsx
@@ -104,8 +104,8 @@ class Monitor extends React.Component {
         this.props.removeMonitorRect(this.props.id);
     }
     handleDragEnd (e, {x, y}) {
-        const newX = parseInt(this.element.style.left, 10) + x;
-        const newY = parseInt(this.element.style.top, 10) + y;
+        const newX = parseInt(this.element.style.left, 10) + Math.round(x);
+        const newY = parseInt(this.element.style.top, 10) + Math.round(y);
         this.props.onDragEnd(
             this.props.id,
             newX,


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

* https://github.com/scratchfoundation/scratch-gui/issues/2949
* https://github.com/scratchfoundation/scratch-gui/issues/2367
* https://github.com/scratchfoundation/scratch-gui/issues/9756
* https://github.com/scratchfoundation/scratch-gui/issues/9610

(most of these are duplicates of each other)

### Proposed Changes

_Describe what this Pull Request does_

1. Resize the dragging bounds with the same CSS transform that resizes the monitors, instead of changing the width/height CSS properties
2. Remove the `<Box>` that used to do the CSS transform
3. Set the `scale` property on the `<Draggable>`
4. Prevent the monitor from going to fractional coordinates even if `scale` is a fraction

### Reason for Changes

_Explain why these changes should be made_

1. This way CSS word wrapping and react-draggable will let the monitors go to the edges of the stage
2. It doesn't do the transform anymore and I don't think it did anything else
3. This way react-draggable knows the speed at which it should move the monitors
4. The existing code expects the monitor coordinates to be integers [here](https://github.com/scratchfoundation/scratch-editor/blob/440957a0c7b4f76ebef93c2dc8706a5e413bd7e6/packages/scratch-gui/src/containers/monitor.jsx#L107-L108) and there might be other places where it expects integers

### Test Coverage

_Please show how you have added tests to cover your changes_

I've run `npm test` and it accepted it (I think) (it didn't say "error" like when it didn't like the identation)

I've tried it out in these browsers and it seems to work

* Windows 10, Chrome 139
* Android, Chrome 138