### PR TITLE
power operator block `a^b`

### DIFF
--- a/packages/scratch-gui/src/lib/make-toolbox-xml.js
+++ b/packages/scratch-gui/src/lib/make-toolbox-xml.js
@@ -579,6 +579,18 @@ const operators = function (isInitialSetup, isStage, targetId, colors) {
                 </shadow>
             </value>
         </block>
+        <block type="operator_power">
+            <value name="NUM1">
+                <shadow type="math_number">
+                    <field name="NUM"/>
+                </shadow>
+            </value>
+            <value name="NUM2">
+                <shadow type="math_number">
+                    <field name="NUM"/>
+                </shadow>
+            </value>
+        </block>
         ${blockSeparator}
         <block type="operator_random">
             <value name="FROM">

--- a/packages/scratch-vm/src/blocks/scratch3_operators.js
+++ b/packages/scratch-vm/src/blocks/scratch3_operators.js
@@ -55,7 +55,7 @@ class Scratch3OperatorsBlocks {
     }
 
     power (args) {
-        return Cast.toNumber(args.NUM1) ** Cast.toNumber(args.NUM2);
+        return Math.pow(Cast.toNumber(args.NUM1), Cast.toNumber(args.NUM2));
     }
 
     lt (args) {

--- a/packages/scratch-vm/src/blocks/scratch3_operators.js
+++ b/packages/scratch-vm/src/blocks/scratch3_operators.js
@@ -20,6 +20,7 @@ class Scratch3OperatorsBlocks {
             operator_subtract: this.subtract,
             operator_multiply: this.multiply,
             operator_divide: this.divide,
+            operator_power: this.power,
             operator_lt: this.lt,
             operator_equals: this.equals,
             operator_gt: this.gt,
@@ -51,6 +52,10 @@ class Scratch3OperatorsBlocks {
 
     divide (args) {
         return Cast.toNumber(args.NUM1) / Cast.toNumber(args.NUM2);
+    }
+
+    power (args) {
+        return Cast.toNumber(args.NUM1) ** Cast.toNumber(args.NUM2);
     }
 
     lt (args) {


### PR DESCRIPTION
See also https://github.com/scratchfoundation/scratch-blocks/pull/3462

### Resolves

#426 

### Proposed Changes

Add a new block to the Operator category to raise a given number to a power of another given number.

### Reason for Changes

This is a highly requested block by many Scratchers and Scratch Team members (I have chatted with some [[1](https://scratch.mit.edu/users/algorithmar/#comments-402360195),[2](https://scratch.mit.edu/users/glowinday/#comments-402404181)], and they agree that it should exist in Scratch). There also aren't any accurate workarounds, besides ones that are crazy inefficient, making this block even more important to have.

It has been discussed in multiple topics and issues, and they always end up with tons of upvotes and supports.

The one thing I would like to discuss is whether, zero to the power of zero, should return `1` or `NaN`. Currently, it returns `1`, as that is what the native JavaScript operator returns. This might confuse younger Scratchers, but then again, I don't know if `NaN` is such a good idea either, since it acts as zero in scratch, making some math equations with the power operator return an incorrect result.

### Test Coverage

Tested locally:
<img width="705" height="326" alt="scratch-power-block-tested-locally" src="https://github.com/user-attachments/assets/d67caf4b-9050-48c5-b973-083743ad97fd" />
