### PR TITLE
feat: statistics for extension-added event

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import VMScratchBlocks from '../lib/blocks';
 import VM from '@scratch/scratch-vm';
 
+import analytics from '../lib/analytics';
 import log from '../lib/log.js';
 import Prompt from './prompt.jsx';
 import BlocksComponent from '../components/blocks/blocks.jsx';
@@ -434,6 +435,12 @@ class Blocks extends React.Component {
         }
     }
     handleExtensionAdded (categoryInfo) {
+        analytics.event({
+            category: 'extensions',
+            action: 'added',
+            label: categoryInfo.id
+        });
+
         const defineBlocks = blockInfoArray => {
             if (blockInfoArray && blockInfoArray.length > 0) {
                 const staticBlocksJson = [];


### PR DESCRIPTION
### Proposed Changes

Record statistics when an extension is added

### Reason for Changes

Bluetooth-driven hardware extensions already recorded statistics for things like "connected" or "connection failed," but this covers all extensions, including software extensions like `pen`. This should help us understand the rate of adoption of new extensions...