### PR TITLE
Fix: Make static assets take precedence over dynamic ones

### DIFF
--- a/packages/scratch-gui/src/lib/merge-dynamic-assets.js
+++ b/packages/scratch-gui/src/lib/merge-dynamic-assets.js
@@ -21,7 +21,10 @@ const mapDynamicAsset = item => {
 };
 
 /**
- * Merge static and dynamic assets, using name as key, giving precedence to dynamic assets
+ * Merge static and dynamic assets, using name as key. If both a static and a dynamic
+ * asset share the same name, the static asset is kept and the dynamic asset is skipped.
+ * This intentionally gives precedence to static (bundled) assets so that dynamic assets
+ * do not override them.
  * @param {Array} staticAssets the static assets bundled with the editor
  * @param {Array} dynamicAssets an array of dynamic assets loaded at runtime
  * @returns {Object} an object containing `source` and `data` properties, where:
@@ -35,7 +38,11 @@ const mergeDynamicAssets = (staticAssets, dynamicAssets) => {
     if (effectiveDynamicAssets.length > 0) {
         const map = new Map();
         staticAssets.forEach(item => map.set(item.name, item));
-        effectiveDynamicAssets.forEach(item => map.set(item.name, mapDynamicAsset(item)));
+        effectiveDynamicAssets.forEach(item => {
+            if (!map.has(item.name)) {
+                map.set(item.name, mapDynamicAsset(item));
+            }
+        });
         data = Array.from(map.values());
         data.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
     }


### PR DESCRIPTION
### Resolves

- Part of [UEPR-402](https://scratchfoundation.atlassian.net/browse/UEPR-402)

### Proposed Changes

- Update the logic in `mergeDynamicAssets` to make sure static assets take precedence over dynamic ones

### Reason for Changes

- Some of the dynamic sprites use generic assets (e.g. the `Pop` sound). In order to prevent these sounds from appearing in the sounds library as member-only, we need to make sure the static ones take precedence during deduplication.

[UEPR-402]: https://scratchfoundation.atlassian.net/browse/UEPR-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ