### PR TITLE
[UEPR-470] Fix misaligned avatar for author image as well

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/author-info.css
+++ b/packages/scratch-gui/src/components/menu-bar/author-info.css
@@ -10,7 +10,7 @@
     cursor: default;
 }
 
-.avatar {
+.avatar-wrapper {
     margin-right: .5625rem;
 }
 

--- a/packages/scratch-gui/src/components/menu-bar/author-info.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/author-info.jsx
@@ -25,6 +25,7 @@ const AuthorInfo = ({
             className={styles.avatar}
             imageUrl={imageUrl}
             showAvatarBadge={!!avatarBadge}
+            wrapperClassName={styles.avatarWrapper}
         />
         <div className={styles.titleAuthor}>
             <span className={styles.projectTitle}>


### PR DESCRIPTION
### Resolves

- Part of [UEPR-470](https://scratchfoundation.atlassian.net/browse/UEPR-470)

### Proposed Changes

- Move the margin to the wrapper class for the author info as well
 
### Reason for Changes

- The author avatar is still misaligned and is missing the required margin


[UEPR-470]: https://scratchfoundation.atlassian.net/browse/UEPR-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ