### PR TITLE
Spork bug fixes, round 1

### DIFF
--- a/packages/scratch-gui/src/components/blocks/blocks.css
+++ b/packages/scratch-gui/src/components/blocks/blocks.css
@@ -40,6 +40,11 @@
     stroke: none;
 }
 
+/*
+    TODO: Check if we still need both `blocklyToolbox` and `blocklyToolboxDiv`, and remove one if possible.
+    Note that there are other places in this file which use both.
+*/
+.blocks :global(.blocklyToolbox),
 .blocks :global(.blocklyToolboxDiv) {
     border-right: 1px solid $ui-black-transparent;
     border-bottom: 1px solid $ui-black-transparent;
@@ -55,11 +60,13 @@
     -ms-overflow-style: none;
 }
 
+[dir="rtl"] .blocks :global(.blocklyToolbox),
 [dir="rtl"] .blocks :global(.blocklyToolboxDiv) {
     border-right: none;
     border-left: 1px solid $ui-black-transparent;
 }
 
+.blocks :global(.blocklyToolbox::-webkit-scrollbar),
 .blocks :global(.blocklyToolboxDiv::-webkit-scrollbar) {
     display: none;
 }

--- a/packages/scratch-gui/src/containers/menu.jsx
+++ b/packages/scratch-gui/src/containers/menu.jsx
@@ -25,10 +25,12 @@ class Menu extends React.Component {
         this.removeListeners();
     }
     addListeners () {
-        document.addEventListener('mouseup', this.handleClick);
+        // The Blockly workspace suppresses compat events like `mouseup`.
+        // Listen for `pointerup` instead.
+        document.addEventListener('pointerup', this.handleClick);
     }
     removeListeners () {
-        document.removeEventListener('mouseup', this.handleClick);
+        document.removeEventListener('pointerup', this.handleClick);
     }
     handleClick (e) {
         if (this.props.open && !this.menu.contains(e.target)) {


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-blocks#3456
- Resolves scratchfoundation/scratch-blocks#3459

### Proposed Changes

- Update `blocks.css` to support the new Blockly div name
- Update `<Menu>` to watch for pointer events rather than mouse events

### Reason for Changes

- The CSS rules to compensate for the "Add Extension" button in the category toolbox need to know about the structure that Blockly generates. The name of that `<div>` has changed, which led to scratchfoundation/scratch-blocks#3459. Adjusting the rule for the new name fixes that issue.
- Newer versions of Blockly call `stopPropagation` on pointer events before mouse compat events are generated, so the menu never heard the `mouseup` event that should have closed the menu. By watching for `pointerup` instead, Blockly's `stopPropagation` doesn't prevent the menu from closing.

### Test Coverage

Tested locally
