### PR TITLE
Incorrectly positioned "delete sprite" modal on resize

### DIFF
--- a/packages/scratch-gui/src/containers/sprite-selector-item.jsx
+++ b/packages/scratch-gui/src/containers/sprite-selector-item.jsx
@@ -36,7 +36,7 @@ class SpriteSelectorItem extends React.PureComponent {
             'handleDeleteSpriteModalConfirm'
         ]);
 
-        this.handleResize = debounce(this.handleResize.bind(this), 200);
+        this.handleResize = debounce(this.handleResize.bind(this), 50, {leading: true});
 
         this.dragRecognizer = new DragRecognizer({
             onDrag: this.handleDrag,

--- a/packages/scratch-gui/src/containers/sprite-selector-item.jsx
+++ b/packages/scratch-gui/src/containers/sprite-selector-item.jsx
@@ -1,4 +1,5 @@
 import bindAll from 'lodash.bindall';
+import debounce from 'lodash.debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -32,9 +33,10 @@ class SpriteSelectorItem extends React.PureComponent {
             'handleTouchEnd',
             'handleDeleteButtonClick',
             'handleDeleteSpriteModalClose',
-            'handleDeleteSpriteModalConfirm',
-            'handleResize'
+            'handleDeleteSpriteModalConfirm'
         ]);
+
+        this.handleResize = debounce(this.handleResize.bind(this), 200);
 
         this.dragRecognizer = new DragRecognizer({
             onDrag: this.handleDrag,
@@ -51,6 +53,7 @@ class SpriteSelectorItem extends React.PureComponent {
         document.removeEventListener('touchend', this.handleTouchEnd);
         window.removeEventListener('resize', this.handleResize);
         this.dragRecognizer.reset();
+        this.handleResize.cancel();
     }
     getCostumeData () {
         if (this.props.costumeURL) return this.props.costumeURL;

--- a/packages/scratch-gui/src/containers/sprite-selector-item.jsx
+++ b/packages/scratch-gui/src/containers/sprite-selector-item.jsx
@@ -32,7 +32,8 @@ class SpriteSelectorItem extends React.PureComponent {
             'handleTouchEnd',
             'handleDeleteButtonClick',
             'handleDeleteSpriteModalClose',
-            'handleDeleteSpriteModalConfirm'
+            'handleDeleteSpriteModalConfirm',
+            'handleResize'
         ]);
 
         this.dragRecognizer = new DragRecognizer({
@@ -44,9 +45,11 @@ class SpriteSelectorItem extends React.PureComponent {
     }
     componentDidMount () {
         document.addEventListener('touchend', this.handleTouchEnd);
+        window.addEventListener('resize', this.handleResize);
     }
     componentWillUnmount () {
         document.removeEventListener('touchend', this.handleTouchEnd);
+        window.removeEventListener('resize', this.handleResize);
         this.dragRecognizer.reset();
     }
     getCostumeData () {
@@ -54,6 +57,9 @@ class SpriteSelectorItem extends React.PureComponent {
         if (!this.props.asset) return null;
 
         return getCostumeUrl(this.props.storage.scratchStorage, this.props.asset);
+    }
+    handleResize () {
+        this.forceUpdate();
     }
     handleDragEnd () {
         if (this.props.dragging) {
@@ -149,6 +155,7 @@ class SpriteSelectorItem extends React.PureComponent {
         } = this.props;
         return (<>
             {this.state.isDeletePromptOpen ? <DeleteConfirmationPrompt
+                key={Date.now()}
                 onOk={this.handleDeleteSpriteModalConfirm}
                 onCancel={this.handleDeleteSpriteModalClose}
                 relativeElemRef={this.ref}

--- a/packages/scratch-gui/src/containers/sprite-selector-item.jsx
+++ b/packages/scratch-gui/src/containers/sprite-selector-item.jsx
@@ -155,7 +155,6 @@ class SpriteSelectorItem extends React.PureComponent {
         } = this.props;
         return (<>
             {this.state.isDeletePromptOpen ? <DeleteConfirmationPrompt
-                key={Date.now()}
                 onOk={this.handleDeleteSpriteModalConfirm}
                 onCancel={this.handleDeleteSpriteModalClose}
                 relativeElemRef={this.ref}


### PR DESCRIPTION
### Resolves

(https://scratchfoundation.atlassian.net/browse/UEPR-81)

### Proposed Changes

It rerenders delete modal prompt on resize so it stays next to the sprite item
Also except for the rerender, I added a key (date) for the delete confirmation prompt so react knows it should rerender it every time instead of cache-ing it.

### Reason for Changes

More consistent UI on resize

