### PR TITLE
[UEPR-477] Tips Library - Focus after item select

### DIFF
--- a/packages/scratch-gui/src/components/cards/cards.jsx
+++ b/packages/scratch-gui/src/components/cards/cards.jsx
@@ -357,7 +357,7 @@ const Cards = props => {
     const cardRef = useRef(null);
 
     useEffect(() => {
-    // Only focus if there’s an actual tutorial step (image/video)
+        // Only focus if there’s an actual tutorial step (image/video)
         const steps = content[activeDeckId]?.steps;
         const isTutorialStep = steps?.[step]?.video || steps?.[step]?.image;
 

--- a/packages/scratch-gui/src/components/cards/cards.jsx
+++ b/packages/scratch-gui/src/components/cards/cards.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {Fragment} from 'react';
+import React, {Fragment, useRef, useEffect} from 'react';
 import classNames from 'classnames';
 import {FormattedMessage} from 'react-intl';
 import Draggable from 'react-draggable';
@@ -354,6 +354,21 @@ const Cards = props => {
 
     if (activeDeckId === null) return;
 
+    const cardRef = useRef(null);
+
+    useEffect(() => {
+    // Only focus if there’s an actual tutorial step (image/video)
+        const steps = content[activeDeckId]?.steps;
+        const isTutorialStep = steps?.[step]?.video || steps?.[step]?.image;
+
+        if (isTutorialStep && cardRef.current) {
+            // Defer focus to next animation frame for layout stability
+            requestAnimationFrame(() => {
+                cardRef.current.focus();
+            });
+        }
+    }, [activeDeckId, step, content]);
+
     // Tutorial cards need to calculate their own dragging bounds
     // to allow for dragging the cards off the left, right and bottom
     // edges of the workspace.
@@ -385,6 +400,8 @@ const Cards = props => {
                 top: `${menuBarHeight}px`,
                 left: `${-cardHorizontalDragOffset}px`
             }}
+            ref={cardRef}
+            tabIndex={-1}
         >
             <Draggable
                 bounds="parent"

--- a/packages/scratch-gui/src/components/cards/cards.jsx
+++ b/packages/scratch-gui/src/components/cards/cards.jsx
@@ -359,7 +359,7 @@ const Cards = props => {
     useEffect(() => {
         // Only focus if there’s an actual tutorial step (image/video)
         const steps = content[activeDeckId]?.steps;
-        const isTutorialStep = steps?.[step]?.video || steps?.[step]?.image;
+        const isTutorialStep = steps?.[step]?.video;
 
         if (isTutorialStep && cardRef.current) {
             // Defer focus to next animation frame for layout stability

--- a/packages/scratch-gui/test/unit/components/__snapshots__/cards.test.jsx.snap
+++ b/packages/scratch-gui/test/unit/components/__snapshots__/cards.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Cards component showVideos=false shows the title image/name instead of video step 1`] = `
 <div
   style="width: 1824px; height: 977px; top: 48px; left: -400px;"
+  tabindex="-1"
 >
   <div
     class="react-draggable"
@@ -51,6 +52,7 @@ exports[`Cards component showVideos=false shows the title image/name instead of 
 exports[`Cards component showVideos=true shows the video step 1`] = `
 <div
   style="width: 1824px; height: 977px; top: 48px; left: -400px;"
+  tabindex="-1"
 >
   <div
     class="react-draggable"


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-477

### Proposed Changes

Made tutorials get focused after being selected. The focus return logic for the tutorials button was pretty much already there.

### Reason for Changes

Part of accessibility initiative for Scratch.