### PR TITLE
fix: support hoisted externals in svg-renderer build

### DIFF
--- a/packages/scratch-svg-renderer/webpack.config.js
+++ b/packages/scratch-svg-renderer/webpack.config.js
@@ -1,6 +1,30 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const ScratchWebpackConfigBuilder = require('scratch-webpack-configuration');
+const fs = require('fs');
+const nodeExternals = require('webpack-node-externals');
+
+// Helper to find monorepo root dynamically
+const findMonorepoRoot = () => {
+    let currentDir = __dirname;
+    while (currentDir !== path.parse(currentDir).root) {
+        if (fs.existsSync(path.join(currentDir, 'package.json'))) {
+            try {
+                const pkg = require(path.join(currentDir, 'package.json'));
+                if (pkg.workspaces) {
+                    return currentDir;
+                }
+            } catch (e) {
+                // ignore
+            }
+        }
+        currentDir = path.dirname(currentDir);
+    }
+    // Fallback to standard location if detection fails
+    return path.resolve(__dirname, '../..');
+};
+
+const MONOREPO_ROOT = findMonorepoRoot();
 
 const common = {
     libraryName: 'scratch-svg-renderer',
@@ -13,6 +37,13 @@ const common = {
 const nodeConfig = new ScratchWebpackConfigBuilder(common)
     .setTarget('node')
     .merge({
+        externals: [
+            // Without this, a hoisted `isomorphic-dompurify` can fail to find its CSS.
+            // TODO: consider moving this into `scratch-webpack-configuration`
+            nodeExternals({
+                modulesDir: path.resolve(MONOREPO_ROOT, 'node_modules')
+            })
+        ],
         output: {
             library: {
                 name: 'ScratchSVGRenderer',


### PR DESCRIPTION
### Proposed Changes

Teach `scratch-svg-renderer`'s `webpack.config.js` about externals that have been hoisted to the monorepo root `node_modules` directory.

If this turns out to be robust, we should probably move it into `scratch-webpack-configuration`... either that, or abandon webpack altogether. 🫣

### Reason for Changes

Without this, the Node-targeting build for `scratch-svg-renderer` can fail to find `isomorphic-dompurify`'s resource files. This shows up as a test failure in `scratch-vm` with messages like:

```
node:fs:439
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^

Error: ENOENT: no such file or directory, open 'scratch-editor/packages/scratch-svg-renderer/browser/default-stylesheet.css'
    at Object.readFileSync (node:fs:439:20)
    at Object.41438 (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:2198160)
    at __webpack_require__ (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:6261692)
    at Object.53648 (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:2669960)
    at __webpack_require__ (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:6261692)
    at Object.73429 (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:3736555)
    at __webpack_require__ (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:6261692)
    at Object.9110 (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:628418)
    at __webpack_require__ (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:6261692)
    at Object.36896 (scratch-editor/packages/scratch-svg-renderer/dist/node/scratch-svg-renderer.js:2:2084993) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'scratch-editor/packages/scratch-svg-renderer/browser/default-stylesheet.css'
}
```
