### PR TITLE
is online?

### DIFF
--- a/packages/scratch-gui/src/lib/make-toolbox-xml.js
+++ b/packages/scratch-gui/src/lib/make-toolbox-xml.js
@@ -5,7 +5,7 @@ const categorySeparator = '<sep gap="36"/>';
 
 const blockSeparator = '<sep gap="36"/>'; // At default scale, about 28px
 
- 
+
 const motion = function (isInitialSetup, isStage, targetId, colors) {
     const stageSelected = ScratchBlocks.ScratchMsgs.translate(
         'MOTION_STAGE_SELECTED',
@@ -513,6 +513,7 @@ const sensing = function (isInitialSetup, isStage, targetId, colors) {
         <block id="current" type="sensing_current"/>
         <block type="sensing_dayssince2000"/>
         ${blockSeparator}
+        <block id="online" type="sensing_online" />
         <block type="sensing_username"/>
         ${categorySeparator}
     </category>
@@ -736,7 +737,7 @@ const myBlocks = function (isInitialSetup, isStage, targetId, colors) {
     </category>
     `;
 };
- 
+
 
 const xmlOpen = '<xml style="display: none">';
 const xmlClose = '</xml>';

--- a/packages/scratch-gui/src/lib/opcode-labels.js
+++ b/packages/scratch-gui/src/lib/opcode-labels.js
@@ -68,6 +68,11 @@ const messages = defineMessages({
         description: 'Label for the loudness monitor when shown on the stage',
         id: 'gui.opcodeLabels.loudness'
     },
+    sensing_online: {
+        defaultMessage: 'online',
+        description: 'Label for the online status monitor when shown on the stage',
+        id: 'gui.opcodeLabels.online'
+    },
     sensing_username: {
         defaultMessage: 'username',
         description: 'Label for the username monitor when shown on the stage',
@@ -152,6 +157,7 @@ class OpcodeLabels {
             // Sensing
             sensing_answer: {category: 'sensing'},
             sensing_loudness: {category: 'sensing'},
+            sensing_online: {category: 'sensing'},
             sensing_username: {category: 'sensing'},
             sensing_current: {category: 'sensing'},
             sensing_timer: {category: 'sensing'}
@@ -208,6 +214,7 @@ class OpcodeLabels {
         // Sensing
         this._opcodeMap.sensing_answer.labelFn = () => this._translator(messages.sensing_answer);
         this._opcodeMap.sensing_loudness.labelFn = () => this._translator(messages.sensing_loudness);
+        this._opcodeMap.sensing_online.labelFn = () => this._translator(messages.sensing_online);
         this._opcodeMap.sensing_username.labelFn = () => this._translator(messages.sensing_username);
         this._opcodeMap.sensing_current.labelFn = params => {
             switch (params.CURRENTMENU.toLowerCase()) {

--- a/packages/scratch-vm/src/blocks/scratch3_sensing.js
+++ b/packages/scratch-vm/src/blocks/scratch3_sensing.js
@@ -71,6 +71,7 @@ class Scratch3SensingBlocks {
             sensing_loud: this.isLoud,
             sensing_askandwait: this.askAndWait,
             sensing_answer: this.getAnswer,
+            sensing_online: this.getOnline,
             sensing_username: this.getUsername,
             sensing_userid: () => {} // legacy no-op block
         };
@@ -83,6 +84,9 @@ class Scratch3SensingBlocks {
             },
             sensing_loudness: {
                 getId: () => 'loudness'
+            },
+            sensing_online: {
+                getId: () => 'online'
             },
             sensing_timer: {
                 getId: () => 'timer'
@@ -326,6 +330,16 @@ class Scratch3SensingBlocks {
 
         // Otherwise, 0
         return 0;
+    }
+
+    getOnline (args, util) {
+        const status = window.navigator.onLine;
+        if (typeof status === 'boolean') {
+            return status;
+        }
+        // an empty string will evaluate as false in a Boolean context,
+        // but it allows distinguishing between "false" and "unknown" if needed
+        return '';
     }
 
     getUsername (args, util) {


### PR DESCRIPTION
See also scratchfoundation/scratch-blocks#3412

### Proposed Changes

Add a new block to the Sensing category to detect whether or not the system is online (has an active Internet connection).

### Reason for Changes

Scratch users have discovered ways to check for online status, most commonly by repeatedly using the Translate extension. While I applaud the ingenuity, this approach generates excess load on the Translate infrastructure. Scratchers and the Scratch Team will all have a better time if we provide a direct way to check for online status.

I'm open to feedback, including:
- Should the label of the monitor be something other than `online`?
- I definitely think this block belongs in the Sensing category, but is this (just before username) the right place for it within the category?

### Test Coverage

Tested locally:
<img width="724" height="342" alt="image" src="https://github.com/user-attachments/assets/0b0cc4be-f9e6-420a-9d51-d1b109a014e2" />
