### PR TITLE
Report test results more visibly

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -19,9 +19,19 @@ runs:
     - name: Test
       working-directory: ./packages/${{ inputs.package_name }}
       shell: bash
+      env:
+        TAP_REPORTER: "junit"
+        TAP_REPORTER_FILE: "test-results/junit.xml"
       run: |
         mkdir -p test-results
         npm run test
+    - name: Publish test reports
+      if: ${{ !cancelled() }}
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        files: "./packages/${{ inputs.package_name }}/test-results/**/*"
+        check_name: "Test report for ${{ inputs.package_name }}"
+        test_file_prefix: "+packages/${{ inputs.package_name }}/"
     - name: Store Test Results
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4

--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         mkdir -p test-results
-        npm run test | tee -a ./test-results/${{ inputs.package_name }}-test-results.txt
+        npm run test
     - name: Store Test Results
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,29 +87,6 @@ jobs:
         with:
           package_name: ${{ matrix.package }}
 
-  report:
-    name: Test Report
-    runs-on: ubuntu-latest
-    needs: test
-    if: ${{ !cancelled() }}
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: read
-      issues: read
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
-        with:
-          path: artifacts
-          pattern: "*-test-output"
-      - name: List downloaded artifacts
-        run: ls -R ./artifacts/
-      - name: Publish test reports
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          files: "./artifacts/*/**/*"
-
   results:
     name: Results
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,34 @@ jobs:
         with:
           package_name: ${{ matrix.package }}
 
+  report:
+    name: Test Report
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ !cancelled() }}
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          path: artifacts
+          pattern: "*-test-output"
+      - name: List downloaded artifacts
+        run: ls -R ./artifacts/
+      - name: Publish test reports
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "./artifacts/*/**/*"
+
   results:
     name: Results
     runs-on: ubuntu-latest
     needs: test
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     steps:
       - run: |
           case "${{ needs.test.result }}" in

--- a/packages/scratch-gui/.gitignore
+++ b/packages/scratch-gui/.gitignore
@@ -8,6 +8,7 @@ npm-*
 # Testing
 /.nyc_output
 /coverage
+/test-results
 
 # Build
 /build
@@ -26,6 +27,3 @@ npm-*
 
 # for act
 .secrets
-
-# Generated test results
-/test-results

--- a/packages/scratch-render/.gitignore
+++ b/packages/scratch-render/.gitignore
@@ -9,6 +9,7 @@ npm-*
 /.nyc_output
 /.tap
 /coverage
+/test-results
 
 # IDEA
 /.idea

--- a/packages/scratch-svg-renderer/.gitignore
+++ b/packages/scratch-svg-renderer/.gitignore
@@ -11,6 +11,7 @@ npm-*
 
 # Test
 /.tap
+/test-results
 
 # Editors
 /#*

--- a/packages/scratch-vm/.gitignore
+++ b/packages/scratch-vm/.gitignore
@@ -9,6 +9,7 @@ npm-*
 /.nyc_output
 /.tap
 /coverage
+/test-results
 
 # Editor
 /.idea


### PR DESCRIPTION
### Resolves

- Inspired by scratchfoundation/scratch-editor#236

### Proposed Changes

Use `EnricoMi/publish-unit-test-result-action` to report the details of test results more visibly, including GHA annotations.

### Reason for Changes

Contributors who aren't part of the scratchfoundation GitHub organization can see when a GHA workflow job fails, but they can't see the full logs. Seeing that a job failed doesn't help much if you can't tell why it failed, especially considering that we sometimes have flaky tests, chromedriver trouble, or other test failures that aren't the fault of a PR. This change allows folks to see the specific reason for a test failure and determine whether or not it's related to their changes.

### Test Coverage

Here's a run with some intentional test failures: <https://github.com/scratchfoundation/scratch-editor/actions/runs/17619379994>

This PR also includes some comments generated by the test results reporter. The reporter updated the comments to reflect that the tests have been "fixed" (the intentional failures have been removed), but the earlier version is available through GitHub's comment history feature.