### PR TITLE
[UEPR-386] Sound editor crashes

### DIFF
--- a/packages/scratch-gui/src/containers/sound-editor.jsx
+++ b/packages/scratch-gui/src/containers/sound-editor.jsx
@@ -485,11 +485,11 @@ const mapStateToProps = (state, {soundIndex}) => {
     const sound = state.scratchGui.vm.editingTarget.sprite.sounds[index];
     const audioBuffer = state.scratchGui.vm.getSoundBuffer(index);
     return {
-        soundId: sound.soundId,
-        sampleRate: audioBuffer.sampleRate,
-        samples: audioBuffer.getChannelData(0),
+        soundId: sound?.soundId,
+        sampleRate: audioBuffer?.sampleRate,
+        samples: audioBuffer?.getChannelData(0),
         isFullScreen: state.scratchGui.mode.isFullScreen,
-        name: sound.name,
+        name: sound?.name,
         vm: state.scratchGui.vm
     };
 };

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -794,7 +794,7 @@ class VirtualMachine extends EventEmitter {
      * @return {AudioBuffer} the sound's audio buffer.
      */
     getSoundBuffer (soundIndex) {
-        const id = this.editingTarget.sprite.sounds[soundIndex].soundId;
+        const id = this.editingTarget.sprite.sounds[soundIndex]?.soundId;
         if (id && this.runtime && this.runtime.audioEngine) {
             return this.editingTarget.sprite.soundBank.getSoundPlayer(id).buffer;
         }


### PR DESCRIPTION
### Resolves

[UEPR-386](https://scratchfoundation.atlassian.net/browse/UEPR-386)

### Proposed Changes

- Check if a sound with the provided index exists before trying to access its data

### Reason for Changes

- This issue became visible after the React 18 upgrade. After a sound is removed for the first time, `mapStateToProps` is not re-evaluated, so no error occurs. On subsequent deletions, however, `mapStateToProps` is re-run via `handleSubsequentCalls`, which ends up calling `getSoundBuffer` when `this.editingTarget.sprite.sounds[soundIndex]` is already empty. This bug existed before React 18, but my assumption is that the previous React-Redux implementation swallowed errors thrown inside `mapStateToProps`, preventing them from surfacing. With React 18 errors thrown during render are no longer suppressed and now propagate, which is why the editor crashes after the upgrade even though the underlying bug was always present.


[UEPR-386]: https://scratchfoundation.atlassian.net/browse/UEPR-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ