### PR TITLE
fix: temporarily disable allowjs in tsconfig.json to fix build errors…

### DIFF
--- a/packages/scratch-gui/eslint.config.mjs
+++ b/packages/scratch-gui/eslint.config.mjs
@@ -40,7 +40,7 @@ export default eslintConfigScratch.defineConfig(
                 projectService: false,
                 tsconfigRootDir: import.meta.dirname,
                 project: [
-                    'tsconfig.json',
+                    'tsconfig.eslint.json',
                     'tsconfig.test.json'
                 ]
             }

--- a/packages/scratch-gui/tsconfig.eslint.json
+++ b/packages/scratch-gui/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "include": ["src"],
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+  }
+}

--- a/packages/scratch-gui/tsconfig.json
+++ b/packages/scratch-gui/tsconfig.json
@@ -6,7 +6,6 @@
     /* Language and Environment */
     "target": "ESNext",
     "jsx": "react",
-    "allowJs": true,
 
     /* Modules */
     "module": "commonjs",

--- a/packages/scratch-gui/tsconfig.test.json
+++ b/packages/scratch-gui/tsconfig.test.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
+    "allowJs": true,
 
     /* Modules */
     "types": ["jest", "./src/types.d.ts"],


### PR DESCRIPTION
… from parsing dist/ folders

### Resolves

Issues with building scratch-gui

### Proposed Changes

Disable the `allowJs` tsconfig option introduced in https://github.com/scratchfoundation/scratch-editor/pull/327/files. 

### Reason for Changes

Currently, when building, TS loader attempts to parse minified .js files in the /dist folders of the vm/renderer/svg-renderer packages.
A more robust solution might be to exclude those folders in `scratch-webpack-configuration`, but this might serve as a temporary solutions.
We might lose some of the ts checks on js[x] files, but it shouldn't affect the build negatively.

