### PR TITLE
fix: replace toString with Cast.toString in switch blocks

### DIFF
--- a/packages/scratch-vm/src/blocks/scratch3_looks.js
+++ b/packages/scratch-vm/src/blocks/scratch3_looks.js
@@ -392,7 +392,7 @@ class Scratch3LooksBlocks {
             target.setCostume(optZeroIndex ? requestedCostume : requestedCostume - 1);
         } else {
             // Strings should be treated as costume names, where possible
-            const costumeIndex = target.getCostumeIndexByName(String(requestedCostume));
+            const costumeIndex = target.getCostumeIndexByName(Cast.toString(requestedCostume));
 
             if (costumeIndex !== -1) {
                 target.setCostume(costumeIndex);
@@ -426,7 +426,7 @@ class Scratch3LooksBlocks {
             stage.setCostume(optZeroIndex ? requestedBackdrop : requestedBackdrop - 1);
         } else {
             // Strings should be treated as backdrop names where possible
-            const costumeIndex = stage.getCostumeIndexByName(String(requestedBackdrop));
+            const costumeIndex = stage.getCostumeIndexByName(Cast.toString(requestedBackdrop));
 
             if (costumeIndex !== -1) {
                 stage.setCostume(costumeIndex);

--- a/packages/scratch-vm/src/blocks/scratch3_looks.js
+++ b/packages/scratch-vm/src/blocks/scratch3_looks.js
@@ -392,7 +392,7 @@ class Scratch3LooksBlocks {
             target.setCostume(optZeroIndex ? requestedCostume : requestedCostume - 1);
         } else {
             // Strings should be treated as costume names, where possible
-            const costumeIndex = target.getCostumeIndexByName(requestedCostume.toString());
+            const costumeIndex = target.getCostumeIndexByName(String(requestedCostume));
 
             if (costumeIndex !== -1) {
                 target.setCostume(costumeIndex);
@@ -426,7 +426,7 @@ class Scratch3LooksBlocks {
             stage.setCostume(optZeroIndex ? requestedBackdrop : requestedBackdrop - 1);
         } else {
             // Strings should be treated as backdrop names where possible
-            const costumeIndex = stage.getCostumeIndexByName(requestedBackdrop.toString());
+            const costumeIndex = stage.getCostumeIndexByName(String(requestedBackdrop));
 
             if (costumeIndex !== -1) {
                 stage.setCostume(costumeIndex);


### PR DESCRIPTION
Prevents the switch costume to (), switch backdrop to (), and switch backdrop to () and wait blocks from hanging indefinitely in certain situations.

### Resolves

N/A (I would rather not create an issue for this, as it's not a problem that would be faced by users using Scratch as intended.)

### Proposed Changes

This is a super minor change, it just prevents the switch costume to (), switch backdrop to (), and switch backdrop to () and wait blocks from hanging indefinitely in certain situations by changing them to use Cast.toString() instead of .toString when converting the input to a string.

### Reason for Changes

To be more consistent with other blocks.

As far as I can tell, all other blocks in the runtime do not rely on the .toString method being available on values passed as input. These blocks do, so if they're given a value without a .toString method, they will throw an error (after which the blocks are run again, and again, and again, throwing the same error and never continuing the script). Changing it to use Cast.toString() makes it more consistent with other blocks. While for most intents and purposes this will never be an issue, it will prevent it from failing under extraordinary circumstances, e.g. if it is given `undefined` as input, which does not have a .toString method.

### Test Coverage

N/A? I'll add a test for it if it's absolutely necessary, but the behavior is effectively the same as before, it just does not throw when given an invalid value.
