### PR TITLE
[UEPR-470] Fix misaligned cat ears frame on some user avatars

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/account-nav.css
+++ b/packages/scratch-gui/src/components/menu-bar/account-nav.css
@@ -19,11 +19,11 @@
     font-weight: normal;
 }
 
-[dir="ltr"] .user-info .avatar {
+[dir="ltr"] .user-info .avatar-wrapper {
     margin-right: calc($space * .8125);
 }
 
-[dir="rtl"] .user-info .avatar {
+[dir="rtl"] .user-info .avatar-wrapper {
     margin-left: calc($space * .8125);
 }
 

--- a/packages/scratch-gui/src/components/menu-bar/account-nav.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/account-nav.jsx
@@ -45,6 +45,7 @@ const AccountNavComponent = ({
             {avatarUrl ? (
                 <UserAvatar
                     className={styles.avatar}
+                    wrapperClassName={styles.avatarWrapper}
                     imageUrl={avatarUrl}
                     showAvatarBadge={!!avatarBadge}
                 />

--- a/packages/scratch-gui/src/components/menu-bar/user-avatar.css
+++ b/packages/scratch-gui/src/components/menu-bar/user-avatar.css
@@ -26,10 +26,3 @@
     height: calc($menu-bar-button-size * 1.28);
 }
 
-[dir="ltr"] .avatar-badge-wrapper {
-    margin-right: calc($space * .8125);
-}
-
-[dir="rtl"] .avatar-badge-wrapper {
-    margin-left: calc($space * .8125);
-}

--- a/packages/scratch-gui/src/components/menu-bar/user-avatar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/user-avatar.jsx
@@ -6,10 +6,17 @@ import styles from './user-avatar.css';
 
 const UserAvatar = ({
     className,
+    wrapperClassName,
     imageUrl,
     showAvatarBadge = false
 }) => (
-    <div className={classNames(showAvatarBadge && styles.avatarBadgeWrapper)}>
+    <div
+        className={classNames(
+            wrapperClassName,
+            styles.avatarWrapper,
+            showAvatarBadge && styles.avatarBadgeWrapper)
+        }
+    >
         <img
             className={classNames(
                 className,
@@ -24,6 +31,7 @@ const UserAvatar = ({
 
 UserAvatar.propTypes = {
     className: PropTypes.string,
+    wrapperClassName: PropTypes.string,
     imageUrl: PropTypes.string,
     showAvatarBadge: PropTypes.bool
 };


### PR DESCRIPTION
### Resolves

- Resolves [UEPR-470](https://scratchfoundation.atlassian.net/browse/UEPR-470)

### Proposed Changes

- Move the margins to a wrapper elements, rather than duplicating them both on the actual image and the badge wrapper

### Reason for Changes

- Member avatar images can appear misaligned when the image has a narrow width. The issue was caused by CSS margins applied to both the avatar wrapper and the `img` element. When the image is smaller, the margin forces the image to shrink instead of filling the fixed avatar frame, resulting in a visible gap.

[UEPR-470]: https://scratchfoundation.atlassian.net/browse/UEPR-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ