### PR TITLE
fix: improve support for isolatedModules flag

### DIFF
--- a/packages/scratch-gui/src/index-standalone.tsx
+++ b/packages/scratch-gui/src/index-standalone.tsx
@@ -6,8 +6,8 @@ import {EditorState} from './lib/editor-state';
 import {ReactComponentLike} from 'prop-types';
 import {compose} from 'redux';
 
-export {EditorState, EditorStateParams} from './lib/editor-state';
-export {AccountMenuOptions} from './lib/account-menu-options';
+export {EditorState, type EditorStateParams} from './lib/editor-state';
+export {type AccountMenuOptions} from './lib/account-menu-options';
 
 export {setAppElement} from 'react-modal';
 

--- a/packages/scratch-gui/src/lib/legacy-storage.ts
+++ b/packages/scratch-gui/src/lib/legacy-storage.ts
@@ -69,11 +69,13 @@ export class LegacyStorage implements GUIStorage {
         vmState: string,
         params: { originalId: string; isCopy: boolean; isRemix: boolean; title: string; }
     ): Promise<{ id: string | number; }> {
-        if (!this.projectHost) {
+        const host = this.projectHost;
+
+        if (!host) {
             return Promise.reject(new Error('Project host not set'));
         }
         // Haven't inlined the code here so that we can keep Git history on the implementation, just in case
-        return saveProjectToServer(this.projectHost, projectId, vmState, params);
+        return saveProjectToServer(host, projectId, vmState, params);
     }
 
     private cacheDefaultProject (storage: ScratchStorage) {


### PR DESCRIPTION
### Resolves

As part of our development, we made use of the TypeScript [isolatedModules flag](https://www.typescriptlang.org/tsconfig/#isolatedModules) and this raised an issue when compiling the project along the lines of:
> Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.ts

### Proposed Changes

This PR implements the `export type` changes as discussed in [this Stackoverflow thread](https://stackoverflow.com/questions/70416680/re-exporting-a-type-when-the-isolatedmodules-flag-is-provided-requires-using), as well as a minor JSDoc fix.

### Reason for Changes

These changes are a tiny step in the direction of supporting `isolatedModules` in Scratch and they improve correctness.

### Test Coverage

I'm not sure what would make sense here, but I'm open to suggestions