### PR TITLE
[UEPR-501] Green flag button receives focus and prevents the project from capturing keyboard events

### DIFF
--- a/packages/scratch-gui/src/components/green-flag/green-flag.jsx
+++ b/packages/scratch-gui/src/components/green-flag/green-flag.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import greenFlagIcon from './icon--green-flag.svg';
 import styles from './green-flag.css';
@@ -13,10 +13,20 @@ const GreenFlagComponent = function (props) {
         title,
         ...componentProps
     } = props;
+
+    // Unfocus so project stage can capture keyboard events
+    const handleOnClick = useCallback(e => {
+        onClick(e);
+
+        const target = e.currentTarget;
+        if (target) target.blur();
+    }, [onClick]);
+
+
     return (
         <button
             className={styles.greenFlagButton}
-            onClick={onClick}
+            onClick={handleOnClick}
             {...componentProps}
         >
             <img

--- a/packages/scratch-gui/src/components/green-flag/green-flag.jsx
+++ b/packages/scratch-gui/src/components/green-flag/green-flag.jsx
@@ -14,14 +14,14 @@ const GreenFlagComponent = function (props) {
         ...componentProps
     } = props;
 
-    // Unfocus so project stage can capture keyboard events
+    // Unfocus so project stage can capture keyboard events for
+    // blocks that react to arrow movement for example
     const handleOnClick = useCallback(e => {
         onClick(e);
 
         const target = e.currentTarget;
         if (target) target.blur();
     }, [onClick]);
-
 
     return (
         <button


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-501

### Proposed Changes

Unfocuses green flag on click, so project stage can capture keyboard events.

### Reason for Changes

Previously it prevented project stage to capture keyboard events.
