### PR TITLE
[UEPR-326] Fix issues after react migration

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/account-nav.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/account-nav.jsx
@@ -39,7 +39,7 @@ const AccountNavComponent = ({
                 styles.userInfo,
                 className
             )}
-            onMouseUp={onClick}
+            onClick={onClick}
         >
             {avatarUrl ? (
                 <UserAvatar

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -169,7 +169,7 @@ const StageHeaderComponent = function (props) {
                         <div className={styles.rightSection}>
                             {manuallySaveThumbnails && (
                                 <Button
-                                    aria-label={props.intl.formatMessage(messages.setThumbnail)}
+                                    aria-label={intl.formatMessage(messages.setThumbnail)}
                                     className={styles.setThumbnailButton}
                                     onClick={onUpdateThumbnail}
                                 >


### PR DESCRIPTION
### Resolves

- Resolves [UEPR-326](https://scratchfoundation.atlassian.net/browse/UEPR-326)

### Proposed Changes

This PR handles the following issues from UEPR-326:
- Remove leftover use of `intl` from `props`, instead of `react-intl` to fix broken projects on PDP
- Fix profile dropdown in the editor not opening

### Reason for Changes

Address regression issues after migrating to React 18

[UEPR-326]: https://scratchfoundation.atlassian.net/browse/UEPR-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ