### PR TITLE
[UEPR-471] Ensure Library modals are navigable through tab navigation

### DIFF
--- a/packages/scratch-gui/src/components/extension-button/extension-button.css
+++ b/packages/scratch-gui/src/components/extension-button/extension-button.css
@@ -39,6 +39,10 @@ $fade-out-distance: 15px;
     --radiate-color: 133, 92, 214; /* $looks-secondary */
 }
 
+.extension-button:focus-visible {
+    outline: revert;
+}
+
 .extension-button-icon {
     width: 1.75rem;
     height: 1.75rem;

--- a/packages/scratch-gui/src/components/extension-button/extension-button.jsx
+++ b/packages/scratch-gui/src/components/extension-button/extension-button.jsx
@@ -74,6 +74,10 @@ const ExtensionButton = props => {
         if (!shouldShowFaceSensingCallouts) return;
 
         const onFirstInteraction = e => {
+            // Make sure to clean up event listeners after first interaction
+            window.removeEventListener('click', onFirstInteraction);
+            window.removeEventListener('keydown', onFirstInteraction);
+
             const isExtensionButtonVisible = document.querySelector('div[class*="extension-button-container"]');
             if (!isExtensionButtonVisible) return;
 
@@ -102,10 +106,6 @@ const ExtensionButton = props => {
             setClicked(true);
             driverRef.current = tooltip;
             tooltip.drive();
-
-            // Make sure to clean up event listeners after first interaction
-            window.removeEventListener('click', onFirstInteraction);
-            window.removeEventListener('keydown', onFirstInteraction);
         };
 
         window.addEventListener('click', onFirstInteraction, {once: true});

--- a/packages/scratch-gui/src/components/extension-button/extension-button.jsx
+++ b/packages/scratch-gui/src/components/extension-button/extension-button.jsx
@@ -73,9 +73,14 @@ const ExtensionButton = props => {
     useEffect(() => {
         if (!shouldShowFaceSensingCallouts) return;
 
-        const onFirstClick = () => {
+        const onFirstInteraction = e => {
             const isExtensionButtonVisible = document.querySelector('div[class*="extension-button-container"]');
             if (!isExtensionButtonVisible) return;
+
+            if (e.type === 'keydown') {
+                // Prevent focus from jumping to the next element in the tab order after keydown finishes
+                e.preventDefault();
+            }
 
             const tooltip = driver({
                 allowClose: false,
@@ -97,8 +102,14 @@ const ExtensionButton = props => {
             setClicked(true);
             driverRef.current = tooltip;
             tooltip.drive();
+
+            // Make sure to clean up event listeners after first interaction
+            window.removeEventListener('click', onFirstInteraction);
+            window.removeEventListener('keydown', onFirstInteraction);
         };
-        window.addEventListener('click', onFirstClick, {once: true});
+
+        window.addEventListener('click', onFirstInteraction, {once: true});
+        window.addEventListener('keydown', onFirstInteraction, {once: true});
 
         return () => {
             if (driverRef.current) {
@@ -145,7 +156,6 @@ const ExtensionButton = props => {
 
     return (
         <Box className={styles.extensionButtonContainer}>
-            {/* TODO: Add focus indicator */}
             <button
                 className={
                     classNames(styles.extensionButton,
@@ -153,6 +163,7 @@ const ExtensionButton = props => {
                     )}
                 title={intl.formatMessage(messages.addExtension)}
                 onClick={handleExtensionButtonClick}
+                aria-label={intl.formatMessage(messages.addExtension)}
             >
                 <img
                     className={styles.extensionButtonIcon}

--- a/packages/scratch-gui/src/components/extension-button/extension-button.jsx
+++ b/packages/scratch-gui/src/components/extension-button/extension-button.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useCallback, useState, useRef} from 'react';
+import React, {useEffect, useCallback, useState, useRef, useContext} from 'react';
 import classNames from 'classnames';
 // eslint-disable-next-line import/no-unresolved
 import {driver} from 'driver.js';
@@ -13,6 +13,7 @@ import {getLocalStorageValue, setLocalStorageValue} from '../../lib/local-storag
 import addExtensionIcon from '../gui/icon--extensions.svg';
 import styles from './extension-button.css';
 import './extension-button.raw.css';
+import {ModalFocusContext} from '../../contexts/modal-focus-context.jsx';
 
 const messages = defineMessages({
     addExtension: {
@@ -62,6 +63,8 @@ const ExtensionButton = props => {
     } = props;
 
     const driverRef = useRef(null);
+    const {captureFocus} = useContext(ModalFocusContext);
+
     // Keep in a state to avoid reads from localStorage on every render.
     const [shouldShowFaceSensingCallouts, setShouldShowFaceSensingCallouts] =
         useState(showNewFeatureCallouts && !hasIntroducedFaceSensing(username) && !hasUsedFaceSensing(username));
@@ -135,8 +138,10 @@ const ExtensionButton = props => {
             setHasIntroducedFaceSensing(username);
             setShouldShowFaceSensingCallouts(false);
         }
+
+        captureFocus();
         onExtensionButtonClick?.();
-    }, [shouldShowFaceSensingCallouts]);
+    }, [shouldShowFaceSensingCallouts, captureFocus, onExtensionButtonClick, username]);
 
     return (
         <Box className={styles.extensionButtonContainer}>

--- a/packages/scratch-gui/src/components/extension-button/extension-button.jsx
+++ b/packages/scratch-gui/src/components/extension-button/extension-button.jsx
@@ -141,7 +141,7 @@ const ExtensionButton = props => {
 
         captureFocus();
         onExtensionButtonClick?.();
-    }, [shouldShowFaceSensingCallouts, captureFocus, onExtensionButtonClick, username]);
+    }, [shouldShowFaceSensingCallouts, captureFocus, onExtensionButtonClick]);
 
     return (
         <Box className={styles.extensionButtonContainer}>

--- a/packages/scratch-gui/src/components/filter/filter.css
+++ b/packages/scratch-gui/src/components/filter/filter.css
@@ -59,6 +59,9 @@
     pointer-events: none;
     cursor: default;
     transition: opacity 0.05s linear;
+
+    border: none;
+    background: none;
 }
 
 [dir="ltr"] .x-icon-wrapper {

--- a/packages/scratch-gui/src/components/filter/filter.jsx
+++ b/packages/scratch-gui/src/components/filter/filter.jsx
@@ -1,10 +1,17 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useCallback, useRef} from 'react';
 
 import filterIcon from './icon--filter.svg';
 import xIcon from './icon--x.svg';
 import styles from './filter.css';
+import {defineMessage, useIntl} from 'react-intl';
+
+const ariaLabel = defineMessage({
+    id: 'gui.aria.clearButton',
+    defaultMessage: 'Clear',
+    description: 'ARIA label for the clear input button'
+});
 
 const FilterComponent = props => {
     const {
@@ -15,6 +22,18 @@ const FilterComponent = props => {
         filterQuery,
         inputClassName
     } = props;
+    const intl = useIntl();
+    const inputRef = useRef(null);
+
+    const handleClear = useCallback(e => {
+        onClear(e);
+        
+        // Return focus to the input after clearing
+        if (inputRef?.current) {
+            inputRef.current.focus();
+        }
+    }, [onClear]);
+
     return (
         <div
             className={classNames(className, styles.filter, {
@@ -26,21 +45,25 @@ const FilterComponent = props => {
                 src={filterIcon}
             />
             <input
+                ref={inputRef}
                 className={classNames(styles.filterInput, inputClassName)}
                 placeholder={placeholderText}
                 type="text"
                 value={filterQuery}
                 onChange={onChange}
             />
-            <div
+            <button
                 className={styles.xIconWrapper}
-                onClick={onClear}
+                onClick={handleClear}
+                aria-label={intl.formatMessage(ariaLabel)}
+                // Make x button focusable only when visible
+                tabIndex={filterQuery.length > 0 ? 0 : -1}
             >
                 <img
                     className={styles.xIcon}
                     src={xIcon}
                 />
-            </div>
+            </button>
         </div>
     );
 };

--- a/packages/scratch-gui/src/components/filter/filter.jsx
+++ b/packages/scratch-gui/src/components/filter/filter.jsx
@@ -27,7 +27,7 @@ const FilterComponent = props => {
 
     const handleClear = useCallback(e => {
         onClear(e);
-        
+
         // Return focus to the input after clearing
         if (inputRef?.current) {
             inputRef.current.focus();
@@ -53,6 +53,7 @@ const FilterComponent = props => {
                 onChange={onChange}
             />
             <button
+                type="button"
                 className={styles.xIconWrapper}
                 onClick={handleClear}
                 aria-label={intl.formatMessage(ariaLabel)}

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -46,6 +46,7 @@ import DebugModal from '../debug-modal/debug-modal.jsx';
 import {setPlatform} from '../../reducers/platform.js';
 import {setTheme} from '../../reducers/settings.js';
 import {PLATFORM} from '../../lib/platform.js';
+import {ModalFocusProvider} from '../../contexts/modal-focus-context.jsx';
 
 const ariaMessages = defineMessages({
     menuBar: {
@@ -271,300 +272,302 @@ const GUIComponent = props => {
                 ) : null}
             </StageWrapper>
         ) : (
-            <Box
-                className={styles.pageWrapper}
-                dir={isRtl ? 'rtl' : 'ltr'}
-                {...componentProps}
-            >
-                {telemetryModalVisible ? (
-                    <TelemetryModal
-                        isRtl={isRtl}
-                        isTelemetryEnabled={isTelemetryEnabled}
-                        onCancel={onTelemetryModalCancel}
-                        onOptIn={onTelemetryModalOptIn}
-                        onOptOut={onTelemetryModalOptOut}
-                        onRequestClose={onRequestCloseTelemetryModal}
-                        onShowPrivacyPolicy={onShowPrivacyPolicy}
-                    />
-                ) : null}
-                {loading ? (
-                    <Loader />
-                ) : null}
-                {isCreating ? (
-                    <Loader messageId="gui.loader.creating" />
-                ) : null}
-                {isRendererSupported ? null : (
-                    <WebGlModal isRtl={isRtl} />
-                )}
-                {tipsLibraryVisible ? (
-                    <TipsLibrary
-                        hideTutorialProjects={hideTutorialProjects}
-                        onTutorialSelect={onTutorialSelect}
-                    />
-                ) : null}
-                {cardsVisible ? (
-                    <Cards />
-                ) : null}
-                {alertsVisible ? (
-                    <Alerts className={styles.alertsContainer} />
-                ) : null}
-                {connectionModalVisible ? (
-                    <ConnectionModal
-                        useExternalPeripheralList={useExternalPeripheralList}
-                        vm={vm}
-                    />
-                ) : null}
-                {costumeLibraryVisible ? (
-                    <CostumeLibrary
-                        vm={vm}
-                        onRequestClose={onRequestCloseCostumeLibrary}
-                    />
-                ) : null}
-                {<DebugModal
-                    isOpen={debugModalVisible}
-                    onClose={onCloseDebugModal}
-                />}
-                {backdropLibraryVisible ? (
-                    <BackdropLibrary
-                        vm={vm}
-                        onRequestClose={onRequestCloseBackdropLibrary}
-                    />
-                ) : null}
-                {!menuBarHidden && <MenuBar
-                    ariaRole="banner"
-                    ariaLabel={intl.formatMessage(ariaMessages.menuBar)}
-                    accountNavOpen={accountNavOpen}
-                    authorId={authorId}
-                    authorThumbnailUrl={authorThumbnailUrl}
-                    authorUsername={authorUsername}
-                    authorAvatarBadge={authorAvatarBadge}
-                    canChangeLanguage={canChangeLanguage}
-                    canChangeColorMode={canChangeColorMode}
-                    canChangeTheme={canChangeTheme}
-                    canCreateCopy={canCreateCopy}
-                    canCreateNew={canCreateNew}
-                    canEditTitle={canEditTitle}
-                    canManageFiles={canManageFiles}
-                    canRemix={canRemix}
-                    canSave={canSave}
-                    canShare={canShare}
-                    className={styles.menuBarPosition}
-                    enableCommunity={enableCommunity}
-                    hasActiveMembership={hasActiveMembership}
-                    isShared={isShared}
-                    isTotallyNormal={isTotallyNormal}
-                    logo={logo}
-                    renderLogin={renderLogin}
-                    showComingSoon={showComingSoon}
-                    onClickAbout={onClickAbout}
-                    onClickAccountNav={onClickAccountNav}
-                    onClickLogo={onClickLogo}
-                    onCloseAccountNav={onCloseAccountNav}
-                    onLogOut={onLogOut}
-                    onOpenRegistration={onOpenRegistration}
-                    onProjectTelemetryEvent={onProjectTelemetryEvent}
-                    onSeeCommunity={onSeeCommunity}
-                    onShare={onShare}
-                    onStartSelectingFileUpload={onStartSelectingFileUpload}
-                    onToggleLoginOpen={onToggleLoginOpen}
-                    userOwnsProject={userOwnsProject}
-                    username={username}
-                    accountMenuOptions={accountMenuOptions}
-                />}
-                <Box className={classNames(boxStyles, styles.flexWrapper)}>
-                    <Box
-                        role="main"
-                        aria-label={intl.formatMessage(ariaMessages.editor)}
-                        className={styles.editorWrapper}
-                        element="main"
-                    >
-                        <Tabs
-                            forceRenderTabPanel
-                            className={tabClassNames.tabs}
-                            selectedIndex={activeTabIndex}
-                            selectedTabClassName={tabClassNames.tabSelected}
-                            selectedTabPanelClassName={tabClassNames.tabPanelSelected}
-                            onSelect={onActivateTab}
-
-                            // TODO: focusTabOnClick should be true for accessibility, but currently conflicts
-                            // with nudge operations in the paint editor. We'll likely need to manage focus
-                            // differently within the paint editor before we can turn this back on.
-                            // Repro steps:
-                            // 1. Click the Costumes tab
-                            // 2. Select something in the paint editor (say, the cat's face)
-                            // 3. Press the left or right arrow key
-                            // Desired behavior: the face should nudge left or right
-                            // Actual behavior: the Code or Sounds tab is now focused
-                            focusTabOnClick={false}
+            <ModalFocusProvider>
+                <Box
+                    className={styles.pageWrapper}
+                    dir={isRtl ? 'rtl' : 'ltr'}
+                    {...componentProps}
+                >
+                    {telemetryModalVisible ? (
+                        <TelemetryModal
+                            isRtl={isRtl}
+                            isTelemetryEnabled={isTelemetryEnabled}
+                            onCancel={onTelemetryModalCancel}
+                            onOptIn={onTelemetryModalOptIn}
+                            onOptOut={onTelemetryModalOptOut}
+                            onRequestClose={onRequestCloseTelemetryModal}
+                            onShowPrivacyPolicy={onShowPrivacyPolicy}
+                        />
+                    ) : null}
+                    {loading ? (
+                        <Loader />
+                    ) : null}
+                    {isCreating ? (
+                        <Loader messageId="gui.loader.creating" />
+                    ) : null}
+                    {isRendererSupported ? null : (
+                        <WebGlModal isRtl={isRtl} />
+                    )}
+                    {tipsLibraryVisible ? (
+                        <TipsLibrary
+                            hideTutorialProjects={hideTutorialProjects}
+                            onTutorialSelect={onTutorialSelect}
+                        />
+                    ) : null}
+                    {cardsVisible ? (
+                        <Cards />
+                    ) : null}
+                    {alertsVisible ? (
+                        <Alerts className={styles.alertsContainer} />
+                    ) : null}
+                    {connectionModalVisible ? (
+                        <ConnectionModal
+                            useExternalPeripheralList={useExternalPeripheralList}
+                            vm={vm}
+                        />
+                    ) : null}
+                    {costumeLibraryVisible ? (
+                        <CostumeLibrary
+                            vm={vm}
+                            onRequestClose={onRequestCloseCostumeLibrary}
+                        />
+                    ) : null}
+                    {<DebugModal
+                        isOpen={debugModalVisible}
+                        onClose={onCloseDebugModal}
+                    />}
+                    {backdropLibraryVisible ? (
+                        <BackdropLibrary
+                            vm={vm}
+                            onRequestClose={onRequestCloseBackdropLibrary}
+                        />
+                    ) : null}
+                    {!menuBarHidden && <MenuBar
+                        ariaRole="banner"
+                        ariaLabel={intl.formatMessage(ariaMessages.menuBar)}
+                        accountNavOpen={accountNavOpen}
+                        authorId={authorId}
+                        authorThumbnailUrl={authorThumbnailUrl}
+                        authorUsername={authorUsername}
+                        authorAvatarBadge={authorAvatarBadge}
+                        canChangeLanguage={canChangeLanguage}
+                        canChangeColorMode={canChangeColorMode}
+                        canChangeTheme={canChangeTheme}
+                        canCreateCopy={canCreateCopy}
+                        canCreateNew={canCreateNew}
+                        canEditTitle={canEditTitle}
+                        canManageFiles={canManageFiles}
+                        canRemix={canRemix}
+                        canSave={canSave}
+                        canShare={canShare}
+                        className={styles.menuBarPosition}
+                        enableCommunity={enableCommunity}
+                        hasActiveMembership={hasActiveMembership}
+                        isShared={isShared}
+                        isTotallyNormal={isTotallyNormal}
+                        logo={logo}
+                        renderLogin={renderLogin}
+                        showComingSoon={showComingSoon}
+                        onClickAbout={onClickAbout}
+                        onClickAccountNav={onClickAccountNav}
+                        onClickLogo={onClickLogo}
+                        onCloseAccountNav={onCloseAccountNav}
+                        onLogOut={onLogOut}
+                        onOpenRegistration={onOpenRegistration}
+                        onProjectTelemetryEvent={onProjectTelemetryEvent}
+                        onSeeCommunity={onSeeCommunity}
+                        onShare={onShare}
+                        onStartSelectingFileUpload={onStartSelectingFileUpload}
+                        onToggleLoginOpen={onToggleLoginOpen}
+                        userOwnsProject={userOwnsProject}
+                        username={username}
+                        accountMenuOptions={accountMenuOptions}
+                    />}
+                    <Box className={classNames(boxStyles, styles.flexWrapper)}>
+                        <Box
+                            role="main"
+                            aria-label={intl.formatMessage(ariaMessages.editor)}
+                            className={styles.editorWrapper}
+                            element="main"
                         >
-                            <Box
-                                role="region"
-                                aria-label={intl.formatMessage(ariaMessages.tabList)}
-                            >
-                                <TabList
-                                    className={tabClassNames.tabList}
-                                    role="tablist"
-                                >
-                                    <Tab
-                                        className={tabClassNames.tab}
-                                        tabIndex="0"
-                                        role="tab"
-                                    >
-                                        <img
-                                            draggable={false}
-                                            src={codeIcon}
-                                        />
-                                        <FormattedMessage
-                                            defaultMessage="Code"
-                                            description="Button to get to the code panel"
-                                            id="gui.gui.codeTab"
-                                        />
-                                    </Tab>
-                                    <Tab
-                                        className={tabClassNames.tab}
-                                        onClick={onActivateCostumesTab}
-                                        role="tab"
-                                        tabIndex="0"
-                                    >
-                                        <img
-                                            draggable={false}
-                                            src={costumesIcon}
-                                        />
-                                        {targetIsStage ? (
-                                            <FormattedMessage
-                                                defaultMessage="Backdrops"
-                                                description="Button to get to the backdrops panel"
-                                                id="gui.gui.backdropsTab"
-                                            />
-                                        ) : (
-                                            <FormattedMessage
-                                                defaultMessage="Costumes"
-                                                description="Button to get to the costumes panel"
-                                                id="gui.gui.costumesTab"
-                                            />
-                                        )}
-                                    </Tab>
-                                    <Tab
-                                        className={tabClassNames.tab}
-                                        onClick={onActivateSoundsTab}
-                                        role="tab"
-                                        tabIndex="0"
-                                    >
-                                        <img
-                                            draggable={false}
-                                            src={soundsIcon}
-                                        />
-                                        <FormattedMessage
-                                            defaultMessage="Sounds"
-                                            description="Button to get to the sounds panel"
-                                            id="gui.gui.soundsTab"
-                                        />
-                                    </Tab>
-                                </TabList>
-                            </Box>
-                            <TabPanel
-                                className={tabClassNames.tabPanel}
-                                role="tabpanel"
+                            <Tabs
+                                forceRenderTabPanel
+                                className={tabClassNames.tabs}
+                                selectedIndex={activeTabIndex}
+                                selectedTabClassName={tabClassNames.tabSelected}
+                                selectedTabPanelClassName={tabClassNames.tabPanelSelected}
+                                onSelect={onActivateTab}
+
+                                // TODO: focusTabOnClick should be true for accessibility, but currently conflicts
+                                // with nudge operations in the paint editor. We'll likely need to manage focus
+                                // differently within the paint editor before we can turn this back on.
+                                // Repro steps:
+                                // 1. Click the Costumes tab
+                                // 2. Select something in the paint editor (say, the cat's face)
+                                // 3. Press the left or right arrow key
+                                // Desired behavior: the face should nudge left or right
+                                // Actual behavior: the Code or Sounds tab is now focused
+                                focusTabOnClick={false}
                             >
                                 <Box
-                                    className={styles.blocksWrapper}
                                     role="region"
-                                    aria-label={intl.formatMessage(ariaMessages.codePanel)}
-                                    element="section"
+                                    aria-label={intl.formatMessage(ariaMessages.tabList)}
                                 >
-                                    <Blocks
-                                        key={`${blocksId}/${colorMode}/${theme}`}
-                                        canUseCloud={canUseCloud}
-                                        grow={1}
-                                        isVisible={blocksTabVisible}
-                                        options={{
-                                            media: `${basePath}static/${colorModeMap[colorMode].blocksMediaFolder}/`
-                                        }}
-                                        stageSize={stageSize}
-                                        theme={theme}
-                                        vm={vm}
-                                        colorMode={colorMode}
+                                    <TabList
+                                        className={tabClassNames.tabList}
+                                        role="tablist"
+                                    >
+                                        <Tab
+                                            className={tabClassNames.tab}
+                                            tabIndex="0"
+                                            role="tab"
+                                        >
+                                            <img
+                                                draggable={false}
+                                                src={codeIcon}
+                                            />
+                                            <FormattedMessage
+                                                defaultMessage="Code"
+                                                description="Button to get to the code panel"
+                                                id="gui.gui.codeTab"
+                                            />
+                                        </Tab>
+                                        <Tab
+                                            className={tabClassNames.tab}
+                                            onClick={onActivateCostumesTab}
+                                            role="tab"
+                                            tabIndex="0"
+                                        >
+                                            <img
+                                                draggable={false}
+                                                src={costumesIcon}
+                                            />
+                                            {targetIsStage ? (
+                                                <FormattedMessage
+                                                    defaultMessage="Backdrops"
+                                                    description="Button to get to the backdrops panel"
+                                                    id="gui.gui.backdropsTab"
+                                                />
+                                            ) : (
+                                                <FormattedMessage
+                                                    defaultMessage="Costumes"
+                                                    description="Button to get to the costumes panel"
+                                                    id="gui.gui.costumesTab"
+                                                />
+                                            )}
+                                        </Tab>
+                                        <Tab
+                                            className={tabClassNames.tab}
+                                            onClick={onActivateSoundsTab}
+                                            role="tab"
+                                            tabIndex="0"
+                                        >
+                                            <img
+                                                draggable={false}
+                                                src={soundsIcon}
+                                            />
+                                            <FormattedMessage
+                                                defaultMessage="Sounds"
+                                                description="Button to get to the sounds panel"
+                                                id="gui.gui.soundsTab"
+                                            />
+                                        </Tab>
+                                    </TabList>
+                                </Box>
+                                <TabPanel
+                                    className={tabClassNames.tabPanel}
+                                    role="tabpanel"
+                                >
+                                    <Box
+                                        className={styles.blocksWrapper}
+                                        role="region"
+                                        aria-label={intl.formatMessage(ariaMessages.codePanel)}
+                                        element="section"
+                                    >
+                                        <Blocks
+                                            key={`${blocksId}/${colorMode}/${theme}`}
+                                            canUseCloud={canUseCloud}
+                                            grow={1}
+                                            isVisible={blocksTabVisible}
+                                            options={{
+                                                media: `${basePath}static/${colorModeMap[colorMode].blocksMediaFolder}/`
+                                            }}
+                                            stageSize={stageSize}
+                                            theme={theme}
+                                            vm={vm}
+                                            colorMode={colorMode}
+                                            showNewFeatureCallouts={showNewFeatureCallouts}
+                                            username={username}
+                                        />
+                                    </Box>
+                                    <ExtensionsButton
+                                        activeTabIndex={activeTabIndex}
+                                        intl={intl}
                                         showNewFeatureCallouts={showNewFeatureCallouts}
+                                        onExtensionButtonClick={onExtensionButtonClick}
                                         username={username}
                                     />
-                                </Box>
-                                <ExtensionsButton
-                                    activeTabIndex={activeTabIndex}
-                                    intl={intl}
-                                    showNewFeatureCallouts={showNewFeatureCallouts}
-                                    onExtensionButtonClick={onExtensionButtonClick}
-                                    username={username}
-                                />
-                                <Box className={styles.watermark}>
-                                    <Watermark />
-                                </Box>
-                            </TabPanel>
-                            <TabPanel
-                                className={tabClassNames.tabPanel}
-                                role="tabpanel"
-                            >
-                                {costumesTabVisible ? <CostumeTab
-                                    ariaLabel={targetIsStage ? intl.formatMessage(ariaMessages.backdropsPanel) :
-                                        intl.formatMessage(ariaMessages.costumesPanel)}
-                                    ariaRole="region"
-                                    vm={vm}
-                                    onNewLibraryBackdropClick={onNewLibraryBackdropClick}
-                                    onNewLibraryCostumeClick={onNewLibraryCostumeClick}
-                                /> : null}
-                            </TabPanel>
-                            <TabPanel
-                                className={tabClassNames.tabPanel}
-                                role="tabpanel"
-                            >
-                                {soundsTabVisible ?
-                                    <SoundTab
-                                        ariaLabel={intl.formatMessage(ariaMessages.soundsPanel)}
+                                    <Box className={styles.watermark}>
+                                        <Watermark />
+                                    </Box>
+                                </TabPanel>
+                                <TabPanel
+                                    className={tabClassNames.tabPanel}
+                                    role="tabpanel"
+                                >
+                                    {costumesTabVisible ? <CostumeTab
+                                        ariaLabel={targetIsStage ? intl.formatMessage(ariaMessages.backdropsPanel) :
+                                            intl.formatMessage(ariaMessages.costumesPanel)}
                                         ariaRole="region"
                                         vm={vm}
+                                        onNewLibraryBackdropClick={onNewLibraryBackdropClick}
+                                        onNewLibraryCostumeClick={onNewLibraryCostumeClick}
                                     /> : null}
-                            </TabPanel>
-                        </Tabs>
-                        {backpackVisible ? (
-                            <Backpack
-                                host={backpackHost}
-                                ariaRole="region"
-                                ariaLabel={intl.formatMessage(ariaMessages.backpack)}
-                            />
-                        ) : null}
-                    </Box>
+                                </TabPanel>
+                                <TabPanel
+                                    className={tabClassNames.tabPanel}
+                                    role="tabpanel"
+                                >
+                                    {soundsTabVisible ?
+                                        <SoundTab
+                                            ariaLabel={intl.formatMessage(ariaMessages.soundsPanel)}
+                                            ariaRole="region"
+                                            vm={vm}
+                                        /> : null}
+                                </TabPanel>
+                            </Tabs>
+                            {backpackVisible ? (
+                                <Backpack
+                                    host={backpackHost}
+                                    ariaRole="region"
+                                    ariaLabel={intl.formatMessage(ariaMessages.backpack)}
+                                />
+                            ) : null}
+                        </Box>
 
-                    <Box
-                        role="complementary"
-                        aria-label={intl.formatMessage(ariaMessages.stageAndTarget)}
-                        className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}
-                        element="aside"
-                    >
-                        <StageWrapper
-                            isFullScreen={isFullScreen}
-                            isRendererSupported={isRendererSupported}
-                            isRtl={isRtl}
-                            stageSize={stageSize}
-                            vm={vm}
-                            ariaRole="region"
-                            ariaLabel={intl.formatMessage(ariaMessages.stage)}
-                        />
                         <Box
-                            className={styles.targetWrapper}
-                            role="region"
-                            aria-label={intl.formatMessage(ariaMessages.targetPane)}
-                            element="section"
+                            role="complementary"
+                            aria-label={intl.formatMessage(ariaMessages.stageAndTarget)}
+                            className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}
+                            element="aside"
                         >
-                            <TargetPane
+                            <StageWrapper
+                                isFullScreen={isFullScreen}
+                                isRendererSupported={isRendererSupported}
+                                isRtl={isRtl}
                                 stageSize={stageSize}
                                 vm={vm}
-                                onNewSpriteClick={onNewSpriteClick}
-                                onNewBackdropClick={onNewLibraryBackdropClick}
+                                ariaRole="region"
+                                ariaLabel={intl.formatMessage(ariaMessages.stage)}
                             />
+                            <Box
+                                className={styles.targetWrapper}
+                                role="region"
+                                aria-label={intl.formatMessage(ariaMessages.targetPane)}
+                                element="section"
+                            >
+                                <TargetPane
+                                    stageSize={stageSize}
+                                    vm={vm}
+                                    onNewSpriteClick={onNewSpriteClick}
+                                    onNewBackdropClick={onNewLibraryBackdropClick}
+                                />
+                            </Box>
                         </Box>
                     </Box>
+                    <DragLayer />
                 </Box>
-                <DragLayer />
-            </Box>
+            </ModalFocusProvider>
         );
     }}</MediaQuery>);
 };

--- a/packages/scratch-gui/src/components/library-item/library-item.jsx
+++ b/packages/scratch-gui/src/components/library-item/library-item.jsx
@@ -46,7 +46,7 @@ class LibraryItemComponent extends React.PureComponent {
     }
     render () {
         return this.props.featured ? (
-            <div
+            <button
                 id={this.props.extensionId}
                 className={classNames(
                     styles.libraryItem,
@@ -58,8 +58,6 @@ class LibraryItemComponent extends React.PureComponent {
                     this.props.hidden ? styles.hidden : null,
                     this.props.showItemCallout ? styles.radiate : null
                 )}
-                role="button"
-                tabIndex={0}
                 onClick={this.props.onClick}
                 onKeyDown={this.props.onKeyDown}
                 // onFocus and onBlur are currently unused for extensions,
@@ -146,7 +144,7 @@ class LibraryItemComponent extends React.PureComponent {
                             </div>
                         ) : null}
                 </div>
-            </div>
+            </button>
         ) : (
             <Box
                 className={classNames(
@@ -154,8 +152,7 @@ class LibraryItemComponent extends React.PureComponent {
                         [styles.hidden]: this.props.hidden
                     }
                 )}
-                role="button"
-                tabIndex="0"
+                element="button"
                 onBlur={this.props.onBlur}
                 onClick={this.props.onClick}
                 onFocus={this.props.onFocus}

--- a/packages/scratch-gui/src/components/library-item/library-item.jsx
+++ b/packages/scratch-gui/src/components/library-item/library-item.jsx
@@ -58,7 +58,14 @@ class LibraryItemComponent extends React.PureComponent {
                     this.props.hidden ? styles.hidden : null,
                     this.props.showItemCallout ? styles.radiate : null
                 )}
+                role="button"
+                tabIndex={0}
                 onClick={this.props.onClick}
+                onKeyDown={this.props.onKeyDown}
+                // onFocus and onBlur are currently unused for extensions,
+                // but are included for potential future use
+                onBlur={this.props.onBlur}
+                onFocus={this.props.onFocus}
             >
                 <div className={styles.contentWrapper}>
                     <div className={styles.featuredImageContainer}>
@@ -152,7 +159,7 @@ class LibraryItemComponent extends React.PureComponent {
                 onBlur={this.props.onBlur}
                 onClick={this.props.onClick}
                 onFocus={this.props.onFocus}
-                onKeyPress={this.props.onKeyPress}
+                onKeyDown={this.props.onKeyDown}
                 onMouseEnter={this.props.showPlayButton ? null : this.props.onMouseEnter}
                 onMouseLeave={this.props.showPlayButton ? null : this.props.onMouseLeave}
             >
@@ -202,7 +209,7 @@ LibraryItemComponent.propTypes = {
     onBlur: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
     onFocus: PropTypes.func.isRequired,
-    onKeyPress: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func.isRequired,
     onMouseEnter: PropTypes.func.isRequired,
     onMouseLeave: PropTypes.func.isRequired,
     onPlay: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -178,9 +178,14 @@ class LibraryComponent extends React.Component {
 
         // We need to create the driver when the content is loaded for the target element to exist
         if (!prevState.loaded && this.state.loaded && this.state.shouldShowFaceSensingCallout) {
-            const onFirstClick = () => {
+            const onFirstInteraction = e => {
                 const isExtensionItemVisible = document.getElementById('faceSensing');
                 if (!isExtensionItemVisible) return;
+
+                if (e.type === 'keydown') {
+                    // Prevent focus from jumping to the next element in the tab order after keydown finishes
+                    e.preventDefault();
+                }
 
                 const tooltip = driver({
                     allowClose: false,
@@ -188,7 +193,7 @@ class LibraryComponent extends React.Component {
                     overlayColor: 'transparent',
                     popoverOffset: -2,
                     steps: [{
-                        element: 'div[id="faceSensing"]',
+                        element: 'button[id="faceSensing"]',
                         popover: {
                             description: this.props.intl.formatMessage(messages.faceSensingModalCallout),
                             side: 'left',
@@ -201,9 +206,15 @@ class LibraryComponent extends React.Component {
 
                 this.driver = tooltip;
                 tooltip.drive();
+                
+                // Make sure to clean up event listeners after first interaction
+                window.removeEventListener('click', onFirstInteraction);
+                window.removeEventListener('keydown', onFirstInteraction);
             };
 
-            window.addEventListener('click', onFirstClick, {once: true});
+            window.addEventListener('click', onFirstInteraction, {once: true});
+            window.addEventListener('keydown', onFirstInteraction, {once: true});
+            
             this.filteredDataRef.addEventListener('scroll', this.handleScroll);
         }
     }
@@ -407,10 +418,6 @@ class LibraryComponent extends React.Component {
                 </div>));
     }
     render () {
-        // TODO: Should the close button be focused first or last when the modal opens?
-        // Focusing it first helps users quickly close the modal if opened by mistake.
-        // It's also at the top left, being the first element that will be read by screen readers.
-        // However, users can always close the modal with ESC as well.
         return (
             <Modal
                 fullScreen

--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -179,6 +179,10 @@ class LibraryComponent extends React.Component {
         // We need to create the driver when the content is loaded for the target element to exist
         if (!prevState.loaded && this.state.loaded && this.state.shouldShowFaceSensingCallout) {
             const onFirstInteraction = e => {
+                // Make sure to clean up event listeners after first interaction
+                window.removeEventListener('click', onFirstInteraction);
+                window.removeEventListener('keydown', onFirstInteraction);
+
                 const isExtensionItemVisible = document.getElementById('faceSensing');
                 if (!isExtensionItemVisible) return;
 
@@ -206,10 +210,6 @@ class LibraryComponent extends React.Component {
 
                 this.driver = tooltip;
                 tooltip.drive();
-                
-                // Make sure to clean up event listeners after first interaction
-                window.removeEventListener('click', onFirstInteraction);
-                window.removeEventListener('keydown', onFirstInteraction);
             };
 
             window.addEventListener('click', onFirstInteraction, {once: true});

--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -19,6 +19,7 @@ import {CATEGORIES} from '../../../src/lib/libraries/decks/index.jsx';
 import {getLocalStorageValue, setLocalStorageValue} from '../../lib/local-storage.js';
 
 import styles from './library.css';
+import {ModalFocusContext} from '../../contexts/modal-focus-context.jsx';
 
 const localStorageAvailable =
     'localStorage' in window && window.localStorage !== null;
@@ -218,6 +219,9 @@ class LibraryComponent extends React.Component {
 
         this.filteredDataRef.removeEventListener('scroll', this.handleScroll);
     }
+
+    static contextType = ModalFocusContext;
+
     handleScroll () {
         if (this.animationFrameId) return;
 
@@ -248,6 +252,7 @@ class LibraryComponent extends React.Component {
     }
     handleClose () {
         this.props.onRequestClose();
+        this.context.restoreFocus();
     }
     handleTagClick (tag) {
         if (this.state.playingItem === null) {
@@ -402,6 +407,10 @@ class LibraryComponent extends React.Component {
                 </div>));
     }
     render () {
+        // TODO: Should the close button be focused first or last when the modal opens?
+        // Focusing it first helps users quickly close the modal if opened by mistake.
+        // It's also at the top left, being the first element that will be read by screen readers.
+        // However, users can always close the modal with ESC as well.
         return (
             <Modal
                 fullScreen

--- a/packages/scratch-gui/src/components/tag-button/tag-button.css
+++ b/packages/scratch-gui/src/components/tag-button/tag-button.css
@@ -17,3 +17,12 @@
 .active {
     background: $data-primary;
 }
+
+.tag-button:focus-visible {
+    /*
+    The outline appears cropped when a tag button is focused because the tag list uses overflow: hidden
+    in order to hide excess items when overflowing. This offset is a workaround to keep the outline visible
+    without restructuring the tag list.
+    */
+    outline-offset: -2px;
+}

--- a/packages/scratch-gui/src/containers/costume-tab.jsx
+++ b/packages/scratch-gui/src/containers/costume-tab.jsx
@@ -37,6 +37,7 @@ import searchIcon from '../components/action-menu/icon--search.svg';
 
 import costumeLibraryContent from '../lib/libraries/costumes.json';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
+import {ModalFocusContext} from '../contexts/modal-focus-context.jsx';
 
 let messages = defineMessages({
     addLibraryBackdropMsg: {
@@ -132,6 +133,8 @@ class CostumeTab extends React.Component {
             this.setState({selectedCostumeIndex: target.currentCostume});
         }
     }
+    static contextType = ModalFocusContext;
+
     handleSelectCostume (costumeIndex) {
         this.props.vm.editingTarget.setCostume(costumeIndex);
         this.setState({selectedCostumeIndex: costumeIndex});
@@ -166,6 +169,7 @@ class CostumeTab extends React.Component {
     }
     handleNewBackdropClick (e) {
         e.preventDefault();
+        this.context.captureFocus();
         this.props.onNewLibraryBackdropClick(jsonStr => {
             const costume = JSON.parse(jsonStr);
             this.handleNewCostume(costume, true);
@@ -173,6 +177,7 @@ class CostumeTab extends React.Component {
     }
     handleNewCostumeClick (e) {
         e.preventDefault();
+        this.context.captureFocus();
         this.props.onNewLibraryCostumeClick(jsonStr => {
             const costume = JSON.parse(jsonStr);
             this.handleNewCostume(costume, true);

--- a/packages/scratch-gui/src/containers/library-item.jsx
+++ b/packages/scratch-gui/src/containers/library-item.jsx
@@ -7,6 +7,7 @@ import {injectIntl} from 'react-intl';
 
 import LibraryItemComponent from '../components/library-item/library-item.jsx';
 import {PLATFORM} from '../lib/platform.js';
+import {KEY} from '../lib/navigation-keys.js';
 
 
 class LibraryItem extends React.PureComponent {
@@ -16,7 +17,7 @@ class LibraryItem extends React.PureComponent {
             'handleBlur',
             'handleClick',
             'handleFocus',
-            'handleKeyPress',
+            'handleKeyDown',
             'handleMouseEnter',
             'handleMouseLeave',
             'handlePlay',
@@ -48,10 +49,34 @@ class LibraryItem extends React.PureComponent {
             this.handleMouseEnter(id);
         }
     }
-    handleKeyPress (e) {
-        if (e.key === ' ' || e.key === 'Enter') {
+    handleKeyDown (e) {
+        if (this.props.disabled) {
+            return;
+        }
+
+        if (e.key === KEY.ENTER) {
             e.preventDefault();
             this.props.onSelect(this.props.id);
+        }
+        /*
+        Previously, pressing SPACE would select a Costume, Sprite, Sound, or Backdrop, but there was a bug:
+        - If the modal was opened from the Sounds page, SPACE played the sound selected in the sound editor
+        - SPACE never worked for Sounds, and only worked for Sprites/Backdrops when not opened from the Sound Editor.
+
+        This implementation fixes that:
+        - Costumes, Sprites, and Backdrops are selectable with both ENTER and SPACE.
+        - Sounds are selectable with ENTER; SPACE previews the sound.
+        TODO: Confirm if this behavior is correct and intuitive.
+        */
+        if (e.key === KEY.SPACE) {
+            e.preventDefault();
+            e.stopPropagation();
+            
+            if (this.props.showPlayButton) {
+                this.handlePlay();
+            } else {
+                this.props.onSelect(this.props.id);
+            }
         }
     }
     handleMouseEnter () {
@@ -130,7 +155,7 @@ class LibraryItem extends React.PureComponent {
                 onBlur={this.handleBlur}
                 onClick={this.handleClick}
                 onFocus={this.handleFocus}
-                onKeyPress={this.handleKeyPress}
+                onKeyDown={this.handleKeyDown}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
                 onPlay={this.handlePlay}

--- a/packages/scratch-gui/src/containers/library-item.jsx
+++ b/packages/scratch-gui/src/containers/library-item.jsx
@@ -71,7 +71,7 @@ class LibraryItem extends React.PureComponent {
         if (e.key === KEY.SPACE) {
             e.preventDefault();
             e.stopPropagation();
-            
+
             if (this.props.showPlayButton) {
                 this.handlePlay();
             } else {

--- a/packages/scratch-gui/src/containers/library-item.jsx
+++ b/packages/scratch-gui/src/containers/library-item.jsx
@@ -59,14 +59,8 @@ class LibraryItem extends React.PureComponent {
             this.props.onSelect(this.props.id);
         }
         /*
-        Previously, pressing SPACE would select a Costume, Sprite, Sound, or Backdrop, but there was a bug:
-        - If the modal was opened from the Sounds page, SPACE played the sound selected in the sound editor
-        - SPACE never worked for Sounds, and only worked for Sprites/Backdrops when not opened from the Sound Editor.
-
-        This implementation fixes that:
-        - Costumes, Sprites, and Backdrops are selectable with both ENTER and SPACE.
-        - Sounds are selectable with ENTER; SPACE previews the sound.
-        TODO: Confirm if this behavior is correct and intuitive.
+            - Costumes, Sprites, and Backdrops are selectable with both ENTER and SPACE.
+            - Sounds are selectable with ENTER; SPACE previews the sound.
         */
         if (e.key === KEY.SPACE) {
             e.preventDefault();

--- a/packages/scratch-gui/src/containers/sound-tab.jsx
+++ b/packages/scratch-gui/src/containers/sound-tab.jsx
@@ -39,6 +39,7 @@ import {
 
 import {setRestore} from '../reducers/restore-deletion';
 import {showStandardAlert, closeAlertWithId} from '../reducers/alerts';
+import {ModalFocusContext} from '../contexts/modal-focus-context.jsx';
 
 class SoundTab extends React.Component {
     constructor (props) {
@@ -52,6 +53,7 @@ class SoundTab extends React.Component {
             'handleSurpriseSound',
             'handleFileUploadClick',
             'handleSoundUpload',
+            'handleNewSoundFromLibraryClick',
             'handleDrop',
             'setFileInput'
         ]);
@@ -77,6 +79,9 @@ class SoundTab extends React.Component {
             this.setState({selectedSoundIndex: Math.max(target.sounds.length - 1, 0)});
         }
     }
+
+    static contextType = ModalFocusContext;
+    
 
     handleSelectSound (soundIndex) {
         this.setState({selectedSoundIndex: soundIndex});
@@ -127,6 +132,11 @@ class SoundTab extends React.Component {
 
     handleFileUploadClick () {
         this.fileInput.click();
+    }
+
+    handleNewSoundFromLibraryClick (e) {
+        this.context.captureFocus();
+        this.props.onNewSoundFromLibraryClick(e);
     }
 
     handleSoundUpload (e) {
@@ -229,7 +239,7 @@ class SoundTab extends React.Component {
                 buttons={[{
                     title: intl.formatMessage(messages.addSound),
                     img: addSoundFromLibraryIcon,
-                    onClick: onNewSoundFromLibraryClick
+                    onClick: this.handleNewSoundFromLibraryClick
                 }, {
                     title: intl.formatMessage(messages.fileUploadSound),
                     img: fileUploadIcon,
@@ -249,7 +259,7 @@ class SoundTab extends React.Component {
                 }, {
                     title: intl.formatMessage(messages.addSound),
                     img: searchIcon,
-                    onClick: onNewSoundFromLibraryClick
+                    onClick: this.handleNewSoundFromLibraryClick
                 }]}
                 dragType={DragConstants.SOUND}
                 isRtl={isRtl}

--- a/packages/scratch-gui/src/containers/sound-tab.jsx
+++ b/packages/scratch-gui/src/containers/sound-tab.jsx
@@ -81,7 +81,6 @@ class SoundTab extends React.Component {
     }
 
     static contextType = ModalFocusContext;
-    
 
     handleSelectSound (soundIndex) {
         this.setState({selectedSoundIndex: soundIndex});

--- a/packages/scratch-gui/src/containers/stage-selector.jsx
+++ b/packages/scratch-gui/src/containers/stage-selector.jsx
@@ -23,6 +23,7 @@ import StageSelectorComponent from '../components/stage-selector/stage-selector.
 
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 import {handleFileUpload, costumeUpload} from '../lib/file-uploader.js';
+import {ModalFocusContext} from '../contexts/modal-focus-context.jsx';
 
 const dragTypes = [
     DragConstants.COSTUME,
@@ -62,6 +63,9 @@ class StageSelector extends React.Component {
     componentWillUnmount () {
         document.removeEventListener('touchend', this.handleTouchEnd);
     }
+    
+    static contextType = ModalFocusContext;
+    
     handleTouchEnd (e) {
         const {x, y} = getEventXY(e);
         const {top, left, bottom, right} = this.ref.getBoundingClientRect();
@@ -85,6 +89,7 @@ class StageSelector extends React.Component {
     }
     handleNewBackdropClick (e) {
         e.stopPropagation();
+        this.context.captureFocus();
         this.props.onNewBackdropClick(jsonStr => {
             this.handleNewBackdrop(JSON.parse(jsonStr), false);
         });

--- a/packages/scratch-gui/src/containers/stage-selector.jsx
+++ b/packages/scratch-gui/src/containers/stage-selector.jsx
@@ -63,9 +63,9 @@ class StageSelector extends React.Component {
     componentWillUnmount () {
         document.removeEventListener('touchend', this.handleTouchEnd);
     }
-    
+
     static contextType = ModalFocusContext;
-    
+
     handleTouchEnd (e) {
         const {x, y} = getEventXY(e);
         const {top, left, bottom, right} = this.ref.getBoundingClientRect();

--- a/packages/scratch-gui/src/containers/target-pane.jsx
+++ b/packages/scratch-gui/src/containers/target-pane.jsx
@@ -24,6 +24,7 @@ import {highlightTarget} from '../reducers/targets';
 import {fetchSprite, fetchCode} from '../lib/backpack-api';
 import randomizeSpritePosition from '../lib/randomize-sprite-position';
 import downloadBlob from '../lib/download-blob';
+import {ModalFocusContext} from '../contexts/modal-focus-context.jsx';
 
 class TargetPane extends React.Component {
     constructor (props) {
@@ -58,6 +59,9 @@ class TargetPane extends React.Component {
     componentWillUnmount () {
         this.props.vm.removeListener('BLOCK_DRAG_END', this.handleBlockDragEnd);
     }
+
+    static contextType = ModalFocusContext;
+     
     handleChangeSpriteDirection (direction) {
         this.props.vm.postSpriteInfo({direction});
     }
@@ -134,6 +138,7 @@ class TargetPane extends React.Component {
     }
     handleNewSpriteClick (e) {
         e.preventDefault();
+        this.context.captureFocus();
         this.props.onNewSpriteClick(this.handleNewSprite);
     }
     handleNewSprite (spriteJSONString) {

--- a/packages/scratch-gui/src/containers/target-pane.jsx
+++ b/packages/scratch-gui/src/containers/target-pane.jsx
@@ -61,7 +61,7 @@ class TargetPane extends React.Component {
     }
 
     static contextType = ModalFocusContext;
-     
+
     handleChangeSpriteDirection (direction) {
         this.props.vm.postSpriteInfo({direction});
     }

--- a/packages/scratch-gui/src/contexts/modal-focus-context.jsx
+++ b/packages/scratch-gui/src/contexts/modal-focus-context.jsx
@@ -1,0 +1,50 @@
+import React, {createContext, useRef, useMemo, useCallback} from 'react';
+import PropTypes from 'prop-types';
+
+export const ModalFocusContext = createContext(null);
+
+/**
+ * A context provider that manages focus restoration strategies for modals.
+ *
+ * It keeps track of the element that was focused prior to a modal opening (`captureFocus`)
+ * and attempts to restore focus to that element when the modal closes (`restoreFocus`).
+ *
+ * This uses a ref to store the DOM element, ensuring that focus restoration only occurs
+ * if the original element is still connected to the DOM.
+ * @param {object} props - The component props.
+ * @param {React.ReactNode} props.children - The child components that will have access to the context.
+ * @returns {React.ReactElement} The Context Provider wrapping the children.
+ */
+export const ModalFocusProvider = ({children}) => {
+    const lastFocusedElement = useRef(null);
+
+    const captureFocus = useCallback(() => {
+        lastFocusedElement.current = document.activeElement;
+    }, []);
+
+    const restoreFocus = useCallback(() => {
+        if (lastFocusedElement.current?.isConnected) {
+            lastFocusedElement.current.focus();
+            lastFocusedElement.current = null;
+        }
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            captureFocus,
+            restoreFocus
+        }),
+        [captureFocus, restoreFocus]
+    );
+
+    return (
+        <ModalFocusContext.Provider value={value}>
+            {children}
+        </ModalFocusContext.Provider>
+    );
+};
+
+
+ModalFocusProvider.propTypes = {
+    children: PropTypes.node
+};

--- a/packages/scratch-gui/src/lib/audio/shared-audio-context.js
+++ b/packages/scratch-gui/src/lib/audio/shared-audio-context.js
@@ -10,6 +10,7 @@ if (!bowser.msie) {
     const initAudioContext = () => {
         document.removeEventListener('mousedown', initAudioContext);
         document.removeEventListener('touchstart', initAudioContext);
+        document.removeEventListener('keydown', initAudioContext);
         if (AUDIO_CONTEXT) return;
 
         AUDIO_CONTEXT = new (window.AudioContext ||
@@ -18,6 +19,7 @@ if (!bowser.msie) {
     };
     document.addEventListener('mousedown', initAudioContext);
     document.addEventListener('touchstart', initAudioContext);
+    document.addEventListener('keydown', initAudioContext);
 }
 
 /**

--- a/packages/scratch-gui/src/lib/navigation-keys.js
+++ b/packages/scratch-gui/src/lib/navigation-keys.js
@@ -1,0 +1,10 @@
+export const KEY = {
+    ARROW_UP: 'ArrowUp',
+    ARROW_DOWN: 'ArrowDown',
+    ARROW_LEFT: 'ArrowLeft',
+    ARROW_RIGHT: 'ArrowRight',
+    ESCAPE: 'Escape',
+    TAB: 'Tab',
+    SPACE: ' ',
+    ENTER: 'Enter'
+};


### PR DESCRIPTION
### Resolves

[UEPR-471](https://scratchfoundation.atlassian.net/browse/UEPR-471)

### Proposed Changes

- Make all elements in the library modal navigable through `Tab` navigation
- Allow keyboard actions with the LibraryItems
- Add ModalFocusContext for restoring the focus to the last focused element when navigating out of the modal

TODOs:
- Feature callouts interfere with keyboard navigation in the Extensions Modal
- Tips Library is currently not navigable until #403 is merged, so restoring focus there would need to be handled separately

### Reason for Changes

- This PR is part of a larger initiative to make the Scratch Editor more accessible and navigable through keyboard.

[UEPR-471]: https://scratchfoundation.atlassian.net/browse/UEPR-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ