### PR TITLE
fix: look for block media assets in colorModeMap instead of themeMap

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -404,7 +404,7 @@ const GUIComponent = props => {
                                         grow={1}
                                         isVisible={blocksTabVisible}
                                         options={{
-                                            media: `${basePath}static/${themeMap[theme].blocksMediaFolder}/`
+                                            media: `${basePath}static/${colorModeMap[colorMode].blocksMediaFolder}/`
                                         }}
                                         stageSize={stageSize}
                                         theme={theme}


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-459

### Proposed Changes

Reference `colorModeMap` for icons in editor instead of `themeMap`.

### Reason for Changes

`themeMap` was renamed to `colorModeMap`. During a backmerge one of the usages was not updated which caused icons in the editor to be unable to be resolved.

