### PR TITLE
[UEPR-500] Moving costumes using the arrow keys changes tabs instead

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -208,20 +208,6 @@ const GUIComponent = props => {
     }
 
     useEffect(() => {
-        const handleDocumentClick = () => {
-            // If any element is focused, blur it.
-            // Usually handled automatically but canvas clicks don't seem to blur previous focus.
-            if (document.activeElement !== document.body) {
-                document.activeElement.blur();
-            }
-        };
-        document.addEventListener('mousedown', handleDocumentClick);
-        return () => {
-            document.removeEventListener('mousedown', handleDocumentClick);
-        };
-    }, []);
-
-    useEffect(() => {
         if (props.platform) {
             // TODO: This uses the imported `setPlatform` directly,
             // but it should probably use the dispatched version from props.

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -211,7 +211,7 @@ const GUIComponent = props => {
         const handleDocumentClick = () => {
             // If any element is focused, blur it.
             // Usually handled automatically but canvas clicks don't seem to blur previous focus.
-            if (document.activeElement) {
+            if (document.activeElement !== document.body) {
                 document.activeElement.blur();
             }
         };

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -208,6 +208,20 @@ const GUIComponent = props => {
     }
 
     useEffect(() => {
+        const handleDocumentClick = () => {
+            // If any element is focused, blur it.
+            // Usually handled automatically but canvas clicks don't seem to blur previous focus.
+            if (document.activeElement) {
+                document.activeElement.blur();
+            }
+        };
+        document.addEventListener('mousedown', handleDocumentClick);
+        return () => {
+            document.removeEventListener('mousedown', handleDocumentClick);
+        };
+    }, []);
+
+    useEffect(() => {
         if (props.platform) {
             // TODO: This uses the imported `setPlatform` directly,
             // but it should probably use the dispatched version from props.

--- a/packages/scratch-gui/src/containers/costume-tab.jsx
+++ b/packages/scratch-gui/src/containers/costume-tab.jsx
@@ -105,6 +105,15 @@ class CostumeTab extends React.Component {
             this.state = {selectedCostumeIndex: 0};
         }
     }
+    componentDidMount () {
+        this.handleDocumentClick = () => {
+            if (document.activeElement !== document.body) {
+                document.activeElement.blur();
+            }
+        };
+        document.addEventListener('mousedown', this.handleDocumentClick);
+    }
+
     componentWillReceiveProps (nextProps) {
         const {
             editingTarget,
@@ -132,6 +141,10 @@ class CostumeTab extends React.Component {
             // If switching editing targets, update the costume index
             this.setState({selectedCostumeIndex: target.currentCostume});
         }
+    }
+
+    componentWillUnmount () {
+        document.removeEventListener('mousedown', this.handleDocumentClick);
     }
     static contextType = ModalFocusContext;
 


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-500

### Proposed Changes

Artificially add an event listener for any clicks on the page so that clicking on canvas will remove the focus for tab (which previously it did not).

### Reason for Changes

Part of an accessibility initiative for Scratch.