### PR TITLE
[UEPR-287] Update new feature callout behavior in extensions modal

### DIFF
--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -231,10 +231,11 @@ class LibraryComponent extends React.Component {
     handleSelect (id) {
         const selectedItem = this.getFilteredData().find(item => this.constructKey(item) === id);
         
-        if (this.state.shouldShowFaceSensingCallout && !this.driver && selectedItem.extensionId !== 'faceSensing') {
-            return;
-        }
         if (this.state.shouldShowFaceSensingCallout && selectedItem.extensionId === 'faceSensing') {
+            if (!this.driver) {
+                return;
+            }
+       
             setHasUsedFaceSensing(this.props.username);
             this.setState({
                 shouldShowFaceSensingCallout: false


### PR DESCRIPTION
### Resolves

[UEPR-387](https://scratchfoundation.atlassian.net/browse/UEPR-387)

### Proposed Changes

- Show the face sensing feature callout only when the user clicks on the face sensing extension (or anywhere outside the other extensions)
- Do not trigger the face-sensing callout when the user interacts with other extensions
- Keep the existing behavior of removing the callout once the face sensing extension has been used

### Reason for Changes

- Prevent the callout from interrupting users when trying to use other extensions


[UEPR-387]: https://scratchfoundation.atlassian.net/browse/UEPR-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ