### PR TITLE
[UEPR-494] Text field not automatically focused

### DIFF
--- a/packages/scratch-gui/src/containers/costume-tab.jsx
+++ b/packages/scratch-gui/src/containers/costume-tab.jsx
@@ -113,7 +113,9 @@ class CostumeTab extends React.Component {
     }
     componentDidMount () {
         this.handleDocumentClick = () => {
-            if (document.activeElement !== document.body) {
+            // If the costume tab is focused and the user clicks outside of it, unfocus the costume tab.
+            // This is to prevent keypresses from affecting the tabs when users try to interact with the paint editor
+            if (document.activeElement instanceof HTMLLIElement && document.activeElement.role === 'tab') {
                 document.activeElement.blur();
             }
         };


### PR DESCRIPTION
### Resolves

[UEPR-494](https://scratchfoundation.atlassian.net/browse/UEPR-494)

### Proposed Changes

- Only attempt to blur if the currently focused element is actually the tab, rather than always blurring

### Reason for Changes

- The text field gains focus before our attempt to blur focus from the tabs, which results in users not being able to type right away

[UEPR-494]: https://scratchfoundation.atlassian.net/browse/UEPR-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ