### PR TITLE
[UEPR-465] Do not allow changing variables outside of the editor

### DIFF
--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -59,7 +59,10 @@ const MonitorComponent = props => (
                         props.onNextMode
                 }
             >
-                <ContextMenu.Trigger className="ContextMenuTrigger">
+                <ContextMenu.Trigger
+                    className="ContextMenuTrigger"
+                    disabled={!props.draggable}
+                >
                     {React.createElement(modes[props.mode], {
                         categoryColor: getCategoryColor(
                             props.colorMode,

--- a/packages/scratch-gui/test/unit/components/__snapshots__/monitor-list.test.jsx.snap
+++ b/packages/scratch-gui/test/unit/components/__snapshots__/monitor-list.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`MonitorListComponent it renders the correct step size for discrete slid
     >
       <span
         class="ContextMenuTrigger"
+        data-disabled=""
         data-state="closed"
       >
         <div>
@@ -54,6 +55,7 @@ exports[`MonitorListComponent it renders the correct step size for non-discrete 
     >
       <span
         class="ContextMenuTrigger"
+        data-disabled=""
         data-state="closed"
       >
         <div>

--- a/packages/scratch-gui/test/unit/components/__snapshots__/monitor.test.jsx.snap
+++ b/packages/scratch-gui/test/unit/components/__snapshots__/monitor.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`Monitor Component it selects the correct colors based on dark mode 1`] 
 >
   <span
     class="ContextMenuTrigger"
+    data-disabled=""
     data-state="closed"
   >
     <div>
@@ -30,6 +31,7 @@ exports[`Monitor Component it selects the correct colors based on default color 
 >
   <span
     class="ContextMenuTrigger"
+    data-disabled=""
     data-state="closed"
   >
     <div>


### PR DESCRIPTION
### Resolves

[UEPR-465](https://scratchfoundation.atlassian.net/browse/UEPR-465)

### Proposed Changes

- Disable the context menu trigger outside of the editor

### Reason for Changes

- Variables can be changed to sliders outside of the editor



[UEPR-465]: https://scratchfoundation.atlassian.net/browse/UEPR-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ