### PR TITLE
[UEPR-517] Return untranslated string when throttling limit is reached for Translate block

### DIFF
--- a/packages/scratch-vm/src/extensions/scratch3_translate/index.js
+++ b/packages/scratch-vm/src/extensions/scratch3_translate/index.js
@@ -278,7 +278,7 @@ class Scratch3TranslateBlocks {
             })
             .catch(err => {
                 log.warn(`error fetching translate result! ${err}`);
-                return '';
+                return args.WORDS;
             });
         return translatePromise;
     }


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-517

### Proposed Changes

Changes fallback when limit is reached to be untranslated string

### Reason for Changes

UX update to prevent bad fallback when throttling limit is reached.