### PR TITLE
[UEPR-390] Fix: Allow pointer events on green flag button

### DIFF
--- a/packages/scratch-gui/src/components/stage/stage.css
+++ b/packages/scratch-gui/src/components/stage/stage.css
@@ -116,7 +116,7 @@ body .stage-bottom-wrapper {
     animation-fill-mode: forwards; /* Leave at 0 opacity after animation */
 }
 
-.green-flag-overlay-wrapper {
+body .green-flag-overlay-wrapper {
     width: 100%;
     height: 100%;
     display: flex;


### PR DESCRIPTION
## Resolves
- [UEPR-390](https://scratchfoundation.atlassian.net/browse/UEPR-390)

### Proposed Changes

Use more specific styles to allow pointer events on green flag overlay

### Reason for Changes

The green flag button is not clickable

[UEPR-390]: https://scratchfoundation.atlassian.net/browse/UEPR-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ