### PR TITLE
Fix dragging monitors on small stage

### DIFF
--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -22,6 +22,7 @@ const MonitorList = props => (
             .map(monitorData => (
                 <Monitor
                     draggable={props.draggable}
+                    scale={props.stageSize.scale}
                     height={monitorData.height}
                     id={monitorData.id}
                     isDiscrete={monitorData.isDiscrete}
@@ -51,7 +52,8 @@ MonitorList.propTypes = {
         width: PropTypes.number,
         height: PropTypes.number,
         widthDefault: PropTypes.number,
-        heightDefault: PropTypes.number
+        heightDefault: PropTypes.number,
+        scale: PropTypes.number
     }).isRequired
 };
 

--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -11,15 +11,14 @@ import styles from './monitor-list.css';
 const MonitorList = props => (
     <Box
         // Use static `monitor-overlay` class for bounds of draggables
-        className={classNames(styles.monitorList, 'monitor-overlay')}
+        className={classNames(styles.monitorList, styles.monitorListScaler, 'monitor-overlay')}
         style={{
-            width: props.stageSize.width,
-            height: props.stageSize.height
+            width: props.stageSize.widthDefault,
+            height: props.stageSize.heightDefault,
+            ...stageSizeToTransform(props.stageSize)
         }}
     >
         <Box
-            className={styles.monitorListScaler}
-            style={stageSizeToTransform(props.stageSize)}
         >
             {props.monitors.valueSeq().filter(m => m.visible)
                 .map(monitorData => (

--- a/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
+++ b/packages/scratch-gui/src/components/monitor-list/monitor-list.jsx
@@ -18,31 +18,28 @@ const MonitorList = props => (
             ...stageSizeToTransform(props.stageSize)
         }}
     >
-        <Box
-        >
-            {props.monitors.valueSeq().filter(m => m.visible)
-                .map(monitorData => (
-                    <Monitor
-                        draggable={props.draggable}
-                        height={monitorData.height}
-                        id={monitorData.id}
-                        isDiscrete={monitorData.isDiscrete}
-                        key={monitorData.id}
-                        max={monitorData.sliderMax}
-                        min={monitorData.sliderMin}
-                        mode={monitorData.mode}
-                        opcode={monitorData.opcode}
-                        params={monitorData.params}
-                        spriteName={monitorData.spriteName}
-                        targetId={monitorData.targetId}
-                        value={monitorData.value}
-                        width={monitorData.width}
-                        x={monitorData.x}
-                        y={monitorData.y}
-                        onDragEnd={props.onMonitorChange}
-                    />
-                ))}
-        </Box>
+        {props.monitors.valueSeq().filter(m => m.visible)
+            .map(monitorData => (
+                <Monitor
+                    draggable={props.draggable}
+                    height={monitorData.height}
+                    id={monitorData.id}
+                    isDiscrete={monitorData.isDiscrete}
+                    key={monitorData.id}
+                    max={monitorData.sliderMax}
+                    min={monitorData.sliderMin}
+                    mode={monitorData.mode}
+                    opcode={monitorData.opcode}
+                    params={monitorData.params}
+                    spriteName={monitorData.spriteName}
+                    targetId={monitorData.targetId}
+                    value={monitorData.value}
+                    width={monitorData.width}
+                    x={monitorData.x}
+                    y={monitorData.y}
+                    onDragEnd={props.onMonitorChange}
+                />
+            ))}
     </Box>
 );
 

--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -52,6 +52,7 @@ const MonitorComponent = props => (
             defaultClassNameDragging={styles.dragging}
             disabled={!props.draggable}
             onStop={props.onDragEnd}
+            scale={props.scale} // Used for moving the monitor at the correct speed
         >
             <Box
                 className={styles.monitorContainer}
@@ -138,6 +139,7 @@ MonitorComponent.propTypes = {
     category: PropTypes.oneOf(Object.keys(categoryColorMap)),
     componentRef: PropTypes.func.isRequired,
     draggable: PropTypes.bool.isRequired,
+    scale: PropTypes.number,
     label: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(monitorModes),
     onDragEnd: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -53,6 +53,8 @@ const MonitorComponent = props => (
             disabled={!props.draggable}
             onStop={props.onDragEnd}
             scale={props.scale} // Used for moving the monitor at the correct speed
+            grid={[1 * props.scale, 1 * props.scale]} // Tell the Draggable to round the coordinates
+            // See https://github.com/react-grid-layout/react-draggable/issues/664 on why it's not just [1, 1]
         >
             <Box
                 className={styles.monitorContainer}

--- a/packages/scratch-gui/src/containers/monitor.jsx
+++ b/packages/scratch-gui/src/containers/monitor.jsx
@@ -208,6 +208,7 @@ class Monitor extends React.Component {
                     componentRef={this.setElement}
                     {...monitorProps}
                     draggable={this.props.draggable}
+                    scale={this.props.scale}
                     height={this.props.height}
                     isDiscrete={this.props.isDiscrete}
                     max={this.props.max}
@@ -234,6 +235,7 @@ class Monitor extends React.Component {
 Monitor.propTypes = {
     addMonitorRect: PropTypes.func.isRequired,
     draggable: PropTypes.bool,
+    scale: PropTypes.number,
     height: PropTypes.number,
     id: PropTypes.string.isRequired,
     intl: intlShape,

--- a/packages/scratch-gui/src/containers/monitor.jsx
+++ b/packages/scratch-gui/src/containers/monitor.jsx
@@ -104,6 +104,13 @@ class Monitor extends React.Component {
         this.props.removeMonitorRect(this.props.id);
     }
     handleDragEnd (e, {x, y}) {
+        // The old version of <Draggable> that Scratch uses doesn't round the coordinates when
+        // it passes them to the event handler, only when it sets the CSS transform.
+        // Newer versions of <Draggable> would round the coordinates, but with floating point errors
+        // so it would still need the manual rounding
+        x = Math.round(x);
+        y = Math.round(y);
+        
         const newX = parseInt(this.element.style.left, 10) + x;
         const newY = parseInt(this.element.style.top, 10) + y;
         this.props.onDragEnd(


### PR DESCRIPTION
### Resolves

* https://github.com/scratchfoundation/scratch-gui/issues/2949
* https://github.com/scratchfoundation/scratch-gui/issues/2367
* https://github.com/scratchfoundation/scratch-gui/issues/9756
* https://github.com/scratchfoundation/scratch-gui/issues/9610
(most of these are duplicates of each other)

There is [a PR that solves this issue](https://github.com/scratchfoundation/scratch-gui/pull/5795) in scratch-gui but I think this way it can be solved with much less changes (out of the 42 added rows 22 is just changing white space for eslint, only the other 20 rows are actual changes)

### Proposed Changes

1. Resize the dragging bounds with the same CSS transform that resizes the monitors, instead of changing the width/height CSS properties
    - This way CSS word wrapping and react-draggable will let the monitors go to the edges of the stage
2. Remove the `<Box>` that used to do the CSS transform
    - It doesn't do the transform anymore and I don't think it did anything else
3. Set the `scale` property on the `<Draggable>`
    - This way react-draggable knows the speed at which it should move the monitors
4. Prevent the monitor from going to fractional coordinates even if `scale` is a fraction
    - The existing code expects the monitor coordinates to be integers [here](https://github.com/scratchfoundation/scratch-editor/blob/440957a0c7b4f76ebef93c2dc8706a5e413bd7e6/packages/scratch-gui/src/containers/monitor.jsx#L107-L108) and there might be other places where it expects integers
    1. set the `grid` property on the `<Draggable>`
        - round coordinates in CSS transform so the monitor appears to move to the position where Scratch will think it is
    2. round the coordinates in the `handleDragEnd` event handler
        - the `<Draggable>` doesn't round the coordinates for the event handler

### Reason for Changes

explained next to each change in Proposed Changes

### Test Coverage

_Please show how you have added tests to cover your changes_

I've run `npm test` and it accepted it (I think) (it didn't say "error" like when it didn't like the identation)

I've tried it out in these browsers and it seems to work

* Windows 10, Chrome 139
* Android, Chrome 138

I've temporarily added this to `handleDragEnd` for testing and it didn't cause any popups:
```js
if(this.element.style.transform!==`translate(${Math.round(x)}px, ${Math.round(y)}px)`) {
    alert(`monitor position doesn't match CSS: [${x},${y}] - ${this.element.style.transform}`);
}
```
