### PR TITLE
fix: use tiny-worker to fix VM tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17625,6 +17625,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -39379,6 +39389,16 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -41700,12 +41720,6 @@
       "integrity": "sha512-RevLfVjp+wwe/dBPe361IpmNpeXXW6JVmlp8dk0YIxLwAh7evn6JpEQQalVgX4PH/jA8tpLpjD/8tFNUYTf88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/web-worker": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
-      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -53314,8 +53328,7 @@
         "scratch-translate-extension-languages": "1.0.7",
         "text-encoding": "0.7.0",
         "tslog": "4.10.2",
-        "uuid": "8.3.2",
-        "web-worker": "1.5.0"
+        "uuid": "8.3.2"
       },
       "devDependencies": {
         "@babel/core": "7.28.6",
@@ -53343,6 +53356,7 @@
         "semantic-release": "19.0.5",
         "stats.js": "0.17.0",
         "tap": "21.5.0",
+        "tiny-worker": "2.3.0",
         "typedoc": "0.28.16",
         "webpack": "5.104.1",
         "webpack-cli": "4.10.0",

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -80,8 +80,7 @@
     "scratch-translate-extension-languages": "1.0.7",
     "text-encoding": "0.7.0",
     "tslog": "4.10.2",
-    "uuid": "8.3.2",
-    "web-worker": "1.5.0"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.28.6",
@@ -109,6 +108,7 @@
     "semantic-release": "19.0.5",
     "stats.js": "0.17.0",
     "tap": "21.5.0",
+    "tiny-worker": "2.3.0",
     "typedoc": "0.28.16",
     "webpack": "5.104.1",
     "webpack-cli": "4.10.0",

--- a/packages/scratch-vm/test/integration/internal-extension.js
+++ b/packages/scratch-vm/test/integration/internal-extension.js
@@ -1,5 +1,5 @@
 const test = require('tap').test;
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 
 const BlockType = require('../../src/extension-support/block-type');
 

--- a/packages/scratch-vm/test/integration/pen.js
+++ b/packages/scratch-vm/test/integration/pen.js
@@ -1,4 +1,4 @@
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 const path = require('path');
 const test = require('tap').test;
 

--- a/packages/scratch-vm/test/integration/runId.js
+++ b/packages/scratch-vm/test/integration/runId.js
@@ -1,4 +1,4 @@
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 const path = require('path');
 const test = require('tap').test;
 

--- a/packages/scratch-vm/test/integration/saythink-and-wait.js
+++ b/packages/scratch-vm/test/integration/saythink-and-wait.js
@@ -1,4 +1,4 @@
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 const path = require('path');
 const test = require('tap').test;
 const makeTestStorage = require('../fixtures/make-test-storage');

--- a/packages/scratch-vm/test/integration/sound.js
+++ b/packages/scratch-vm/test/integration/sound.js
@@ -1,4 +1,4 @@
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 const path = require('path');
 const test = require('tap').test;
 const makeTestStorage = require('../fixtures/make-test-storage');

--- a/packages/scratch-vm/test/unit/dispatch.js
+++ b/packages/scratch-vm/test/unit/dispatch.js
@@ -1,5 +1,5 @@
 const DispatchTestService = require('../fixtures/dispatch-test-service');
-const Worker = require('web-worker');
+const Worker = require('tiny-worker');
 
 const dispatch = require('../../src/dispatch/central-dispatch');
 const path = require('path');


### PR DESCRIPTION
### Proposed Changes

Switch from `web-worker` to `tiny-worker` for VM tests

### Reason for Changes

Yet another "test failures have been hidden for a while" fix: this solves a problem where a `require` in the worker JS was causing the dispatch test to fail. The `web-worker` package doesn't support `require`; the `tiny-worker` package does.
