### PR TITLE
[UEPR-307] Fix loading extension toast displayed multiple times

### DIFF
--- a/packages/scratch-gui/src/lib/alerts/index.jsx
+++ b/packages/scratch-gui/src/lib/alerts/index.jsx
@@ -216,7 +216,7 @@ const alerts = [
     {
         alertId: 'loadingExtensionData',
         alertType: AlertTypes.STANDARD,
-        clearList: [],
+        clearList: ['loadingExtensionData'],
         content: (
             <FormattedMessage
                 defaultMessage="Loading extension..."

--- a/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
+++ b/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
@@ -69,6 +69,8 @@ const vmListenerHOC = function (WrappedComponent) {
         }
         componentWillUnmount () {
             this.props.vm.removeListener('PERIPHERAL_CONNECTION_LOST_ERROR', this.props.onShowExtensionAlert);
+            this.props.vm.removeListener('EXTENSION_DATA_LOADING', this.props.onExtensionDataLoading);
+            
             if (this.props.attachKeyboardEvents) {
                 document.removeEventListener('keydown', this.handleKeyDown);
                 document.removeEventListener('keyup', this.handleKeyUp);


### PR DESCRIPTION
### Resolves

[UEPR-307](https://scratchfoundation.atlassian.net/browse/UEPR-307)

### Proposed Changes

- Remove loading extension event listener to prevent multiple alerts when moving from PDP to the editor or when switching languages
- Allow only one `loadingExtensionData` alert to be present at a time

### Reason for Changes

Ensure only a single "Loading extension..." alert is displayed

[UEPR-307]: https://scratchfoundation.atlassian.net/browse/UEPR-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ