### PR TITLE
[UEPR-453] Avatar elements on older browsers

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/user-avatar.css
+++ b/packages/scratch-gui/src/components/menu-bar/user-avatar.css
@@ -17,10 +17,10 @@
 }
 
 .avatar-badge-wrapper {
-    display: inline-block;
+    display: inline-flex;
     background: url('./cat-ears.svg') no-repeat top ;
     background-size: contain;
-    align-content: end;
+    align-items: flex-end;
 
     width: $menu-bar-button-size;
     height: calc($menu-bar-button-size * 1.28);


### PR DESCRIPTION
### Resolves

[UEPR-453](https://scratchfoundation.atlassian.net/browse/UEPR-453)

### Proposed Changes

- Make the avatar wrapper a flexbox to avoid using unsupported css properties

### Reason for Changes

- Display avatar elements properly on older browsers


[UEPR-453]: https://scratchfoundation.atlassian.net/browse/UEPR-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ