### PR TITLE
test: add VM state snapshot integration test

### DIFF
--- a/packages/scratch-vm/eslint.config.mjs
+++ b/packages/scratch-vm/eslint.config.mjs
@@ -38,6 +38,7 @@ export default eslintConfigScratch.defineConfig(
         'coverage/**/*',
         'dist/**/*',
         'node_modules/**/*',
-        'playground/**/*'
+        'playground/**/*',
+        'tap-snapshots/**/*'
     ])
 );

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/block-to-workspace-comments-without-scripts.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/block-to-workspace-comments-without-scripts.sb2.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/block-to-workspace-comments.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/block-to-workspace-comments.sb2.json
@@ -1,0 +1,120 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/broadcast_special_chars.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/broadcast_special_chars.sb2.json
@@ -1,0 +1,127 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:<": "< perfect",
+        "broadcast:a": "a&b"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "< perfect",
+                  "broadcast:<"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "a&b",
+                  "broadcast:a"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/broadcast_special_chars.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/broadcast_special_chars.sb3.json
@@ -1,0 +1,127 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:<": "< perfect",
+        "broadcast:a": "a&b"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "be4269f29458b8a167da107dd32f7fcb",
+          "md5ext": "be4269f29458b8a167da107dd32f7fcb.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "647af087a73872c7019b594b4419b70c",
+          "md5ext": "647af087a73872c7019b594b4419b70c.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "< perfect",
+                  "broadcast:<"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "a&b",
+                  "broadcast:a"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/clone-cleanup.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/clone-cleanup.sb2.json
@@ -1,0 +1,331 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "testStep 0"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_create_clone_of",
+                    "inputs": {
+                      "CLONE_OPTION": [
+                        1,
+                        {
+                          "opcode": "control_create_clone_of_menu",
+                          "shadow": true,
+                          "fields": {
+                            "CLONE_OPTION": [
+                              "_myself_"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "testStep 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "testStep 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_create_clone_of",
+                    "inputs": {
+                      "CLONE_OPTION": [
+                        1,
+                        {
+                          "opcode": "control_create_clone_of_menu",
+                          "shadow": true,
+                          "fields": {
+                            "CLONE_OPTION": [
+                              "_myself_"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "testStep 3"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_delete_this_clone"
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "motion_turnright",
+                    "inputs": {
+                      "DEGREES": [
+                        1,
+                        [
+                          4,
+                          15
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_touchingobject",
+                          "inputs": {
+                            "TOUCHINGOBJECTMENU": [
+                              1,
+                              {
+                                "opcode": "sensing_touchingobjectmenu",
+                                "shadow": true,
+                                "fields": {
+                                  "TOUCHINGOBJECTMENU": [
+                                    "_mouse_"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_nextcostume"
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_exceeded_limit.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_exceeded_limit.sb2.json
@@ -1,0 +1,293 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ cloud1": [
+          "☁ cloud1",
+          0,
+          true
+        ],
+        "var:☁ cloud2": [
+          "☁ cloud2",
+          0,
+          true
+        ],
+        "var:☁ cloud3": [
+          "☁ cloud3",
+          0,
+          true
+        ],
+        "var:☁ cloud4": [
+          "☁ cloud4",
+          0,
+          true
+        ],
+        "var:☁ cloud5": [
+          "☁ cloud5",
+          0,
+          true
+        ],
+        "var:☁ cloud6": [
+          "☁ cloud6",
+          0,
+          true
+        ],
+        "var:☁ cloud7": [
+          "☁ cloud7",
+          0,
+          true
+        ],
+        "var:☁ cloud8": [
+          "☁ cloud8",
+          0,
+          true
+        ],
+        "var:☁ cloud9": [
+          "☁ cloud9",
+          0,
+          true
+        ],
+        "var:☁ cloud10": [
+          "☁ cloud10",
+          0,
+          true
+        ],
+        "var:☁ cloud11": [
+          "☁ cloud11",
+          0
+        ],
+        "var:☁ cloud12": [
+          "☁ cloud12",
+          0
+        ],
+        "var:☁ cloud13": [
+          "☁ cloud13",
+          0
+        ],
+        "var:☁ cloud14": [
+          "☁ cloud14",
+          0
+        ],
+        "var:☁ cloud15": [
+          "☁ cloud15",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud1\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud1"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud2\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud2"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud3\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud3"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud4\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud4"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 86,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud5\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud5"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 113,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud6\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud6"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 140,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud7\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud7"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 167,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ cloud8\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ cloud8"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 194,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_exceeded_limit.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_exceeded_limit.sb3.json
@@ -1,0 +1,164 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ cloud1": [
+          "☁ cloud1",
+          0,
+          true
+        ],
+        "var:☁ cloud2": [
+          "☁ cloud2",
+          0,
+          true
+        ],
+        "var:☁ cloud3": [
+          "☁ cloud3",
+          0,
+          true
+        ],
+        "var:☁ cloud4": [
+          "☁ cloud4",
+          0,
+          true
+        ],
+        "var:☁ cloud5": [
+          "☁ cloud5",
+          0,
+          true
+        ],
+        "var:☁ cloud6": [
+          "☁ cloud6",
+          0,
+          true
+        ],
+        "var:☁ cloud7": [
+          "☁ cloud7",
+          0,
+          true
+        ],
+        "var:☁ cloud8": [
+          "☁ cloud8",
+          0,
+          true
+        ],
+        "var:☁ cloud9": [
+          "☁ cloud9",
+          0,
+          true
+        ],
+        "var:☁ cloud10": [
+          "☁ cloud10",
+          0,
+          true
+        ],
+        "var:☁ cloud11": [
+          "☁ cloud11",
+          0
+        ],
+        "var:☁ cloud12": [
+          "☁ cloud12",
+          0
+        ],
+        "var:☁ cloud13": [
+          "☁ cloud13",
+          0
+        ],
+        "var:☁ cloud14": [
+          "☁ cloud14",
+          0
+        ],
+        "var:☁ cloud15": [
+          "☁ cloud15",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_limit.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_limit.sb2.json
@@ -1,0 +1,305 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ 1": [
+          "☁ 1",
+          "0",
+          true
+        ],
+        "var:☁ 2": [
+          "☁ 2",
+          "0",
+          true
+        ],
+        "var:☁ 3": [
+          "☁ 3",
+          "0",
+          true
+        ],
+        "var:☁ 4": [
+          "☁ 4",
+          "0",
+          true
+        ],
+        "var:☁ 5": [
+          "☁ 5",
+          "0",
+          true
+        ],
+        "var:☁ 6": [
+          "☁ 6",
+          "0",
+          true
+        ],
+        "var:☁ 7": [
+          "☁ 7",
+          "0",
+          true
+        ],
+        "var:☁ 8": [
+          "☁ 8",
+          "0",
+          true
+        ],
+        "var:☁ 9": [
+          "☁ 9",
+          "0",
+          true
+        ],
+        "var:☁ 10": [
+          "☁ 10",
+          "0",
+          true
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 1\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 1"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 10\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 10"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 248,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 2\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 2"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 3\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 3"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 4\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 4"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 86,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 5\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 5"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 113,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 6\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 6"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 140,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 7\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 7"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 167,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 8\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 8"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 194,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 9\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 9"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 221,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_limit.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_limit.sb3.json
@@ -1,0 +1,324 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ 1": [
+          "☁ 1",
+          0,
+          true
+        ],
+        "var:☁ 2": [
+          "☁ 2",
+          0,
+          true
+        ],
+        "var:☁ 3": [
+          "☁ 3",
+          0,
+          true
+        ],
+        "var:☁ 4": [
+          "☁ 4",
+          0,
+          true
+        ],
+        "var:☁ 5": [
+          "☁ 5",
+          0,
+          true
+        ],
+        "var:☁ 6": [
+          "☁ 6",
+          0,
+          true
+        ],
+        "var:☁ 7": [
+          "☁ 7",
+          0,
+          true
+        ],
+        "var:☁ 8": [
+          "☁ 8",
+          0,
+          true
+        ],
+        "var:☁ 9": [
+          "☁ 9",
+          0,
+          true
+        ],
+        "var:☁ 10": [
+          "☁ 10",
+          0,
+          true
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a88da48fdc30493c5cc24089f645eb58",
+          "md5ext": "a88da48fdc30493c5cc24089f645eb58.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a1508ade4cfe8563ec1a148071e609d9",
+          "md5ext": "a1508ade4cfe8563ec1a148071e609d9.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 1\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 1"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 10\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 10"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 105,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 2\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 2"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 36,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 3\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 3"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 67,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 4\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 4"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 98,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 5\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 5"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 129,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 6\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 6"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 160,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 7\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 7"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 191,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 8\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 8"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 222,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ 9\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ 9"
+      },
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 253,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_local.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_local.sb2.json
@@ -1,0 +1,115 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {
+        "var:☁ localCloud": [
+          "☁ localCloud",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ localCloud\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ localCloud"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_local.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_local.sb3.json
@@ -1,0 +1,98 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {
+        "var:☁ localCloud": [
+          "☁ localCloud",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_simple.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_simple.sb2.json
@@ -1,0 +1,116 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ firstCloud": [
+          "☁ firstCloud",
+          "100",
+          true
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"☁ firstCloud\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "☁ firstCloud"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_simple.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/cloud_variables_simple.sb3.json
@@ -1,0 +1,99 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:☁ firstCloud": [
+          "☁ firstCloud",
+          "100",
+          true
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments.sb2.json
@@ -1,0 +1,165 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 10,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          25
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_stop",
+            "fields": {
+              "STOP_OPTION": [
+                "all"
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments.sb3.json
@@ -1,0 +1,165 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 10,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          25
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_stop",
+            "fields": {
+              "STOP_OPTION": [
+                "all"
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments_no_duplicate_id_serialization.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/comments_no_duplicate_id_serialization.sb3.json
@@ -1,0 +1,112 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 1,
+          "rotationCenterY": 1
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  "10"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/complex.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/complex.sb2.json
@@ -1,0 +1,404 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "atom playground",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "e5f794c8756ca0cead5cb7e7fe354c41",
+          "md5ext": "e5f794c8756ca0cead5cb7e7fe354c41.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "baseball-field",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "6b3d87ba2a7f89be703163b6c1d4c964",
+          "md5ext": "6b3d87ba2a7f89be703163b6c1d4c964.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -165,
+      "y": 95,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Adrian",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "adrian-a",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b983d99560313e38b4b3cd36cbd5f0d1",
+          "md5ext": "b983d99560313e38b4b3cd36cbd5f0d1.png",
+          "rotationCenterX": 138,
+          "rotationCenterY": 126
+        },
+        {
+          "name": "adrian-b",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "d0c3b4b24fbf1152de3ebb68f6b875ae",
+          "md5ext": "d0c3b4b24fbf1152de3ebb68f6b875ae.png",
+          "rotationCenterX": 48,
+          "rotationCenterY": 160
+        },
+        {
+          "name": "adrian-c",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "5fdce07935156bbcf943793fa84e826c",
+          "md5ext": "5fdce07935156bbcf943793fa84e826c.png",
+          "rotationCenterX": 170,
+          "rotationCenterY": 130
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -31,
+      "y": 91,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Alex",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "alex-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "b49309b5be7168ef746e324b510349f0",
+          "md5ext": "b49309b5be7168ef746e324b510349f0.svg",
+          "rotationCenterX": 31,
+          "rotationCenterY": 100
+        },
+        {
+          "name": "alex-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "bff21910d023785583572db77eeb82b0",
+          "md5ext": "bff21910d023785583572db77eeb82b0.svg",
+          "rotationCenterX": 31,
+          "rotationCenterY": 100
+        },
+        {
+          "name": "alex-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "48426895cf6136423861c6ca196690f4",
+          "md5ext": "48426895cf6136423861c6ca196690f4.svg",
+          "rotationCenterX": 32,
+          "rotationCenterY": 100
+        },
+        {
+          "name": "alex-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4ec18e0db3937725621dba9990f7679e",
+          "md5ext": "4ec18e0db3937725621dba9990f7679e.svg",
+          "rotationCenterX": 31,
+          "rotationCenterY": 100
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 137,
+      "y": 66,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Anna Ode to Code",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 13,
+      "costumes": [
+        {
+          "name": "anna01",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "74b5e9c882deb81d88c175d548b8ff66",
+          "md5ext": "74b5e9c882deb81d88c175d548b8ff66.png",
+          "rotationCenterX": 78,
+          "rotationCenterY": 190
+        },
+        {
+          "name": "anna02",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "ece557e1c4500b30fd0e22b0d693cf4c",
+          "md5ext": "ece557e1c4500b30fd0e22b0d693cf4c.png",
+          "rotationCenterX": 132,
+          "rotationCenterY": 260
+        },
+        {
+          "name": "anna03",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "2e97d9d9d6bc1f174d3fc897638e8a46",
+          "md5ext": "2e97d9d9d6bc1f174d3fc897638e8a46.png",
+          "rotationCenterX": 138,
+          "rotationCenterY": 242
+        },
+        {
+          "name": "anna04",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "69da72a9a29181425944e7963eb4f32a",
+          "md5ext": "69da72a9a29181425944e7963eb4f32a.png",
+          "rotationCenterX": 138,
+          "rotationCenterY": 70
+        },
+        {
+          "name": "anna05",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "1b396abf1336bceddb01166d975dad3b",
+          "md5ext": "1b396abf1336bceddb01166d975dad3b.png",
+          "rotationCenterX": 134,
+          "rotationCenterY": 246
+        },
+        {
+          "name": "anna06",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "d32ac2b2e9c8fa2f7b251275d8eec8c9",
+          "md5ext": "d32ac2b2e9c8fa2f7b251275d8eec8c9.png",
+          "rotationCenterX": 118,
+          "rotationCenterY": 224
+        },
+        {
+          "name": "anna07",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "c0961caabfa8545b6080ea7825d6fc66",
+          "md5ext": "c0961caabfa8545b6080ea7825d6fc66.png",
+          "rotationCenterX": 124,
+          "rotationCenterY": 224
+        },
+        {
+          "name": "anna07b",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "c21f0ef20be25af3b7c1ed42e974c75f",
+          "md5ext": "c21f0ef20be25af3b7c1ed42e974c75f.png",
+          "rotationCenterX": 202,
+          "rotationCenterY": 224
+        },
+        {
+          "name": "anna07c",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "54ed739e6ea31d128c319e8a3401af71",
+          "md5ext": "54ed739e6ea31d128c319e8a3401af71.png",
+          "rotationCenterX": 58,
+          "rotationCenterY": 218
+        },
+        {
+          "name": "anna08",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "2d9bffdb6cda1ce0c77cfb3e001598f3",
+          "md5ext": "2d9bffdb6cda1ce0c77cfb3e001598f3.png",
+          "rotationCenterX": 126,
+          "rotationCenterY": 212
+        },
+        {
+          "name": "anna09",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "91f689627fa18d43ff6362ef872d90e2",
+          "md5ext": "91f689627fa18d43ff6362ef872d90e2.png",
+          "rotationCenterX": 130,
+          "rotationCenterY": 220
+        },
+        {
+          "name": "anna10",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "eab5b5e2c4be253de024dd3deab68a66",
+          "md5ext": "eab5b5e2c4be253de024dd3deab68a66.png",
+          "rotationCenterX": 148,
+          "rotationCenterY": 260
+        },
+        {
+          "name": "anna11",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "859f95864d28fdb49d4170ce30fdd031",
+          "md5ext": "859f95864d28fdb49d4170ce30fdd031.png",
+          "rotationCenterX": 46,
+          "rotationCenterY": 278
+        },
+        {
+          "name": "anna12",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "66133f695a23f669cc0fa6f06f275ab7",
+          "md5ext": "66133f695a23f669cc0fa6f06f275ab7.png",
+          "rotationCenterX": 42,
+          "rotationCenterY": 206
+        }
+      ],
+      "sounds": [
+        {
+          "name": "odesong-b",
+          "assetId": "2c41921491b1da2bfa1ebcaba34265ca",
+          "dataFormat": "wav",
+          "format": "adpcm",
+          "rate": 22050,
+          "sampleCount": 212553,
+          "md5ext": "2c41921491b1da2bfa1ebcaba34265ca.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -119,
+      "y": -106,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenkeypressed",
+            "fields": {
+              "KEY_OPTION": [
+                "space"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_nextcostume"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/control.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/control.sb2.json
@@ -1,0 +1,338 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_create_clone_of",
+                    "inputs": {
+                      "CLONE_OPTION": [
+                        1,
+                        {
+                          "opcode": "control_create_clone_of_menu",
+                          "shadow": true,
+                          "fields": {
+                            "CLONE_OPTION": [
+                              "_myself_"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.01
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait_until",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ],
+                    "OPERAND2": [
+                      3,
+                      {
+                        "opcode": "operator_random",
+                        "inputs": {
+                          "FROM": [
+                            1,
+                            [
+                              4,
+                              1
+                            ]
+                          ],
+                          "TO": [
+                            1,
+                            [
+                              4,
+                              2
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "motion_turnright",
+                    "inputs": {
+                      "DEGREES": [
+                        1,
+                        [
+                          4,
+                          15
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "motion_pointindirection",
+            "inputs": {
+              "DIRECTION": [
+                3,
+                {
+                  "opcode": "operator_random",
+                  "inputs": {
+                    "FROM": [
+                      1,
+                      [
+                        4,
+                        1
+                      ]
+                    ],
+                    "TO": [
+                      1,
+                      [
+                        4,
+                        360
+                      ]
+                    ]
+                  }
+                },
+                [
+                  8,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "motion_movesteps",
+                    "inputs": {
+                      "STEPS": [
+                        1,
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "motion_ifonedgebounce"
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_touchingobject",
+                          "inputs": {
+                            "TOUCHINGOBJECTMENU": [
+                              1,
+                              {
+                                "opcode": "sensing_touchingobjectmenu",
+                                "shadow": true,
+                                "fields": {
+                                  "TOUCHINGOBJECTMENU": [
+                                    "_edge_"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_changeeffectby",
+                            "fields": {
+                              "EFFECT": [
+                                "color"
+                              ]
+                            },
+                            "inputs": {
+                              "CHANGE": [
+                                1,
+                                [
+                                  4,
+                                  25
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_png.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_png.sb2.json
@@ -1,0 +1,84 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "GreenGuy",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "GreenGuy",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "6cd4a800bac238e3b9dba8ade206569e",
+          "md5ext": "6cd4a800bac238e3b9dba8ade206569e.png",
+          "rotationCenterX": 119,
+          "rotationCenterY": 121
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -26,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_png.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_png.sb3.json
@@ -1,0 +1,87 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Green Guy",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "Green Guy",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "95509eea3f1dba35b726ff97fbe46b7f",
+          "md5ext": "95509eea3f1dba35b726ff97fbe46b7f.png",
+          "rotationCenterX": 306,
+          "rotationCenterY": 343
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -13,
+      "y": -18,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_sound.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_sound.sb3.json
@@ -1,0 +1,97 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "702d6b19295a4135a0cd6c49606e2a44",
+          "md5ext": "702d6b19295a4135a0cd6c49606e2a44.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "6f0c9b9f05092d28f36191d7e68d84a3",
+          "md5ext": "6f0c9b9f05092d28f36191d7e68d84a3.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Boop Sound Recording",
+          "assetId": "06cd1c59340566c193f8f28e63ba145b",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1,
+          "md5ext": "06cd1c59340566c193f8f28e63ba145b.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_svg.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_svg.sb2.json
@@ -1,0 +1,84 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Blue Guy",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "Blue Guy 2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4dd6986f9969af1a99fc18dbb2a78157",
+          "md5ext": "4dd6986f9969af1a99fc18dbb2a78157.svg",
+          "rotationCenterX": 53,
+          "rotationCenterY": 40
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -44,
+      "y": 5,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_svg.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/corrupt_svg.sb3.json
@@ -1,0 +1,88 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Blue Square Guy",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4dd6986f9969af1a99fc18dbb2a78157",
+          "md5ext": "4dd6986f9969af1a99fc18dbb2a78157.svg",
+          "rotationCenterX": 90.484375,
+          "rotationCenterY": 62.5
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 36,
+      "y": 28,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/data.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/data.sb2.json
@@ -1,0 +1,622 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:foo": [
+          "foo",
+          50
+        ]
+      },
+      "lists": {
+        "list:bar": [
+          "bar",
+          [
+            1.467,
+            0.8,
+            0.835,
+            1.304,
+            1.335,
+            1.165,
+            1.201,
+            0.865,
+            0.903,
+            1.438,
+            0.936,
+            0.97,
+            1.4,
+            1.232,
+            1.366,
+            1.001,
+            1.033,
+            1.072,
+            1.137,
+            1.099
+          ]
+        ]
+      },
+      "broadcasts": {
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {
+        "var:local": [
+          "local",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "foo",
+                "var:foo"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  100
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "foo",
+                        "var:foo"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          0.5
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                3,
+                {
+                  "opcode": "data_lengthoflist",
+                  "fields": {
+                    "LIST": [
+                      "bar",
+                      "list:bar"
+                    ]
+                  }
+                },
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_deleteoflist",
+                    "fields": {
+                      "LIST": [
+                        "bar",
+                        "list:bar"
+                      ]
+                    },
+                    "inputs": {
+                      "INDEX": [
+                        3,
+                        {
+                          "opcode": "data_lengthoflist",
+                          "fields": {
+                            "LIST": [
+                              "bar",
+                              "list:bar"
+                            ]
+                          }
+                        },
+                        [
+                          7,
+                          10
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "bar",
+                        "list:bar"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        3,
+                        {
+                          "opcode": "sensing_timer"
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                3,
+                {
+                  "opcode": "data_lengthoflist",
+                  "fields": {
+                    "LIST": [
+                      "bar",
+                      "list:bar"
+                    ]
+                  }
+                },
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_insertatlist",
+                    "fields": {
+                      "LIST": [
+                        "bar",
+                        "list:bar"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        3,
+                        {
+                          "opcode": "sensing_timer"
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ],
+                      "INDEX": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                1
+                              ]
+                            ],
+                            "TO": [
+                              3,
+                              {
+                                "opcode": "data_lengthoflist",
+                                "fields": {
+                                  "LIST": [
+                                    "bar",
+                                    "list:bar"
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          7,
+                          10
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "data_listcontainsitem",
+                  "fields": {
+                    "LIST": [
+                      "bar",
+                      "list:bar"
+                    ]
+                  },
+                  "inputs": {
+                    "ITEM": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "bar",
+                        "list:bar"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        1,
+                        [
+                          10,
+                          "match!"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_replaceitemoflist",
+            "fields": {
+              "LIST": [
+                "bar",
+                "list:bar"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ],
+              "ITEM": [
+                3,
+                {
+                  "opcode": "sensing_timer"
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "color"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "data_itemoflist",
+                  "fields": {
+                    "LIST": [
+                      "bar",
+                      "list:bar"
+                    ]
+                  },
+                  "inputs": {
+                    "INDEX": [
+                      1,
+                      [
+                        7,
+                        1
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "whirl"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                [
+                  12,
+                  "foo",
+                  "var:foo"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "data_listcontainsitem",
+                  "fields": {
+                    "LIST": [
+                      "bar",
+                      "list:bar"
+                    ]
+                  },
+                  "inputs": {
+                    "ITEM": [
+                      1,
+                      [
+                        10,
+                        "1.0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          25
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"bar\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "bar"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 108,
+      "height": 208,
+      "x": 5,
+      "y": 32,
+      "visible": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"foo\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "foo"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite2_data_variable_{\"VARIABLE\":\"local\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "local"
+      },
+      "spriteName": "Sprite2",
+      "value": "",
+      "x": 5,
+      "y": 245,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default.sb2.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default.sb3.json
@@ -1,0 +1,97 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "702d6b19295a4135a0cd6c49606e2a44",
+          "md5ext": "702d6b19295a4135a0cd6c49606e2a44.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "6f0c9b9f05092d28f36191d7e68d84a3",
+          "md5ext": "6f0c9b9f05092d28f36191d7e68d84a3.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default_nested.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/default_nested.sb2.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/draggable.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/draggable.sb3.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "78d212878a6f0a2b3067aa2c8bca28e1",
+          "md5ext": "78d212878a6f0a2b3067aa2c8bca28e1.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "c48d79cecfb38a7b489c39e24ea0d3a1",
+          "md5ext": "c48d79cecfb38a7b489c39e24ea0d3a1.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a39db2db09bd245308a64a5cb9beee96",
+          "md5ext": "a39db2db09bd245308a64a5cb9beee96.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1.906493,
+      "y": 16.3136646,
+      "size": 100,
+      "direction": 90,
+      "draggable": true,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/edge-triggered-hat.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/edge-triggered-hat.sb3.json
@@ -1,0 +1,129 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a88da48fdc30493c5cc24089f645eb58",
+          "md5ext": "a88da48fdc30493c5cc24089f645eb58.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a1508ade4cfe8563ec1a148071e609d9",
+          "md5ext": "a1508ade4cfe8563ec1a148071e609d9.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 50,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whengreaterthan",
+            "fields": {
+              "WHENGREATERTHANMENU": [
+                "TIMER"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  "-1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  "10"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/event.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/event.sb2.json
@@ -1,0 +1,348 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "city with water",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "341a933b6426e70459960e472f12660a",
+          "md5ext": "341a933b6426e70459960e472f12660a.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 180,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "backdrop1"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_glidesecstoxy",
+            "inputs": {
+              "SECS": [
+                1,
+                [
+                  4,
+                  0.25
+                ]
+              ],
+              "X": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_glidesecstoxy",
+            "inputs": {
+              "SECS": [
+                1,
+                [
+                  4,
+                  0.25
+                ]
+              ],
+              "X": [
+                1,
+                [
+                  4,
+                  -100
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_glidesecstoxy",
+            "inputs": {
+              "SECS": [
+                1,
+                [
+                  4,
+                  0.25
+                ]
+              ],
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "city with water"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "motion_turnright",
+                    "inputs": {
+                      "DEGREES": [
+                        1,
+                        [
+                          4,
+                          15
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          25
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbackdropswitchesto",
+            "fields": {
+              "BACKDROP": [
+                "city with water"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "whirl"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  50
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/broadcast-wait-arg-change.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/broadcast-wait-arg-change.sb2.json
@@ -1,0 +1,275 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:broadcast name": [
+          "broadcast name",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:b": "broadcast a",
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "broadcast name",
+                "var:broadcast name"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "broadcast a"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                3,
+                [
+                  12,
+                  "broadcast name",
+                  "var:broadcast name"
+                ],
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "fail broadcast a did not complete"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_stop",
+            "fields": {
+              "STOP_OPTION": [
+                "all"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "broadcast a",
+                "broadcast:b"
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "pass broadcast a completed"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_stop",
+            "fields": {
+              "STOP_OPTION": [
+                "all"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "broadcast name",
+                "var:broadcast name"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "something else"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"broadcast name\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "broadcast name"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-false-then-else.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-false-then-else.sb2.json
@@ -1,0 +1,166 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                1,
+                null
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail condition always false"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass condition always false"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-false-then.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-false-then.sb2.json
@@ -1,0 +1,161 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                1,
+                null
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail condition always is false"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "pass"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-true-then-else.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-true-then-else.sb2.json
@@ -1,0 +1,174 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass condition always true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail condition always true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-true-then.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-if-true-then.sb2.json
@@ -1,0 +1,157 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass condition always is true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-stop-all-leaks.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/control-stop-all-leaks.sb2.json
@@ -1,0 +1,709 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          3
+        ],
+        "var:tests correct": [
+          "tests correct",
+          3
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 21,
+      "y": -97,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -29,
+      "y": 10,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.032
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_stop",
+            "fields": {
+              "STOP_OPTION": [
+                "all"
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-operators-global.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-operators-global.sb2.json
@@ -1,0 +1,447 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:global": [
+          "global",
+          "2"
+        ]
+      },
+      "lists": {
+        "list:global": [
+          "global",
+          [
+            "1",
+            "2"
+          ]
+        ],
+        "list:_answer": [
+          "_answer",
+          [
+            "4",
+            "5",
+            "3"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -158,
+      "y": -87,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "global",
+                        "var:global"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass global var is 2"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "global",
+                "var:global"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "global",
+                        "var:global"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass global var is 4"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "global",
+                "list:global"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_insertatlist",
+            "fields": {
+              "LIST": [
+                "global",
+                "list:global"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "4"
+                ]
+              ],
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_replaceitemoflist",
+            "fields": {
+              "LIST": [
+                "global",
+                "list:global"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  3
+                ]
+              ],
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "5"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_deleteoflist",
+            "fields": {
+              "LIST": [
+                "global",
+                "list:global"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  2
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        13,
+                        "global",
+                        "list:global"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      3,
+                      [
+                        13,
+                        "_answer",
+                        "list:_answer"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass global list is correct"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"_answer\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "_answer"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 114,
+      "height": 214,
+      "x": 112,
+      "y": 6,
+      "visible": false
+    },
+    {
+      "id": "_data_listcontents_{\"LIST\":\"global\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "global"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 116,
+      "height": 102,
+      "x": 5,
+      "y": 5,
+      "visible": false
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"global\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "global"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 307,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-operators-local.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-operators-local.sb2.json
@@ -1,0 +1,431 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {
+        "var:local": [
+          "local",
+          "1"
+        ]
+      },
+      "lists": {
+        "list:local": [
+          "local",
+          [
+            "3",
+            "4"
+          ]
+        ],
+        "list:answer": [
+          "answer",
+          [
+            "6",
+            "7",
+            "5"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "local",
+                        "var:local"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass local var is 1"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "local",
+                "var:local"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "local",
+                        "var:local"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass local var is 3"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "local",
+                "list:local"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "5"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_insertatlist",
+            "fields": {
+              "LIST": [
+                "local",
+                "list:local"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "6"
+                ]
+              ],
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_replaceitemoflist",
+            "fields": {
+              "LIST": [
+                "local",
+                "list:local"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  3
+                ]
+              ],
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "7"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_deleteoflist",
+            "fields": {
+              "LIST": [
+                "local",
+                "list:local"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  2
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        13,
+                        "local",
+                        "list:local"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      3,
+                      [
+                        13,
+                        "answer",
+                        "list:answer"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass local list is correct"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "Sprite2_data_listcontents_{\"LIST\":\"answer\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "answer"
+      },
+      "spriteName": "Sprite2",
+      "value": "",
+      "width": 114,
+      "height": 214,
+      "x": 4,
+      "y": 97,
+      "visible": false
+    },
+    {
+      "id": "Sprite2_data_listcontents_{\"LIST\":\"local\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "local"
+      },
+      "spriteName": "Sprite2",
+      "value": "",
+      "width": 118,
+      "height": 218,
+      "x": 4,
+      "y": 96,
+      "visible": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-reporter-contents-global.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-reporter-contents-global.sb2.json
@@ -1,0 +1,263 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:global": [
+          "global",
+          "2"
+        ]
+      },
+      "lists": {
+        "list:global": [
+          "global",
+          [
+            "1",
+            "2"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -158,
+      "y": -87,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "global",
+                        "var:global"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass global var is 2"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "data_itemoflist",
+                        "fields": {
+                          "LIST": [
+                            "global",
+                            "list:global"
+                          ]
+                        },
+                        "inputs": {
+                          "INDEX": [
+                            1,
+                            [
+                              7,
+                              2
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass global list index 2 is 2"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"global\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "global"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 114,
+      "height": 100,
+      "x": 5,
+      "y": 5,
+      "visible": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-reporter-contents-local.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/data-reporter-contents-local.sb2.json
@@ -1,0 +1,263 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {
+        "var:local": [
+          "local",
+          "1"
+        ]
+      },
+      "lists": {
+        "list:local": [
+          "local",
+          [
+            "3",
+            "4"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "local",
+                        "var:local"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass local var is 1"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "data_itemoflist",
+                        "fields": {
+                          "LIST": [
+                            "local",
+                            "list:local"
+                          ]
+                        },
+                        "inputs": {
+                          "INDEX": [
+                            1,
+                            [
+                              7,
+                              2
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass local list index 2 is 4"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "Sprite2_data_listcontents_{\"LIST\":\"local\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "local"
+      },
+      "spriteName": "Sprite2",
+      "value": "",
+      "width": 114,
+      "height": 214,
+      "x": 6,
+      "y": 96,
+      "visible": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/event-broadcast-and-wait-can-continue-same-tick.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/event-broadcast-and-wait-can-continue-same-tick.sb2.json
@@ -1,0 +1,915 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          3
+        ],
+        "var:tests correct": [
+          "tests correct",
+          3
+        ]
+      },
+      "lists": {
+        "list:tests": [
+          "tests",
+          [
+            "pass order is correct (1)",
+            "pass order is correct (2)",
+            "pass order is correct (3)"
+          ]
+        ]
+      },
+      "broadcasts": {
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1,
+      "y": -1,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_deleteoflist",
+            "fields": {
+              "LIST": [
+                "tests",
+                "list:tests"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_deleteoflist",
+            "fields": {
+              "LIST": [
+                "tests",
+                "list:tests"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_deleteoflist",
+            "fields": {
+              "LIST": [
+                "tests",
+                "list:tests"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  2
+                ]
+              ],
+              "SUBSTACK": [
+                1,
+                null
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                3,
+                {
+                  "opcode": "data_lengthoflist",
+                  "fields": {
+                    "LIST": [
+                      "tests",
+                      "list:tests"
+                    ]
+                  }
+                },
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "order",
+                        "var:order"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "data_itemoflist",
+                          "fields": {
+                            "LIST": [
+                              "tests",
+                              "list:tests"
+                            ]
+                          },
+                          "inputs": {
+                            "INDEX": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                7,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 147,
+      "y": -7,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_addtolist",
+                    "fields": {
+                      "LIST": [
+                        "tests",
+                        "list:tests"
+                      ]
+                    },
+                    "inputs": {
+                      "ITEM": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"tests\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "tests"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 102,
+      "height": 202,
+      "x": 5,
+      "y": 59,
+      "visible": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/event-when-green-flag.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/event-when-green-flag.sb2.json
@@ -1,0 +1,135 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "pass green flag thread did start"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/events-broadcast-and-wait-yields-a-tick.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/events-broadcast-and-wait-yields-a-tick.sb2.json
@@ -1,0 +1,771 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          5
+        ],
+        "var:tests correct": [
+          "tests correct",
+          3
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message3"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait_until",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "5"
+                      ]
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "event_broadcast",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "message2",
+                          "broadcast:m"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "event_broadcast",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "message3",
+                          "broadcast:m"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message3",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  0.032
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "5"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (5)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 5 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/hat-thread-execution.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/hat-thread-execution.sb2.json
@@ -1,0 +1,504 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:Green flag counter": [
+          "Green flag counter",
+          20
+        ],
+        "var:Greater than timer counter": [
+          "Greater than timer counter",
+          57
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whengreaterthan",
+            "fields": {
+              "WHENGREATERTHANMENU": [
+                "timer"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  1
+                ]
+              ],
+              "SUBSTACK": [
+                1,
+                null
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "Greater than timer counter",
+                "var:Greater than timer counter"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "sensing_resettimer"
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "Green flag counter",
+                "var:Green flag counter"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "Greater than timer counter",
+                "var:Greater than timer counter"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan  2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat_until",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "Green flag counter",
+                        "var:Green flag counter"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "20"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "Green flag counter",
+                        "var:Green flag counter"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          -1
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "Green flag counter",
+                        "var:Green flag counter"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "20"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass Green flag counter is correct"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail Flag counter should be 20 and it is "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "Green flag counter",
+                                "var:Green flag counter"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "Greater than timer counter",
+                        "var:Greater than timer counter"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "10"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass Greater than timer is correct"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail Timer counter should be 10 and it is "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "Greater than timer counter",
+                                "var:Greater than timer counter"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end  "
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"Greater than timer counter\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "Greater than timer counter"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"Green flag counter\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "Green flag counter"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/monitors-stage-name.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/monitors-stage-name.sb2.json
@@ -1,0 +1,157 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:variable": [
+          "variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 0"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "comment test that this project loads"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"variable\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "variable"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/operators-not-blank.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/operators-not-blank.sb2.json
@@ -1,0 +1,157 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass condition always is true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-back-2-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-back-2-broadcast-wait.sb2.json
@@ -1,0 +1,936 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  999
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-and-wait-repeat-message.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-and-wait-repeat-message.sb2.json
@@ -1,0 +1,1017 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:finished": [
+          "finished",
+          2
+        ],
+        "var:wait": [
+          "wait",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message1",
+        "broadcast:s": "sprite done"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "2"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (2)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 2 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "3"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (3)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 3 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "sprite done",
+                  "broadcast:s"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "1"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (1)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 1 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_goforwardbackwardlayers",
+                    "fields": {
+                      "FORWARD_BACKWARD": [
+                        "backward"
+                      ]
+                    },
+                    "inputs": {
+                      "NUM": [
+                        1,
+                        [
+                          7,
+                          1
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "4"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (4)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 4 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "sprite done",
+                  "broadcast:s"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "finished",
+                "var:finished"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "sprite done",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "finished",
+                "var:finished"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      2,
+                      {
+                        "opcode": "operator_lt",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            [
+                              12,
+                              "finished",
+                              "var:finished"
+                            ],
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "2"
+                            ]
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "end"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"finished\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "finished"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-and-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-and-wait.sb2.json
@@ -1,0 +1,910 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2",
+        "broadcast:e": "end"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "end",
+                  "broadcast:e"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  2
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "end",
+                "broadcast:e"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-no-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-no-wait.sb2.json
@@ -1,0 +1,902 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-broadcast-wait.sb2.json
@@ -1,0 +1,936 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-continuous.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-continuous.sb2.json
@@ -1,0 +1,918 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-threads-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-backwards-2-threads-broadcast-wait.sb2.json
@@ -1,0 +1,1476 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          0
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ],
+        "var:order2": [
+          "order2",
+          4
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:c": "continue",
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order2",
+                "var:order2"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "continue",
+                  "broadcast:c"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "continue",
+                "broadcast:c"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order2",
+                "var:order2"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order2",
+                        "var:order2"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order2 is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order2 is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order2",
+                                "var:order2"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order2",
+                "var:order2"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order2",
+                        "var:order2"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order2 is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order2 is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order2",
+                                "var:order2"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "continue",
+                "broadcast:c"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order2",
+                "var:order2"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order2",
+                        "var:order2"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order2 is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order2 is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order2",
+                                "var:order2"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order2",
+                "var:order2"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order2",
+                        "var:order2"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order2 is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order2 is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order2",
+                                "var:order2"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 8"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order2\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order2"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-forewards-2-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-forewards-2-broadcast-wait.sb2.json
@@ -1,0 +1,936 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  -1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-front-2-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-changes-front-2-broadcast-wait.sb2.json
@@ -1,0 +1,927 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 3,
+      "y": 134,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 2,
+      "y": -112,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-backwards-2-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-backwards-2-broadcast-wait.sb2.json
@@ -1,0 +1,1729 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          8
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite4",
+      "variables": {
+        "var:is clone": [
+          "is clone",
+          "false"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "false"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "true"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  80
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "1"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (1)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 1 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_goforwardbackwardlayers",
+                    "fields": {
+                      "FORWARD_BACKWARD": [
+                        "backward"
+                      ]
+                    },
+                    "inputs": {
+                      "NUM": [
+                        1,
+                        [
+                          7,
+                          1
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "2"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (2)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 2 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "6"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (6)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 6 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "5"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (5)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 5 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -184,
+      "y": 23,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 8"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {
+        "var:is clone": [
+          "is clone",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -1,
+      "y": -136,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "false"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "true"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  -80
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "8"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (8)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 8 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "7"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (7)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 7 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "3"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (3)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 3 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_goforwardbackwardlayers",
+                    "fields": {
+                      "FORWARD_BACKWARD": [
+                        "backward"
+                      ]
+                    },
+                    "inputs": {
+                      "NUM": [
+                        1,
+                        [
+                          7,
+                          1
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "4"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (4)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 4 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite4_data_variable_{\"VARIABLE\":\"is clone\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "is clone"
+      },
+      "spriteName": "Sprite4",
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-backwards-broadcast-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-backwards-broadcast-wait.sb2.json
@@ -1,0 +1,973 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite4",
+      "variables": {
+        "var:is clone": [
+          "is clone",
+          "false"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "false"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "true"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  80
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "1"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (1)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 1 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_goforwardbackwardlayers",
+                    "fields": {
+                      "FORWARD_BACKWARD": [
+                        "backward"
+                      ]
+                    },
+                    "inputs": {
+                      "NUM": [
+                        1,
+                        [
+                          7,
+                          1
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "2"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (2)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 2 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "4"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (4)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 4 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "3"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (3)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 3 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -184,
+      "y": 23,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite4_data_variable_{\"VARIABLE\":\"is clone\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "is clone"
+      },
+      "spriteName": "Sprite4",
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-static-2.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-clones-static-2.sb2.json
@@ -1,0 +1,1146 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          8
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite4",
+      "variables": {
+        "var:is clone": [
+          "is clone",
+          "false"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "false"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "true"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  80
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "1"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (1)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 1 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "2"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (2)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 2 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -184,
+      "y": 23,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {
+        "var:is clone": [
+          "is clone",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -1,
+      "y": -136,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "false"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "is clone",
+                "var:is clone"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "true"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  -80
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "is clone",
+                        "var:is clone"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "false"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "3"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (3)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 3 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "4"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass order is correct (4)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail order is incorrect 4 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      [
+                                        12,
+                                        "order",
+                                        "var:order"
+                                      ],
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite4_data_variable_{\"VARIABLE\":\"is clone\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "is clone"
+      },
+      "spriteName": "Sprite4",
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-immobile-stage.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-immobile-stage.sb2.json
@@ -1,0 +1,857 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          4
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message2"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message2",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "4"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (4)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 4 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  999
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message2",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "3"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (3)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 3 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -13,
+      "y": 103,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 4"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library-reverse.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library-reverse.sb2.json
@@ -1,0 +1,610 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          2
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -4,
+      "y": -24,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1,
+      "y": 53,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -195,
+      "y": -121,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library-reverse.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library-reverse.sb3.json
@@ -1,0 +1,577 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          2
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -4,
+      "y": -24,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1,
+      "y": 53,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -195,
+      "y": -121,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library.sb2.json
@@ -1,0 +1,610 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          2
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -4,
+      "y": -24,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1,
+      "y": 54,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -195,
+      "y": -121,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"order\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "order"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"wait\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "wait"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/order-library.sb3.json
@@ -1,0 +1,577 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:order": [
+          "order",
+          2
+        ],
+        "var:wait": [
+          "wait",
+          "0.032"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -4,
+      "y": -24,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 1,
+      "y": 54,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "order",
+                "var:order"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "order",
+                        "var:order"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "2"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass order is correct (2)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail order is incorrect 2 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              [
+                                12,
+                                "order",
+                                "var:order"
+                              ],
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "244ffdf1f893d3ac0ce40bd573713070",
+          "md5ext": "244ffdf1f893d3ac0ce40bd573713070.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e8999420c804040549e0d2f8ef84e21f",
+          "md5ext": "e8999420c804040549e0d2f8ef84e21f.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -195,
+      "y": -121,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                3,
+                [
+                  12,
+                  "wait",
+                  "var:wait"
+                ],
+                [
+                  5,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-boolean-reporter-bug.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-boolean-reporter-bug.sb2.json
@@ -1,0 +1,194 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "boolean %b",
+                    "argumentnames": "[\"boolean1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "argument_reporter_boolean",
+                  "fields": {
+                    "VALUE": [
+                      "boolean1"
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass fixed boolean report r parameter to b"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ]
+            },
+            "mutation": {
+              "proccode": "boolean %b"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-boolean-param.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-boolean-param.sb2.json
@@ -1,0 +1,345 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 1 %b"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %b",
+                    "argumentnames": "[\"boolean1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                null
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 2 %b"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 2 %b",
+                    "argumentnames": "[\"boolean2\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_boolean",
+                        "fields": {
+                          "VALUE": [
+                            "boolean1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass boolean1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail boolean1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_boolean",
+                                "fields": {
+                                  "VALUE": [
+                                    "boolean1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-no-param.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-no-param.sb2.json
@@ -1,0 +1,334 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 1 %n"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %n",
+                    "argumentnames": "[\"number1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "Test 2"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 2",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "number1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass number1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail number1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "number1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-number-param.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-number-param.sb2.json
@@ -1,0 +1,343 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 1 %n"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %n",
+                    "argumentnames": "[\"number1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 2 %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 2 %n",
+                    "argumentnames": "[\"number2\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "number1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass number1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail number1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "number1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-string-param.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-nested-missing-string-param.sb2.json
@@ -1,0 +1,343 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  10,
+                  "a"
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 1 %s"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %s",
+                    "argumentnames": "[\"string1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  10,
+                  ""
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test 2 %s"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 2 %s",
+                    "argumentnames": "[\"string2\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "string1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass string1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail string1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "string1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-number-number-boolean.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-number-number-boolean.sb2.json
@@ -1,0 +1,343 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "foo"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "foo",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                1,
+                null
+              ]
+            },
+            "mutation": {
+              "proccode": "bar %n %n %b"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ]
+            },
+            "mutation": {
+              "proccode": "baz %n %n %b"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "baz %n %n %b",
+                    "argumentnames": "[\"number1\",\"number2\",\"mustBeTrue\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "argument_reporter_boolean",
+                  "fields": {
+                    "VALUE": [
+                      "mustBeTrue"
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass boolean is true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail boolean is true"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "bar %n %n %b",
+                    "argumentnames": "[\"number1\",\"number2\",\"mustBeFalse\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "argument_reporter_boolean",
+                  "fields": {
+                    "VALUE": [
+                      "mustBeFalse"
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail boolean is false"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass boolean is false"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-boolean.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-boolean.sb2.json
@@ -1,0 +1,295 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_boolean",
+                        "fields": {
+                          "VALUE": [
+                            "boolean1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass boolean1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail boolean1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_boolean",
+                                "fields": {
+                                  "VALUE": [
+                                    "boolean1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %b",
+                    "argumentnames": "[\"boolean1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-number.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-number.sb2.json
@@ -1,0 +1,295 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "number1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass number1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail number1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "number1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %n",
+                    "argumentnames": "[\"number1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-string.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-param-outside-string.sb2.json
@@ -1,0 +1,295 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "string1"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "0"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass string1 is correct (0)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail string1 is incorrect 0 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "string1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test 1 %s",
+                    "argumentnames": "[\"string1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-boolean.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-boolean.sb2.json
@@ -1,0 +1,613 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:depth": [
+          "depth",
+          1
+        ],
+        "var:tests correct": [
+          "tests correct",
+          2
+        ],
+        "var:tests ran": [
+          "tests ran",
+          2
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "depth",
+                "var:depth"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests ran",
+                "var:tests ran"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      1,
+                      null
+                    ]
+                  }
+                }
+              ]
+            },
+            "mutation": {
+              "proccode": "Test Boolean %b"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test Boolean %b",
+                    "argumentnames": "[\"boolean1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "depth",
+                        "var:depth"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_boolean",
+                                "fields": {
+                                  "VALUE": [
+                                    "boolean1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "true"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass boolean1 is correct (true)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail boolean1 is incorrect true != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_boolean",
+                                        "fields": {
+                                          "VALUE": [
+                                            "boolean1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "depth",
+                        "var:depth"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        null
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "Test Boolean %b"
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_boolean",
+                                "fields": {
+                                  "VALUE": [
+                                    "boolean1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "false"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass boolean1 is correct (false)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail boolean1 is incorrect false != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_boolean",
+                                        "fields": {
+                                          "VALUE": [
+                                            "boolean1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"depth\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "depth"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests ran\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests ran"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-number.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-number.sb2.json
@@ -1,0 +1,611 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:depth": [
+          "depth",
+          1
+        ],
+        "var:tests correct": [
+          "tests correct",
+          2
+        ],
+        "var:tests ran": [
+          "tests ran",
+          2
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "depth",
+                "var:depth"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests ran",
+                "var:tests ran"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test Number %n"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test Number %n",
+                    "argumentnames": "[\"number1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "depth",
+                        "var:depth"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "number1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "1"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass number1 is correct (1)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail number1 is incorrect 1 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_string_number",
+                                        "fields": {
+                                          "VALUE": [
+                                            "number1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "depth",
+                        "var:depth"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "Test Number %n"
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "number1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "0"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass number1 is correct (0)"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail number1 is incorrect 0 != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_string_number",
+                                        "fields": {
+                                          "VALUE": [
+                                            "number1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"depth\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "depth"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests ran\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests ran"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-string.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/procedures-recursive-default-string.sb2.json
@@ -1,0 +1,611 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:depth": [
+          "depth",
+          1
+        ],
+        "var:tests correct": [
+          "tests correct",
+          2
+        ],
+        "var:tests ran": [
+          "tests ran",
+          2
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 2"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "depth",
+                "var:depth"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests ran",
+                "var:tests ran"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  10,
+                  "a"
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "Test Strings %s"
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "Test Strings %s",
+                    "argumentnames": "[\"string1\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      [
+                        12,
+                        "depth",
+                        "var:depth"
+                      ],
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "string1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                "a"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass string1 is correct ('a')"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail string1 is incorrect 'a' != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_string_number",
+                                        "fields": {
+                                          "VALUE": [
+                                            "string1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "depth",
+                        "var:depth"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "Test Strings %s"
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests ran",
+                        "var:tests ran"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if_else",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "operator_equals",
+                          "inputs": {
+                            "OPERAND1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "string1"
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ],
+                            "OPERAND2": [
+                              1,
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_changevariableby",
+                            "fields": {
+                              "VARIABLE": [
+                                "tests correct",
+                                "var:tests correct"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  4,
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                1,
+                                [
+                                  10,
+                                  "pass string1 is correct ('')"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ],
+                      "SUBSTACK2": [
+                        2,
+                        [
+                          {
+                            "opcode": "looks_say",
+                            "inputs": {
+                              "MESSAGE": [
+                                3,
+                                {
+                                  "opcode": "operator_join",
+                                  "inputs": {
+                                    "STRING1": [
+                                      1,
+                                      [
+                                        10,
+                                        "fail string1 is incorrect '' != "
+                                      ]
+                                    ],
+                                    "STRING2": [
+                                      3,
+                                      {
+                                        "opcode": "argument_reporter_string_number",
+                                        "fields": {
+                                          "VALUE": [
+                                            "string1"
+                                          ]
+                                        }
+                                      },
+                                      [
+                                        10,
+                                        ""
+                                      ]
+                                    ]
+                                  }
+                                },
+                                [
+                                  10,
+                                  ""
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"depth\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "depth"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests ran\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests ran"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/sensing-get-attribute-of-stage-alt-name.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/sensing-get-attribute-of-stage-alt-name.sb2.json
@@ -1,0 +1,305 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:tests correct": [
+          "tests correct",
+          1
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "tests correct",
+                "var:tests correct"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "sensing_of",
+                        "fields": {
+                          "PROPERTY": [
+                            "backdrop #"
+                          ]
+                        },
+                        "inputs": {
+                          "OBJECT": [
+                            1,
+                            {
+                              "opcode": "sensing_of_object_menu",
+                              "shadow": true,
+                              "fields": {
+                                "OBJECT": [
+                                  "_stage_"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "tests correct",
+                        "var:tests correct"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass backdrop is correct (1)"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        3,
+                        {
+                          "opcode": "operator_join",
+                          "inputs": {
+                            "STRING1": [
+                              1,
+                              [
+                                10,
+                                "fail backdrop is incorrect 1 != "
+                              ]
+                            ],
+                            "STRING2": [
+                              3,
+                              {
+                                "opcode": "sensing_of",
+                                "fields": {
+                                  "PROPERTY": [
+                                    "backdrop #"
+                                  ]
+                                },
+                                "inputs": {
+                                  "OBJECT": [
+                                    1,
+                                    {
+                                      "opcode": "sensing_of_object_menu",
+                                      "shadow": true,
+                                      "fields": {
+                                        "OBJECT": [
+                                          "_stage_"
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              [
+                                10,
+                                ""
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          10,
+                          ""
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"tests correct\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tests correct"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/sprite-number-name.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/execute/sprite-number-name.sb2.json
@@ -1,0 +1,767 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:num": [
+          "num",
+          "3"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": -90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "plan 5"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "num",
+                "var:num"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "sensing_distanceto",
+                        "inputs": {
+                          "DISTANCETOMENU": [
+                            3,
+                            {
+                              "opcode": "operator_round",
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  [
+                                    12,
+                                    "num",
+                                    "var:num"
+                                  ],
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            {
+                              "opcode": "sensing_distancetomenu",
+                              "shadow": true,
+                              "fields": {
+                                "DISTANCETOMENU": [
+                                  ""
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        " 1000"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass distance to sprite found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail distance to sprite not found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_setx",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_goto",
+            "inputs": {
+              "TO": [
+                3,
+                {
+                  "opcode": "operator_round",
+                  "inputs": {
+                    "NUM": [
+                      3,
+                      [
+                        12,
+                        "num",
+                        "var:num"
+                      ],
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "opcode": "motion_goto_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TO": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_not",
+                  "inputs": {
+                    "OPERAND": [
+                      2,
+                      {
+                        "opcode": "operator_equals",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            {
+                              "opcode": "motion_xposition"
+                            },
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "0  "
+                            ]
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass go to sprite found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail go to sprite not found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_pointtowards",
+            "inputs": {
+              "TOWARDS": [
+                3,
+                {
+                  "opcode": "operator_round",
+                  "inputs": {
+                    "NUM": [
+                      3,
+                      [
+                        12,
+                        "num",
+                        "var:num"
+                      ],
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "opcode": "motion_pointtowards_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TOWARDS": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "motion_direction"
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        " -90"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass point towards sprite found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail point towards sprite not found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "sensing_of",
+                        "fields": {
+                          "PROPERTY": [
+                            "x position"
+                          ]
+                        },
+                        "inputs": {
+                          "OBJECT": [
+                            3,
+                            {
+                              "opcode": "operator_round",
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  [
+                                    12,
+                                    "num",
+                                    "var:num"
+                                  ],
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            {
+                              "opcode": "sensing_of_object_menu",
+                              "shadow": true,
+                              "fields": {
+                                "OBJECT": [
+                                  "_stage_"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "-140"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass x position of sprite found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "fail x position of sprite not found"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                3,
+                {
+                  "opcode": "operator_round",
+                  "inputs": {
+                    "NUM": [
+                      3,
+                      [
+                        12,
+                        "num",
+                        "var:num"
+                      ],
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 3,
+      "costumes": [
+        {
+          "name": "ballerina-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "c88bb0420ea499d07bdfa8c8c61931f9",
+          "md5ext": "c88bb0420ea499d07bdfa8c8c61931f9.svg",
+          "rotationCenterX": 75,
+          "rotationCenterY": 75
+        },
+        {
+          "name": "ballerina-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "27eaf57ec9d15cd17439e17985a747a7",
+          "md5ext": "27eaf57ec9d15cd17439e17985a747a7.svg",
+          "rotationCenterX": 75,
+          "rotationCenterY": 75
+        },
+        {
+          "name": "ballerina-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "21b923819484ba50609050840961d0fa",
+          "md5ext": "21b923819484ba50609050840961d0fa.svg",
+          "rotationCenterX": 75,
+          "rotationCenterY": 75
+        },
+        {
+          "name": "ballerina-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "d7e6d564a5043b549385ea27fc305246",
+          "md5ext": "d7e6d564a5043b549385ea27fc305246.svg",
+          "rotationCenterX": 75,
+          "rotationCenterY": 75
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -140,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "control_start_as_clone"
+          },
+          {
+            "opcode": "control_if",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_equals",
+                  "inputs": {
+                    "OPERAND1": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "1"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_say",
+                    "inputs": {
+                      "MESSAGE": [
+                        1,
+                        [
+                          10,
+                          "pass create clone of sprite"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_say",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "end"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  -140
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"num\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "num"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/hat-execution-order.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/hat-execution-order.sb2.json
@@ -1,0 +1,279 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {
+        "list:results": [
+          "results",
+          []
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "results",
+                "list:results"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "stage"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "d36f6603ec293d2c2198d3ea05109fe0",
+          "md5ext": "d36f6603ec293d2c2198d3ea05109fe0.png",
+          "rotationCenterX": 0,
+          "rotationCenterY": 0
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 54,
+      "y": 19,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "results",
+                "list:results"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "1"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite2",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "d36f6603ec293d2c2198d3ea05109fe0",
+          "md5ext": "d36f6603ec293d2c2198d3ea05109fe0.png",
+          "rotationCenterX": 0,
+          "rotationCenterY": 0
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -15,
+      "y": -35,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "results",
+                "list:results"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "2"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite3",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "d36f6603ec293d2c2198d3ea05109fe0",
+          "md5ext": "d36f6603ec293d2c2198d3ea05109fe0.png",
+          "rotationCenterX": 0,
+          "rotationCenterY": 0
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -84,
+      "y": 46,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "results",
+                "list:results"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"results\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "results"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 104,
+      "height": 204,
+      "x": 5,
+      "y": 5,
+      "visible": false
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/invisible-tempo-monitor-no-other-music-blocks.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/invisible-tempo-monitor-no-other-music-blocks.sb2.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 120,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/invisible-video-monitor.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/invisible-video-monitor.sb2.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/list-monitor-rename.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/list-monitor-rename.sb3.json
@@ -1,0 +1,138 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {
+        "list:renamed global": [
+          "renamed global",
+          []
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {
+        "list:renamed local": [
+          "renamed local",
+          []
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a88da48fdc30493c5cc24089f645eb58",
+          "md5ext": "a88da48fdc30493c5cc24089f645eb58.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a1508ade4cfe8563ec1a148071e609d9",
+          "md5ext": "a1508ade4cfe8563ec1a148071e609d9.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"renamed global\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "renamed global"
+      },
+      "spriteName": null,
+      "value": [],
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 5,
+      "visible": true
+    },
+    {
+      "id": "Sprite1_data_listcontents_{\"LIST\":\"renamed local\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "renamed local"
+      },
+      "spriteName": "Sprite1",
+      "value": [],
+      "width": 0,
+      "height": 0,
+      "x": 155,
+      "y": 5,
+      "visible": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/ev3-simple-project.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/ev3-simple-project.sb3.json
@@ -1,0 +1,105 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "ev3"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "ev3_getDistance"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/microbit-simple-project.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/microbit-simple-project.sb3.json
@@ -1,0 +1,114 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "microbit"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "microbit_displayText",
+            "inputs": {
+              "TEXT": [
+                1,
+                [
+                  10,
+                  "Hello!"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/music-simple-project.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/music-simple-project.sb2.json
@@ -1,0 +1,122 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "music"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "music_playDrumForBeats",
+            "inputs": {
+              "DRUM": [
+                1,
+                {
+                  "opcode": "music_menu_DRUM",
+                  "shadow": true,
+                  "fields": {
+                    "DRUM": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "BEATS": [
+                1,
+                [
+                  4,
+                  0.25
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/music-simple-project.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/music-simple-project.sb3.json
@@ -1,0 +1,126 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "music"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "music_playDrumForBeats",
+            "inputs": {
+              "DRUM": [
+                1,
+                {
+                  "opcode": "music_menu_DRUM",
+                  "shadow": true,
+                  "fields": {
+                    "DRUM": [
+                      "1"
+                    ]
+                  }
+                }
+              ],
+              "BEATS": [
+                1,
+                [
+                  4,
+                  "0.25"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-dolphin-3d.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-dolphin-3d.sb2.json
@@ -1,0 +1,5309 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "pen"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:i": "initialize",
+        "broadcast:p": "position camera",
+        "broadcast:d": "draw frame",
+        "broadcast:s": "show preview"
+      },
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "blank",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "preview",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "7bd9467ddeadae49b4da02d13aa98702",
+          "md5ext": "7bd9467ddeadae49b4da02d13aa98702.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "320839__thoribass__soundscape1-freesound",
+          "assetId": "e334982c8d4d30ae15092ff03a3961a7",
+          "dataFormat": "wav",
+          "format": "adpcm",
+          "rate": 22050,
+          "sampleCount": 3178496,
+          "md5ext": "e334982c8d4d30ae15092ff03a3961a7.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "blank"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "initialize",
+                  "broadcast:i"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "event_broadcastandwait",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "position camera",
+                          "broadcast:p"
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "event_broadcastandwait",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "draw frame",
+                          "broadcast:d"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "sound_playuntildone",
+                    "inputs": {
+                      "SOUND_MENU": [
+                        1,
+                        {
+                          "opcode": "sound_sounds_menu",
+                          "shadow": true,
+                          "fields": {
+                            "SOUND_MENU": [
+                              "320839__thoribass__soundscape1-freesound"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "preview"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "show preview",
+                  "broadcast:s"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Pen",
+      "variables": {
+        "var:x": [
+          "x",
+          -40
+        ],
+        "var:y": [
+          "y",
+          80
+        ],
+        "var:z": [
+          "z",
+          -40
+        ],
+        "var:phase": [
+          "phase",
+          180
+        ],
+        "var:dir": [
+          "dir",
+          "0"
+        ],
+        "var:amplitude": [
+          "amplitude",
+          "20"
+        ],
+        "var:period": [
+          "period",
+          "3"
+        ],
+        "var:i": [
+          "i",
+          29
+        ],
+        "var:zoom": [
+          "zoom",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "underwater",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "f957e718a223c57572f5baa322842647",
+          "md5ext": "f957e718a223c57572f5baa322842647.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": -130.6763685642264,
+      "y": -64.36498910271536,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "initialize",
+                "broadcast:i"
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          },
+          {
+            "opcode": "pen_setPenColorToColor",
+            "inputs": {
+              "COLOR": [
+                1,
+                [
+                  9,
+                  "#135b8d"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "0"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "period",
+                "var:period"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "amplitude",
+                "var:amplitude"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint frame",
+                    "argumentnames": "[]",
+                    "warp": true
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "paint background"
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-40"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "phase",
+                "var:phase"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "240"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  3
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                360
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_divide",
+                                "inputs": {
+                                  "NUM1": [
+                                    3,
+                                    {
+                                      "opcode": "sensing_timer"
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ],
+                                  "NUM2": [
+                                    3,
+                                    [
+                                      12,
+                                      "period",
+                                      "var:period"
+                                    ],
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "paint dolphin %n"
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "x",
+                        "var:x"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "y",
+                        "var:y"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          40
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "z",
+                        "var:z"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "phase",
+                        "var:phase"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "flat go to %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"size\",\"multiplier\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_and",
+                  "inputs": {
+                    "OPERAND1": [
+                      2,
+                      {
+                        "opcode": "operator_gt",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "size"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "multiplier"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "0"
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "OPERAND2": [
+                      2,
+                      {
+                        "opcode": "operator_lt",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "multiplier"
+                                ]
+                              }
+                            },
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "32"
+                            ]
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "pen_setPenSizeTo",
+                    "inputs": {
+                      "SIZE": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "size"
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "multiplier"
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_penDown"
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "pen_penUp"
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "x"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "multiplier"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "Y": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "y"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "multiplier"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "rotated go to %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"z\",\"size\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "x"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "y"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "cos"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "z"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "size"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                3,
+                {
+                  "opcode": "operator_divide",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "sensing_of",
+                        "fields": {
+                          "PROPERTY": [
+                            "zoom"
+                          ]
+                        },
+                        "inputs": {
+                          "OBJECT": [
+                            1,
+                            {
+                              "opcode": "sensing_of_object_menu",
+                              "shadow": true,
+                              "fields": {
+                                "OBJECT": [
+                                  "Camera"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "sensing_of",
+                                          "fields": {
+                                            "PROPERTY": [
+                                              "dir"
+                                            ]
+                                          },
+                                          "inputs": {
+                                            "OBJECT": [
+                                              1,
+                                              {
+                                                "opcode": "sensing_of_object_menu",
+                                                "shadow": true,
+                                                "fields": {
+                                                  "OBJECT": [
+                                                    "Camera"
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "sensing_of",
+                                          "fields": {
+                                            "PROPERTY": [
+                                              "dir"
+                                            ]
+                                          },
+                                          "inputs": {
+                                            "OBJECT": [
+                                              1,
+                                              {
+                                                "opcode": "sensing_of_object_menu",
+                                                "shadow": true,
+                                                "fields": {
+                                                  "OBJECT": [
+                                                    "Camera"
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "flat go to %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "go to %n %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"z\",\"size\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "x",
+                              "var:x"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "sensing_of",
+                              "fields": {
+                                "PROPERTY": [
+                                  "x"
+                                ]
+                              },
+                              "inputs": {
+                                "OBJECT": [
+                                  1,
+                                  {
+                                    "opcode": "sensing_of_object_menu",
+                                    "shadow": true,
+                                    "fields": {
+                                      "OBJECT": [
+                                        "Camera"
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "y",
+                              "var:y"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "sensing_of",
+                              "fields": {
+                                "PROPERTY": [
+                                  "y"
+                                ]
+                              },
+                              "inputs": {
+                                "OBJECT": [
+                                  1,
+                                  {
+                                    "opcode": "sensing_of_object_menu",
+                                    "shadow": true,
+                                    "fields": {
+                                      "OBJECT": [
+                                        "Camera"
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_subtract",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  [
+                                    12,
+                                    "z",
+                                    "var:z"
+                                  ],
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "z"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "z"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "amplitude",
+                              "var:amplitude"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "operator_add",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        {
+                                          "opcode": "operator_add",
+                                          "inputs": {
+                                            "NUM1": [
+                                              3,
+                                              [
+                                                12,
+                                                "phase",
+                                                "var:phase"
+                                              ],
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ],
+                                            "NUM2": [
+                                              3,
+                                              {
+                                                "opcode": "argument_reporter_string_number",
+                                                "fields": {
+                                                  "VALUE": [
+                                                    "x"
+                                                  ]
+                                                }
+                                              },
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        3,
+                                        {
+                                          "opcode": "argument_reporter_string_number",
+                                          "fields": {
+                                            "VALUE": [
+                                              "wave"
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "size"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "rotated go to %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint body %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-61"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  90
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        [
+                          12,
+                          "i",
+                          "var:i"
+                        ],
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input3": [
+                        3,
+                        {
+                          "opcode": "operator_subtract",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_multiply",
+                                "inputs": {
+                                  "NUM1": [
+                                    1,
+                                    [
+                                      4,
+                                      8
+                                    ]
+                                  ],
+                                  "NUM2": [
+                                    3,
+                                    {
+                                      "opcode": "operator_mathop",
+                                      "fields": {
+                                        "OPERATOR": [
+                                          "cos"
+                                        ]
+                                      },
+                                      "inputs": {
+                                        "NUM": [
+                                          3,
+                                          {
+                                            "opcode": "operator_subtract",
+                                            "inputs": {
+                                              "NUM1": [
+                                                3,
+                                                {
+                                                  "opcode": "operator_multiply",
+                                                  "inputs": {
+                                                    "NUM1": [
+                                                      1,
+                                                      [
+                                                        4,
+                                                        40
+                                                      ]
+                                                    ],
+                                                    "NUM2": [
+                                                      3,
+                                                      {
+                                                        "opcode": "operator_mathop",
+                                                        "fields": {
+                                                          "OPERATOR": [
+                                                            "sqrt"
+                                                          ]
+                                                        },
+                                                        "inputs": {
+                                                          "NUM": [
+                                                            3,
+                                                            {
+                                                              "opcode": "operator_subtract",
+                                                              "inputs": {
+                                                                "NUM1": [
+                                                                  1,
+                                                                  [
+                                                                    4,
+                                                                    30
+                                                                  ]
+                                                                ],
+                                                                "NUM2": [
+                                                                  3,
+                                                                  [
+                                                                    12,
+                                                                    "i",
+                                                                    "var:i"
+                                                                  ],
+                                                                  [
+                                                                    4,
+                                                                    10
+                                                                  ]
+                                                                ]
+                                                              }
+                                                            },
+                                                            [
+                                                              4,
+                                                              10
+                                                            ]
+                                                          ]
+                                                        }
+                                                      },
+                                                      [
+                                                        4,
+                                                        10
+                                                      ]
+                                                    ]
+                                                  }
+                                                },
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ],
+                                              "NUM2": [
+                                                1,
+                                                [
+                                                  4,
+                                                  36
+                                                ]
+                                              ]
+                                            }
+                                          },
+                                          [
+                                            4,
+                                            10
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint flippers %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "8"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw diagonally for flipper %n %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          11
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw diagonally for flipper %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "draw diagonally for flipper %n %n %n",
+                    "argumentnames": "[\"y\",\"z\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      [
+                        12,
+                        "i",
+                        "var:i"
+                      ],
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        15
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "y"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    4
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_subtract",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        [
+                                          12,
+                                          "i",
+                                          "var:i"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        1,
+                                        [
+                                          4,
+                                          9
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "z"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    4
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_subtract",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        [
+                                          12,
+                                          "i",
+                                          "var:i"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        1,
+                                        [
+                                          4,
+                                          9
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  2
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint dorsal fin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-13"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  12
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        [
+                          12,
+                          "i",
+                          "var:i"
+                        ],
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input3": [
+                        1,
+                        [
+                          4,
+                          2
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "operator_subtract",
+                          "inputs": {
+                            "NUM1": [
+                              3,
+                              [
+                                12,
+                                "i",
+                                "var:i"
+                              ],
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              1,
+                              [
+                                4,
+                                15
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                12
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_mathop",
+                                "fields": {
+                                  "OPERATOR": [
+                                    "cos"
+                                  ]
+                                },
+                                "inputs": {
+                                  "NUM": [
+                                    3,
+                                    {
+                                      "opcode": "operator_multiply",
+                                      "inputs": {
+                                        "NUM1": [
+                                          1,
+                                          [
+                                            4,
+                                            4
+                                          ]
+                                        ],
+                                        "NUM2": [
+                                          3,
+                                          {
+                                            "opcode": "operator_add",
+                                            "inputs": {
+                                              "NUM1": [
+                                                3,
+                                                [
+                                                  12,
+                                                  "i",
+                                                  "var:i"
+                                                ],
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ],
+                                              "NUM2": [
+                                                1,
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ]
+                                            }
+                                          },
+                                          [
+                                            4,
+                                            10
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input3": [
+                        1,
+                        [
+                          4,
+                          2
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint tail fin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-62"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          12
+                        ]
+                      ],
+                      "input1": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw horizontally for fluke %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          -12
+                        ]
+                      ],
+                      "input1": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw horizontally for fluke %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "draw horizontally for fluke %n %n",
+                    "argumentnames": "[\"span\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  -63
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "span"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            1,
+                            [
+                              4,
+                              1
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "abs"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "operator_multiply",
+                                          "inputs": {
+                                            "NUM1": [
+                                              1,
+                                              [
+                                                4,
+                                                8
+                                              ]
+                                            ],
+                                            "NUM2": [
+                                              3,
+                                              {
+                                                "opcode": "operator_add",
+                                                "inputs": {
+                                                  "NUM1": [
+                                                    3,
+                                                    [
+                                                      12,
+                                                      "i",
+                                                      "var:i"
+                                                    ],
+                                                    [
+                                                      4,
+                                                      10
+                                                    ]
+                                                  ],
+                                                  "NUM2": [
+                                                    1,
+                                                    [
+                                                      4,
+                                                      55.25
+                                                    ]
+                                                  ]
+                                                }
+                                              },
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  2
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint dolphin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint tail fin %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint dorsal fin %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint flippers %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint body %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint background",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "pen_penUp"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                3,
+                {
+                  "opcode": "operator_mod",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "zoom"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_divide",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    3.1416
+                                  ]
+                                ],
+                                "NUM2": [
+                                  1,
+                                  [
+                                    4,
+                                    180
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        460
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_stamp"
+          },
+          {
+            "opcode": "motion_changexby",
+            "inputs": {
+              "DX": [
+                1,
+                [
+                  4,
+                  -460
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_stamp"
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "draw frame",
+                "broadcast:d"
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "paint frame"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Camera",
+      "variables": {
+        "var:x": [
+          "x",
+          -149.42692070582703
+        ],
+        "var:y": [
+          "y",
+          13.099441529106574
+        ],
+        "var:z": [
+          "z",
+          "0"
+        ],
+        "var:dir": [
+          "dir",
+          354.99
+        ],
+        "var:zoom": [
+          "zoom",
+          "500"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "empty",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 0,
+          "rotationCenterY": 0
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "initialize",
+                "broadcast:i"
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "zoom",
+                "var:zoom"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "500"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "position camera %n",
+                    "argumentnames": "[\"time\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "time"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "20"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "time"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "rush from behind %n"
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "time"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -150
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "circle around %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "position camera",
+                "broadcast:p"
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "sensing_timer"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "position camera %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "rush from behind %n",
+                    "argumentnames": "[\"time\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        20
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_divide",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "time"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            1,
+                            [
+                              4,
+                              2
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        -120
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "time"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            1,
+                            [
+                              4,
+                              8
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-20"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "circle around %n %n",
+                    "argumentnames": "[\"time\",\"distance\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "time"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "distance"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            [
+                              12,
+                              "dir",
+                              "var:dir"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "distance"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "sin"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            [
+                              12,
+                              "dir",
+                              "var:dir"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "0"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Title",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "Dolphins",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "c956278c6d9cdae7a196b7910b7ed232",
+          "md5ext": "c956278c6d9cdae7a196b7910b7ed232.png",
+          "rotationCenterX": 354,
+          "rotationCenterY": -84
+        },
+        {
+          "name": "HeldLaw presents",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "fb3b01d2a9901ca2b143f15c7981cdc2",
+          "md5ext": "fb3b01d2a9901ca2b143f15c7981cdc2.svg",
+          "rotationCenterX": 218,
+          "rotationCenterY": 145
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "ghost"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "HeldLaw presents"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_show"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  1.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade in"
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  3.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade out"
+            }
+          },
+          {
+            "opcode": "control_wait_until",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_gt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "sensing_timer"
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "11.5"
+                      ]
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "Dolphins"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade in"
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  4
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade out"
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade in",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          -10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade out",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  25
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          4
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Trivia",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "species",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "d8c8e4c6d380cc066db4c11d92d64b29",
+          "md5ext": "d8c8e4c6d380cc066db4c11d92d64b29.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "river dolphins",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "74539915e63cb56125f0228532c60a49",
+          "md5ext": "74539915e63cb56125f0228532c60a49.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "mammals",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "72e631dc8de12e2f99dd567f955543c2",
+          "md5ext": "72e631dc8de12e2f99dd567f955543c2.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "blowhole",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "8e208cc99c9e6fcf4b8118b562ab9ec6",
+          "md5ext": "8e208cc99c9e6fcf4b8118b562ab9ec6.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "hold breath",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4f4d04c25729c13251e602253421cee3",
+          "md5ext": "4f4d04c25729c13251e602253421cee3.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "bulls cows",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "201d5c8e5e19944f28737d74a931c93c",
+          "md5ext": "201d5c8e5e19944f28737d74a931c93c.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "intelligent",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "d74ecbeda818424c3a0d8ae9c29043a2",
+          "md5ext": "d74ecbeda818424c3a0d8ae9c29043a2.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "social",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "36160c27141dbc73ce4ffff5cac581d0",
+          "md5ext": "36160c27141dbc73ce4ffff5cac581d0.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "communicate",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "39c1390bd3f9be1f638987721082536a",
+          "md5ext": "39c1390bd3f9be1f638987721082536a.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "nonverbal",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "19cc26b886720acab6ca5de4510914f9",
+          "md5ext": "19cc26b886720acab6ca5de4510914f9.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "endangered",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "ed491c1edcfec015eb6e0d9234cdc4e5",
+          "md5ext": "ed491c1edcfec015eb6e0d9234cdc4e5.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_hide"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "ghost"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "species"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  24
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_show"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          2
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "mutation": {
+                      "proccode": "fade in"
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "mutation": {
+                      "proccode": "fade out"
+                    }
+                  },
+                  {
+                    "opcode": "looks_nextcostume"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade in",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          -10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade out",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  25
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          4
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_sensing_timer_{}",
+      "mode": "default",
+      "opcode": "sensing_timer",
+      "params": {},
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 221,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Camera_data_variable_{\"VARIABLE\":\"dir\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "dir"
+      },
+      "spriteName": "Camera",
+      "value": "",
+      "x": 268,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Camera_data_variable_{\"VARIABLE\":\"x\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "x"
+      },
+      "spriteName": "Camera",
+      "value": "",
+      "x": 5,
+      "y": 275,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Camera_data_variable_{\"VARIABLE\":\"y\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "y"
+      },
+      "spriteName": "Camera",
+      "value": "",
+      "x": 5,
+      "y": 302,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Camera_data_variable_{\"VARIABLE\":\"z\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "z"
+      },
+      "spriteName": "Camera",
+      "value": "",
+      "x": 127,
+      "y": 32,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Camera_data_variable_{\"VARIABLE\":\"zoom\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "zoom"
+      },
+      "spriteName": "Camera",
+      "value": "",
+      "x": 5,
+      "y": 194,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"amplitude\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "amplitude"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 113,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"dir\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "dir"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 86,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"i\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "i"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 248,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"period\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "period"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 167,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"phase\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "phase"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 140,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"x\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "x"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"y\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "y"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Pen_data_variable_{\"VARIABLE\":\"z\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "z"
+      },
+      "spriteName": "Pen",
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-dolphin-3d.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-dolphin-3d.sb3.json
@@ -1,0 +1,5086 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "pen"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:i": "initialize",
+        "broadcast:p": "position camera",
+        "broadcast:d": "draw frame",
+        "broadcast:s": "show preview"
+      },
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "blank",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "preview",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "7bd9467ddeadae49b4da02d13aa98702",
+          "md5ext": "7bd9467ddeadae49b4da02d13aa98702.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "320839__thoribass__soundscape1-freesound",
+          "assetId": "e334982c8d4d30ae15092ff03a3961a7",
+          "dataFormat": "wav",
+          "format": "adpcm",
+          "rate": 22050,
+          "sampleCount": 3176017,
+          "md5ext": "e334982c8d4d30ae15092ff03a3961a7.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "blank"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcastandwait",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "initialize",
+                  "broadcast:i"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "event_broadcastandwait",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "position camera",
+                          "broadcast:p"
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "event_broadcastandwait",
+                    "inputs": {
+                      "BROADCAST_INPUT": [
+                        1,
+                        [
+                          11,
+                          "draw frame",
+                          "broadcast:d"
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "sound_playuntildone",
+                    "inputs": {
+                      "SOUND_MENU": [
+                        1,
+                        {
+                          "opcode": "sound_sounds_menu",
+                          "shadow": true,
+                          "fields": {
+                            "SOUND_MENU": [
+                              "320839__thoribass__soundscape1-freesound"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "preview"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "show preview",
+                  "broadcast:s"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Pen",
+      "variables": {
+        "var:x": [
+          "x",
+          -40
+        ],
+        "var:y": [
+          "y",
+          80
+        ],
+        "var:z": [
+          "z",
+          -40
+        ],
+        "var:phase": [
+          "phase",
+          180
+        ],
+        "var:dir": [
+          "dir",
+          "0"
+        ],
+        "var:amplitude": [
+          "amplitude",
+          "20"
+        ],
+        "var:period": [
+          "period",
+          "3"
+        ],
+        "var:i": [
+          "i",
+          29
+        ],
+        "var:zoom": [
+          "zoom",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "underwater",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "f957e718a223c57572f5baa322842647",
+          "md5ext": "f957e718a223c57572f5baa322842647.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": -130.67636857,
+      "y": -41.81574809,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "initialize",
+                "broadcast:i"
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          },
+          {
+            "opcode": "pen_setPenColorToColor",
+            "inputs": {
+              "COLOR": [
+                1,
+                [
+                  9,
+                  "#135b8d"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "0"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "period",
+                "var:period"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "3"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "amplitude",
+                "var:amplitude"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint frame",
+                    "argumentnames": "[]",
+                    "warp": true
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "paint background"
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-40"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "phase",
+                "var:phase"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "240"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  3
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                360
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_divide",
+                                "inputs": {
+                                  "NUM1": [
+                                    3,
+                                    {
+                                      "opcode": "sensing_timer"
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ],
+                                  "NUM2": [
+                                    3,
+                                    [
+                                      12,
+                                      "period",
+                                      "var:period"
+                                    ],
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "paint dolphin %n"
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "x",
+                        "var:x"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "y",
+                        "var:y"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          40
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "z",
+                        "var:z"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "phase",
+                        "var:phase"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          -20
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "flat go to %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"size\",\"multiplier\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_and",
+                  "inputs": {
+                    "OPERAND1": [
+                      2,
+                      {
+                        "opcode": "operator_gt",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "size"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "multiplier"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "0"
+                            ]
+                          ]
+                        }
+                      }
+                    ],
+                    "OPERAND2": [
+                      2,
+                      {
+                        "opcode": "operator_lt",
+                        "inputs": {
+                          "OPERAND1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "multiplier"
+                                ]
+                              }
+                            },
+                            [
+                              10,
+                              ""
+                            ]
+                          ],
+                          "OPERAND2": [
+                            1,
+                            [
+                              10,
+                              "32"
+                            ]
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "pen_setPenSizeTo",
+                    "inputs": {
+                      "SIZE": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "size"
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "argument_reporter_string_number",
+                                "fields": {
+                                  "VALUE": [
+                                    "multiplier"
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_penDown"
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "pen_penUp"
+                  }
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "x"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "multiplier"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "Y": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "y"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "multiplier"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "rotated go to %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"z\",\"size\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "x"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "y"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "cos"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "z"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "size"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                3,
+                {
+                  "opcode": "operator_divide",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "sensing_of",
+                        "fields": {
+                          "PROPERTY": [
+                            "zoom"
+                          ]
+                        },
+                        "inputs": {
+                          "OBJECT": [
+                            1,
+                            {
+                              "opcode": "sensing_of_object_menu",
+                              "shadow": true,
+                              "fields": {
+                                "OBJECT": [
+                                  "Camera"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "sensing_of",
+                                          "fields": {
+                                            "PROPERTY": [
+                                              "dir"
+                                            ]
+                                          },
+                                          "inputs": {
+                                            "OBJECT": [
+                                              1,
+                                              {
+                                                "opcode": "sensing_of_object_menu",
+                                                "shadow": true,
+                                                "fields": {
+                                                  "OBJECT": [
+                                                    "Camera"
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "sensing_of",
+                                          "fields": {
+                                            "PROPERTY": [
+                                              "dir"
+                                            ]
+                                          },
+                                          "inputs": {
+                                            "OBJECT": [
+                                              1,
+                                              {
+                                                "opcode": "sensing_of_object_menu",
+                                                "shadow": true,
+                                                "fields": {
+                                                  "OBJECT": [
+                                                    "Camera"
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "flat go to %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "go to %n %n %n %n %n",
+                    "argumentnames": "[\"x\",\"y\",\"z\",\"size\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "x",
+                              "var:x"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "sensing_of",
+                              "fields": {
+                                "PROPERTY": [
+                                  "x"
+                                ]
+                              },
+                              "inputs": {
+                                "OBJECT": [
+                                  1,
+                                  {
+                                    "opcode": "sensing_of_object_menu",
+                                    "shadow": true,
+                                    "fields": {
+                                      "OBJECT": [
+                                        "Camera"
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "y",
+                              "var:y"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "sensing_of",
+                              "fields": {
+                                "PROPERTY": [
+                                  "y"
+                                ]
+                              },
+                              "inputs": {
+                                "OBJECT": [
+                                  1,
+                                  {
+                                    "opcode": "sensing_of_object_menu",
+                                    "shadow": true,
+                                    "fields": {
+                                      "OBJECT": [
+                                        "Camera"
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "y"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "cos"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "argument_reporter_string_number",
+                                    "fields": {
+                                      "VALUE": [
+                                        "x"
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "sin"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        [
+                                          12,
+                                          "dir",
+                                          "var:dir"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_add",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_subtract",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  [
+                                    12,
+                                    "z",
+                                    "var:z"
+                                  ],
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "z"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "z"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            [
+                              12,
+                              "amplitude",
+                              "var:amplitude"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "operator_add",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        {
+                                          "opcode": "operator_add",
+                                          "inputs": {
+                                            "NUM1": [
+                                              3,
+                                              [
+                                                12,
+                                                "phase",
+                                                "var:phase"
+                                              ],
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ],
+                                            "NUM2": [
+                                              3,
+                                              {
+                                                "opcode": "argument_reporter_string_number",
+                                                "fields": {
+                                                  "VALUE": [
+                                                    "x"
+                                                  ]
+                                                }
+                                              },
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        3,
+                                        {
+                                          "opcode": "argument_reporter_string_number",
+                                          "fields": {
+                                            "VALUE": [
+                                              "wave"
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "size"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "rotated go to %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint body %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-61"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  90
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        [
+                          12,
+                          "i",
+                          "var:i"
+                        ],
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input3": [
+                        3,
+                        {
+                          "opcode": "operator_subtract",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_multiply",
+                                "inputs": {
+                                  "NUM1": [
+                                    1,
+                                    [
+                                      4,
+                                      8
+                                    ]
+                                  ],
+                                  "NUM2": [
+                                    3,
+                                    {
+                                      "opcode": "operator_mathop",
+                                      "fields": {
+                                        "OPERATOR": [
+                                          "cos"
+                                        ]
+                                      },
+                                      "inputs": {
+                                        "NUM": [
+                                          3,
+                                          {
+                                            "opcode": "operator_subtract",
+                                            "inputs": {
+                                              "NUM1": [
+                                                3,
+                                                {
+                                                  "opcode": "operator_multiply",
+                                                  "inputs": {
+                                                    "NUM1": [
+                                                      1,
+                                                      [
+                                                        4,
+                                                        40
+                                                      ]
+                                                    ],
+                                                    "NUM2": [
+                                                      3,
+                                                      {
+                                                        "opcode": "operator_mathop",
+                                                        "fields": {
+                                                          "OPERATOR": [
+                                                            "sqrt"
+                                                          ]
+                                                        },
+                                                        "inputs": {
+                                                          "NUM": [
+                                                            3,
+                                                            {
+                                                              "opcode": "operator_subtract",
+                                                              "inputs": {
+                                                                "NUM1": [
+                                                                  1,
+                                                                  [
+                                                                    4,
+                                                                    30
+                                                                  ]
+                                                                ],
+                                                                "NUM2": [
+                                                                  3,
+                                                                  [
+                                                                    12,
+                                                                    "i",
+                                                                    "var:i"
+                                                                  ],
+                                                                  [
+                                                                    4,
+                                                                    10
+                                                                  ]
+                                                                ]
+                                                              }
+                                                            },
+                                                            [
+                                                              4,
+                                                              10
+                                                            ]
+                                                          ]
+                                                        }
+                                                      },
+                                                      [
+                                                        4,
+                                                        10
+                                                      ]
+                                                    ]
+                                                  }
+                                                },
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ],
+                                              "NUM2": [
+                                                1,
+                                                [
+                                                  4,
+                                                  36
+                                                ]
+                                              ]
+                                            }
+                                          },
+                                          [
+                                            4,
+                                            10
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint flippers %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "8"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw diagonally for flipper %n %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          11
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -11
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw diagonally for flipper %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "draw diagonally for flipper %n %n %n",
+                    "argumentnames": "[\"y\",\"z\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      [
+                        12,
+                        "i",
+                        "var:i"
+                      ],
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        15
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "y"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    4
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_subtract",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        [
+                                          12,
+                                          "i",
+                                          "var:i"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        1,
+                                        [
+                                          4,
+                                          9
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "z"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    4
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "operator_subtract",
+                                    "inputs": {
+                                      "NUM1": [
+                                        3,
+                                        [
+                                          12,
+                                          "i",
+                                          "var:i"
+                                        ],
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ],
+                                      "NUM2": [
+                                        1,
+                                        [
+                                          4,
+                                          9
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  2
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint dorsal fin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-13"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  12
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        [
+                          12,
+                          "i",
+                          "var:i"
+                        ],
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input3": [
+                        1,
+                        [
+                          4,
+                          2
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "operator_subtract",
+                          "inputs": {
+                            "NUM1": [
+                              3,
+                              [
+                                12,
+                                "i",
+                                "var:i"
+                              ],
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              1,
+                              [
+                                4,
+                                15
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          0
+                        ]
+                      ],
+                      "input2": [
+                        3,
+                        {
+                          "opcode": "operator_multiply",
+                          "inputs": {
+                            "NUM1": [
+                              1,
+                              [
+                                4,
+                                12
+                              ]
+                            ],
+                            "NUM2": [
+                              3,
+                              {
+                                "opcode": "operator_mathop",
+                                "fields": {
+                                  "OPERATOR": [
+                                    "cos"
+                                  ]
+                                },
+                                "inputs": {
+                                  "NUM": [
+                                    3,
+                                    {
+                                      "opcode": "operator_multiply",
+                                      "inputs": {
+                                        "NUM1": [
+                                          1,
+                                          [
+                                            4,
+                                            4
+                                          ]
+                                        ],
+                                        "NUM2": [
+                                          3,
+                                          {
+                                            "opcode": "operator_add",
+                                            "inputs": {
+                                              "NUM1": [
+                                                3,
+                                                [
+                                                  12,
+                                                  "i",
+                                                  "var:i"
+                                                ],
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ],
+                                              "NUM2": [
+                                                1,
+                                                [
+                                                  4,
+                                                  10
+                                                ]
+                                              ]
+                                            }
+                                          },
+                                          [
+                                            4,
+                                            10
+                                          ]
+                                        ]
+                                      }
+                                    },
+                                    [
+                                      4,
+                                      10
+                                    ]
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input3": [
+                        1,
+                        [
+                          4,
+                          2
+                        ]
+                      ],
+                      "input4": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "go to %n %n %n %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint tail fin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "i",
+                "var:i"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-62"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "data_changevariableby",
+                    "fields": {
+                      "VARIABLE": [
+                        "i",
+                        "var:i"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          12
+                        ]
+                      ],
+                      "input1": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw horizontally for fluke %n %n"
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        1,
+                        [
+                          4,
+                          -12
+                        ]
+                      ],
+                      "input1": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "wave"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "draw horizontally for fluke %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "draw horizontally for fluke %n %n",
+                    "argumentnames": "[\"span\",\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                [
+                  12,
+                  "i",
+                  "var:i"
+                ],
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input1": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  -63
+                ]
+              ],
+              "input1": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "span"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            1,
+                            [
+                              4,
+                              1
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_mathop",
+                              "fields": {
+                                "OPERATOR": [
+                                  "sin"
+                                ]
+                              },
+                              "inputs": {
+                                "NUM": [
+                                  3,
+                                  {
+                                    "opcode": "operator_mathop",
+                                    "fields": {
+                                      "OPERATOR": [
+                                        "abs"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "NUM": [
+                                        3,
+                                        {
+                                          "opcode": "operator_multiply",
+                                          "inputs": {
+                                            "NUM1": [
+                                              1,
+                                              [
+                                                4,
+                                                8
+                                              ]
+                                            ],
+                                            "NUM2": [
+                                              3,
+                                              {
+                                                "opcode": "operator_add",
+                                                "inputs": {
+                                                  "NUM1": [
+                                                    3,
+                                                    [
+                                                      12,
+                                                      "i",
+                                                      "var:i"
+                                                    ],
+                                                    [
+                                                      4,
+                                                      10
+                                                    ]
+                                                  ],
+                                                  "NUM2": [
+                                                    1,
+                                                    [
+                                                      4,
+                                                      55.25
+                                                    ]
+                                                  ]
+                                                }
+                                              },
+                                              [
+                                                4,
+                                                10
+                                              ]
+                                            ]
+                                          }
+                                        },
+                                        [
+                                          4,
+                                          10
+                                        ]
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "input2": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "input3": [
+                1,
+                [
+                  4,
+                  2
+                ]
+              ],
+              "input4": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "go to %n %n %n %n %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint dolphin %n",
+                    "argumentnames": "[\"wave\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint tail fin %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint dorsal fin %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint flippers %n"
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "wave"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "paint body %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "paint background",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "pen_penUp"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                3,
+                {
+                  "opcode": "operator_mod",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "operator_multiply",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "operator_multiply",
+                              "inputs": {
+                                "NUM1": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "zoom"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ],
+                                "NUM2": [
+                                  3,
+                                  {
+                                    "opcode": "sensing_of",
+                                    "fields": {
+                                      "PROPERTY": [
+                                        "dir"
+                                      ]
+                                    },
+                                    "inputs": {
+                                      "OBJECT": [
+                                        1,
+                                        {
+                                          "opcode": "sensing_of_object_menu",
+                                          "shadow": true,
+                                          "fields": {
+                                            "OBJECT": [
+                                              "Camera"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  [
+                                    4,
+                                    10
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            3,
+                            {
+                              "opcode": "operator_divide",
+                              "inputs": {
+                                "NUM1": [
+                                  1,
+                                  [
+                                    4,
+                                    3.1416
+                                  ]
+                                ],
+                                "NUM2": [
+                                  1,
+                                  [
+                                    4,
+                                    180
+                                  ]
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        460
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_stamp"
+          },
+          {
+            "opcode": "motion_changexby",
+            "inputs": {
+              "DX": [
+                1,
+                [
+                  4,
+                  -460
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_stamp"
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "draw frame",
+                "broadcast:d"
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "paint frame"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "pen_clear"
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Camera",
+      "variables": {
+        "var:x": [
+          "x",
+          -149.42692070582703
+        ],
+        "var:y": [
+          "y",
+          13.099441529106574
+        ],
+        "var:z": [
+          "z",
+          "0"
+        ],
+        "var:dir": [
+          "dir",
+          354.99
+        ],
+        "var:zoom": [
+          "zoom",
+          "500"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "empty",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "576aeb8905e0b5685794e01ca28d417a",
+          "md5ext": "576aeb8905e0b5685794e01ca28d417a.svg",
+          "rotationCenterX": 0,
+          "rotationCenterY": 0
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "initialize",
+                "broadcast:i"
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "zoom",
+                "var:zoom"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "500"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "position camera %n",
+                    "argumentnames": "[\"time\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_if_else",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_lt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "time"
+                          ]
+                        }
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "20"
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "time"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "rush from behind %n"
+                    }
+                  }
+                ]
+              ],
+              "SUBSTACK2": [
+                2,
+                [
+                  {
+                    "opcode": "procedures_call",
+                    "inputs": {
+                      "input0": [
+                        3,
+                        {
+                          "opcode": "argument_reporter_string_number",
+                          "fields": {
+                            "VALUE": [
+                              "time"
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "input1": [
+                        1,
+                        [
+                          4,
+                          -150
+                        ]
+                      ]
+                    },
+                    "mutation": {
+                      "proccode": "circle around %n %n"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "position camera",
+                "broadcast:p"
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                3,
+                {
+                  "opcode": "sensing_timer"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "position camera %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "rush from behind %n",
+                    "argumentnames": "[\"time\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_subtract",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        20
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_divide",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "time"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            1,
+                            [
+                              4,
+                              2
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        -120
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_subtract",
+                        "inputs": {
+                          "NUM1": [
+                            3,
+                            {
+                              "opcode": "argument_reporter_string_number",
+                              "fields": {
+                                "VALUE": [
+                                  "time"
+                                ]
+                              }
+                            },
+                            [
+                              4,
+                              10
+                            ]
+                          ],
+                          "NUM2": [
+                            1,
+                            [
+                              4,
+                              8
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-20"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "-20"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "circle around %n %n",
+                    "argumentnames": "[\"time\",\"distance\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "dir",
+                "var:dir"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "time"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "x",
+                "var:x"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "distance"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "cos"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            [
+                              12,
+                              "dir",
+                              "var:dir"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "y",
+                "var:y"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "operator_multiply",
+                  "inputs": {
+                    "NUM1": [
+                      3,
+                      {
+                        "opcode": "argument_reporter_string_number",
+                        "fields": {
+                          "VALUE": [
+                            "distance"
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ],
+                    "NUM2": [
+                      3,
+                      {
+                        "opcode": "operator_mathop",
+                        "fields": {
+                          "OPERATOR": [
+                            "sin"
+                          ]
+                        },
+                        "inputs": {
+                          "NUM": [
+                            3,
+                            [
+                              12,
+                              "dir",
+                              "var:dir"
+                            ],
+                            [
+                              4,
+                              10
+                            ]
+                          ]
+                        }
+                      },
+                      [
+                        4,
+                        10
+                      ]
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "z",
+                "var:z"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "0"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Title",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "Dolphins",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "c956278c6d9cdae7a196b7910b7ed232",
+          "md5ext": "c956278c6d9cdae7a196b7910b7ed232.png",
+          "rotationCenterX": 354,
+          "rotationCenterY": -84
+        },
+        {
+          "name": "HeldLaw presents",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "75af5e30018f0c7294349a0a21954743",
+          "md5ext": "75af5e30018f0c7294349a0a21954743.svg",
+          "rotationCenterX": 218,
+          "rotationCenterY": 145
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "ghost"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "HeldLaw presents"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_show"
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  1.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade in"
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  3.5
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade out"
+            }
+          },
+          {
+            "opcode": "control_wait_until",
+            "inputs": {
+              "CONDITION": [
+                2,
+                {
+                  "opcode": "operator_gt",
+                  "inputs": {
+                    "OPERAND1": [
+                      3,
+                      {
+                        "opcode": "sensing_timer"
+                      },
+                      [
+                        10,
+                        ""
+                      ]
+                    ],
+                    "OPERAND2": [
+                      1,
+                      [
+                        10,
+                        "11.5"
+                      ]
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "Dolphins"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade in"
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  4
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "fade out"
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade in",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          -10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade out",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  25
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          4
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Trivia",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "species",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9743a9355593b6e88c56ac9c87cbd7da",
+          "md5ext": "9743a9355593b6e88c56ac9c87cbd7da.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "river dolphins",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "cab4cf159421327aaa712ee323e0da4a",
+          "md5ext": "cab4cf159421327aaa712ee323e0da4a.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "mammals",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "26a0c311fa0b10405e8b336298b9a892",
+          "md5ext": "26a0c311fa0b10405e8b336298b9a892.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "blowhole",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "14457492310d5fd48fbf2590bfdbf58b",
+          "md5ext": "14457492310d5fd48fbf2590bfdbf58b.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "hold breath",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a82bb7f524502ebc66749152b481f575",
+          "md5ext": "a82bb7f524502ebc66749152b481f575.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "bulls cows",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "5e13271a5ab6489af473fa28e5c15190",
+          "md5ext": "5e13271a5ab6489af473fa28e5c15190.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "intelligent",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "30ba561d4deca607d7eba7be90dcffc0",
+          "md5ext": "30ba561d4deca607d7eba7be90dcffc0.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "social",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "7089040b78d5dbf418d61fc24a8f2522",
+          "md5ext": "7089040b78d5dbf418d61fc24a8f2522.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "communicate",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "3d5422711f3f046eb27792b26cc79ab4",
+          "md5ext": "3d5422711f3f046eb27792b26cc79ab4.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "nonverbal",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1edebcc018a1dc419811572faefde422",
+          "md5ext": "1edebcc018a1dc419811572faefde422.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        },
+        {
+          "name": "endangered",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "3920ee8046f686c0aed2c14f40f556dd",
+          "md5ext": "3920ee8046f686c0aed2c14f40f556dd.svg",
+          "rotationCenterX": 233,
+          "rotationCenterY": -125
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": false,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "don't rotate",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_hide"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "ghost"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "species"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_wait",
+            "inputs": {
+              "DURATION": [
+                1,
+                [
+                  5,
+                  24
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_show"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          2
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "mutation": {
+                      "proccode": "fade in"
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "procedures_call",
+                    "mutation": {
+                      "proccode": "fade out"
+                    }
+                  },
+                  {
+                    "opcode": "looks_nextcostume"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade in",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  10
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          -10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "fade out",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  25
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_changeeffectby",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "CHANGE": [
+                        1,
+                        [
+                          4,
+                          4
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_wait",
+                    "inputs": {
+                      "DURATION": [
+                        1,
+                        [
+                          5,
+                          0.033
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "show preview",
+                "broadcast:s"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_hide"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-simple-project.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-simple-project.sb2.json
@@ -1,0 +1,110 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "pen"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "pen_setPenSizeTo",
+            "inputs": {
+              "SIZE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-simple-project.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/pen-simple-project.sb3.json
@@ -1,0 +1,105 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "pen"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "pen_penDown"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/text2speech-simple-project.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/text2speech-simple-project.sb3.json
@@ -1,0 +1,114 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "text2speech"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": "en",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "text2speech_speakAndWait",
+            "inputs": {
+              "WORDS": [
+                1,
+                [
+                  10,
+                  "hello"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/wedo2-simple-project.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/load-extensions/confirm-load/wedo2-simple-project.sb2.json
@@ -1,0 +1,101 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "wedo2"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "wedo2_getDistance"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/looks.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/looks.sb2.json
@@ -1,0 +1,460 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:state": [
+          "state",
+          100
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        },
+        {
+          "name": "baseball-field",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "6b3d87ba2a7f89be703163b6c1d4c964",
+          "md5ext": "6b3d87ba2a7f89be703163b6c1d4c964.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "state",
+                "var:state"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "looks_costumenumbername",
+                  "fields": {
+                    "NUMBER_NAME": [
+                      "number"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "state",
+                "var:state"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "looks_backdropnumbername",
+                  "fields": {
+                    "NUMBER_NAME": [
+                      "name"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "state",
+                "var:state"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "looks_size"
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_hide"
+          },
+          {
+            "opcode": "looks_show"
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "costume2"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                1,
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      "costume1"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchcostumeto",
+            "inputs": {
+              "COSTUME": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        1
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        0
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "opcode": "looks_costume",
+                  "shadow": true,
+                  "fields": {
+                    "COSTUME": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_nextcostume"
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "backdrop1"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "next backdrop"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                1,
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      "previous backdrop"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_switchbackdropto",
+            "inputs": {
+              "BACKDROP": [
+                3,
+                {
+                  "opcode": "operator_add",
+                  "inputs": {
+                    "NUM1": [
+                      1,
+                      [
+                        4,
+                        1
+                      ]
+                    ],
+                    "NUM2": [
+                      1,
+                      [
+                        4,
+                        0
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "opcode": "looks_backdrops",
+                  "shadow": true,
+                  "fields": {
+                    "BACKDROP": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_changeeffectby",
+            "fields": {
+              "EFFECT": [
+                "color"
+              ]
+            },
+            "inputs": {
+              "CHANGE": [
+                1,
+                [
+                  4,
+                  25
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_seteffectto",
+            "fields": {
+              "EFFECT": [
+                "color"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_cleargraphiceffects"
+          },
+          {
+            "opcode": "looks_changesizeby",
+            "inputs": {
+              "CHANGE": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_setsizeto",
+            "inputs": {
+              "SIZE": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_gotofrontback",
+            "fields": {
+              "FRONT_BACK": [
+                "front"
+              ]
+            }
+          },
+          {
+            "opcode": "looks_goforwardbackwardlayers",
+            "fields": {
+              "FORWARD_BACKWARD": [
+                "backward"
+              ]
+            },
+            "inputs": {
+              "NUM": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"state\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "state"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitored_variables.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitored_variables.sb3.json
@@ -1,0 +1,228 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          "0"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Referee",
+      "variables": {
+        "var:refereevar1": [
+          "refereevar1",
+          "cat"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "referee-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "5e4389db3c5f5a39af0b0ac5b2d65271",
+          "md5ext": "5e4389db3c5f5a39af0b0ac5b2d65271.svg",
+          "rotationCenterX": 76,
+          "rotationCenterY": 68
+        },
+        {
+          "name": "referee-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "fcd39eb555891043f8083653ae87b976",
+          "md5ext": "fcd39eb555891043f8083653ae87b976.svg",
+          "rotationCenterX": 76,
+          "rotationCenterY": 68
+        },
+        {
+          "name": "referee-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "2b2251020e2144c3b16396ef9a4afe29",
+          "md5ext": "2b2251020e2144c3b16396ef9a4afe29.svg",
+          "rotationCenterX": 76,
+          "rotationCenterY": 68
+        },
+        {
+          "name": "referee-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "20bd21a62ba09f1d3f98dc8f72437ec8",
+          "md5ext": "20bd21a62ba09f1d3f98dc8f72437ec8.svg",
+          "rotationCenterX": 76,
+          "rotationCenterY": 68
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -140.43983402489627,
+      "y": 12.93922651933702,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Jamal",
+      "variables": {
+        "var:jamalvar": [
+          "jamalvar",
+          "12"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "jamal-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "29c4b1be0e00c7d95b4a86c9069e2698",
+          "md5ext": "29c4b1be0e00c7d95b4a86c9069e2698.svg",
+          "rotationCenterX": 82,
+          "rotationCenterY": 105
+        },
+        {
+          "name": "jamal-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "ab9a9c3249eba11f7c21edc62eddc13e",
+          "md5ext": "ab9a9c3249eba11f7c21edc62eddc13e.svg",
+          "rotationCenterX": 82,
+          "rotationCenterY": 105
+        },
+        {
+          "name": "jamal-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "96662d4e405d513800417e19875a7e20",
+          "md5ext": "96662d4e405d513800417e19875a7e20.svg",
+          "rotationCenterX": 82,
+          "rotationCenterY": 105
+        },
+        {
+          "name": "jamal-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "5c988632650bbfb2c9f5e354f4a224af",
+          "md5ext": "5c988632650bbfb2c9f5e354f4a224af.svg",
+          "rotationCenterX": 82,
+          "rotationCenterY": 105
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 56,
+      "y": 37,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "Jamal_data_variable_{\"VARIABLE\":\"jamalvar\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "jamalvar"
+      },
+      "spriteName": "Jamal",
+      "value": "12",
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Referee_data_variable_{\"VARIABLE\":\"refereevar1\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "refereevar1"
+      },
+      "spriteName": "Referee",
+      "value": "cat",
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 33,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitors.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitors.sb2.json
@@ -1,0 +1,254 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:global": [
+          "global",
+          -200
+        ]
+      },
+      "lists": {
+        "list:global list": [
+          "global list",
+          []
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {
+        "var:local": [
+          "local",
+          0
+        ]
+      },
+      "lists": {
+        "list:local list": [
+          "local list",
+          []
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"global list\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "global list"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 106,
+      "height": 206,
+      "x": 5,
+      "y": 140,
+      "visible": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"global\"}",
+      "mode": "slider",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "global"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 59,
+      "visible": true,
+      "sliderMin": -200,
+      "sliderMax": 30,
+      "isDiscrete": false
+    },
+    {
+      "id": "_looks_backdropnumbername_{\"NUMBER_NAME\":\"name\"}",
+      "mode": "default",
+      "opcode": "looks_backdropnumbername",
+      "params": {
+        "NUMBER_NAME": "name"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"DATE\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "DATE"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 365,
+      "y": 45,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"DAYOFWEEK\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "DAYOFWEEK"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 345,
+      "y": 83,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"MINUTE\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "MINUTE"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 365,
+      "y": 12,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite1_data_listcontents_{\"LIST\":\"local list\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "local list"
+      },
+      "spriteName": "Sprite1",
+      "value": "",
+      "width": 106,
+      "height": 206,
+      "x": 112,
+      "y": 140,
+      "visible": true
+    },
+    {
+      "id": "Sprite1_data_variable_{\"VARIABLE\":\"local\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "local"
+      },
+      "spriteName": "Sprite1",
+      "value": "",
+      "x": 5,
+      "y": 86,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Sprite1_motion_xposition_{}",
+      "mode": "large",
+      "opcode": "motion_xposition",
+      "params": {},
+      "spriteName": "Sprite1",
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitors.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/monitors.sb3.json
@@ -1,0 +1,516 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          "my"
+        ],
+        "var:secret_slide": [
+          "secret_slide",
+          81
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        },
+        {
+          "name": "School",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "1dea69ac0f62cf538d368a7bde1372ac",
+          "md5ext": "1dea69ac0f62cf538d368a7bde1372ac.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 120,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Shirt-T",
+      "variables": {
+        "var:tee": [
+          "tee",
+          60
+        ]
+      },
+      "lists": {
+        "list:fashion": [
+          "fashion",
+          [
+            "shirt",
+            "shoe",
+            "service"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "shirt-t",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "b87a27aadb562284f811f5983703cea4",
+          "md5ext": "b87a27aadb562284f811f5983703cea4.svg",
+          "rotationCenterX": 39,
+          "rotationCenterY": 28
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -220.22821868,
+      "y": -161.13259432,
+      "size": 30,
+      "direction": 40,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenkeypressed",
+            "fields": {
+              "KEY_OPTION": [
+                "space"
+              ]
+            }
+          },
+          {
+            "opcode": "data_showvariable",
+            "fields": {
+              "VARIABLE": [
+                "secret_slide",
+                "var:secret_slide"
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_hidevariable",
+            "fields": {
+              "VARIABLE": [
+                "secret_slide",
+                "var:secret_slide"
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Heart",
+      "variables": {
+        "var:hearty": [
+          "hearty",
+          "happy"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 1,
+      "costumes": [
+        {
+          "name": "heart red",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "08b7e67803155c071c968ab8dc8f1885",
+          "md5ext": "08b7e67803155c071c968ab8dc8f1885.svg",
+          "rotationCenterX": 65,
+          "rotationCenterY": 56
+        },
+        {
+          "name": "heart purple",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1faaf7ac9f66fe7aeea8ed18b9ca9e04",
+          "md5ext": "1faaf7ac9f66fe7aeea8ed18b9ca9e04.svg",
+          "rotationCenterX": 66,
+          "rotationCenterY": 62
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 165.29045643,
+      "y": -96.45303867,
+      "size": 60,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"my variable\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "my variable"
+      },
+      "spriteName": null,
+      "value": "my",
+      "width": 0,
+      "height": 0,
+      "x": 10,
+      "y": 62,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"secret_slide\"}",
+      "mode": "slider",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "secret_slide"
+      },
+      "spriteName": null,
+      "value": 81,
+      "width": 0,
+      "height": 0,
+      "x": 158,
+      "y": 217,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_ev3_getDistance_{}",
+      "mode": "default",
+      "opcode": "ev3_getDistance",
+      "params": {},
+      "spriteName": null,
+      "value": 0,
+      "width": 0,
+      "height": 0,
+      "x": 155,
+      "y": 102,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_looks_backdropnumbername_{\"NUMBER_NAME\":\"name\"}",
+      "mode": "default",
+      "opcode": "looks_backdropnumbername",
+      "params": {
+        "NUMBER_NAME": "name"
+      },
+      "spriteName": null,
+      "value": "School",
+      "width": 0,
+      "height": 0,
+      "x": 321,
+      "y": 74,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_looks_backdropnumbername_{\"NUMBER_NAME\":\"number\"}",
+      "mode": "default",
+      "opcode": "looks_backdropnumbername",
+      "params": {
+        "NUMBER_NAME": "number"
+      },
+      "spriteName": null,
+      "value": 2,
+      "width": 0,
+      "height": 0,
+      "x": 288,
+      "y": 22,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_music_getTempo_{}",
+      "mode": "default",
+      "opcode": "music_getTempo",
+      "params": {},
+      "spriteName": null,
+      "value": 120,
+      "width": 0,
+      "height": 0,
+      "x": 61,
+      "y": 242,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"DATE\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "DATE"
+      },
+      "spriteName": null,
+      "value": 9,
+      "width": 0,
+      "height": 0,
+      "x": 155,
+      "y": 61,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"MONTH\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "MONTH"
+      },
+      "spriteName": null,
+      "value": 11,
+      "width": 0,
+      "height": 0,
+      "x": 105,
+      "y": 34,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_sensing_current_{\"CURRENTMENU\":\"YEAR\"}",
+      "mode": "default",
+      "opcode": "sensing_current",
+      "params": {
+        "CURRENTMENU": "YEAR"
+      },
+      "spriteName": null,
+      "value": 2018,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 34,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Heart_data_variable_{\"VARIABLE\":\"hearty\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "hearty"
+      },
+      "spriteName": "Heart",
+      "value": "happy",
+      "width": 0,
+      "height": 0,
+      "x": 327,
+      "y": 204,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_data_listcontents_{\"LIST\":\"fashion\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "fashion"
+      },
+      "spriteName": "Shirt-T",
+      "value": [
+        "shirt",
+        "shoe",
+        "service"
+      ],
+      "width": 104,
+      "height": 122,
+      "x": 5,
+      "y": 90,
+      "visible": true
+    },
+    {
+      "id": "Shirt-T_data_variable_{\"VARIABLE\":\"tee\"}",
+      "mode": "slider",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "tee"
+      },
+      "spriteName": "Shirt-T",
+      "value": 60,
+      "width": 0,
+      "height": 0,
+      "x": 160,
+      "y": 158,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_looks_costumenumbername_{\"NUMBER_NAME\":\"name\"}",
+      "mode": "default",
+      "opcode": "looks_costumenumbername",
+      "params": {
+        "NUMBER_NAME": "name"
+      },
+      "spriteName": "Shirt-T",
+      "value": "shirt-t",
+      "width": 0,
+      "height": 0,
+      "x": 134,
+      "y": 294,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_looks_costumenumbername_{\"NUMBER_NAME\":\"number\"}",
+      "mode": "default",
+      "opcode": "looks_costumenumbername",
+      "params": {
+        "NUMBER_NAME": "number"
+      },
+      "spriteName": "Shirt-T",
+      "value": 1,
+      "width": 0,
+      "height": 0,
+      "x": 93,
+      "y": 325,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_looks_size_{}",
+      "mode": "large",
+      "opcode": "looks_size",
+      "params": {},
+      "spriteName": "Shirt-T",
+      "value": 30,
+      "width": 0,
+      "height": 0,
+      "x": 34,
+      "y": 328,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_motion_direction_{}",
+      "mode": "large",
+      "opcode": "motion_direction",
+      "params": {},
+      "spriteName": "Shirt-T",
+      "value": 40,
+      "width": 0,
+      "height": 0,
+      "x": 219,
+      "y": 4,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_motion_xposition_{}",
+      "mode": "large",
+      "opcode": "motion_xposition",
+      "params": {},
+      "spriteName": "Shirt-T",
+      "value": -220.22821868,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Shirt-T_motion_yposition_{}",
+      "mode": "large",
+      "opcode": "motion_yposition",
+      "params": {},
+      "spriteName": "Shirt-T",
+      "value": -161.13259432,
+      "width": 0,
+      "height": 0,
+      "x": 113,
+      "y": 4,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/motion.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/motion.sb2.json
@@ -1,0 +1,502 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {
+        "broadcast:m": "message1"
+      },
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -194.14610649424313,
+      "y": 129.7,
+      "size": 100,
+      "direction": 37.999999999999986,
+      "draggable": false,
+      "rotationStyle": "left-right",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnleft",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_pointindirection",
+            "inputs": {
+              "DIRECTION": [
+                3,
+                {
+                  "opcode": "motion_direction"
+                },
+                [
+                  8,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_pointtowards",
+            "inputs": {
+              "TOWARDS": [
+                1,
+                {
+                  "opcode": "motion_pointtowards_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TOWARDS": [
+                      "_mouse_"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "motion_pointtowards",
+            "inputs": {
+              "TOWARDS": [
+                1,
+                {
+                  "opcode": "motion_pointtowards_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TOWARDS": [
+                      "Ball"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_goto",
+            "inputs": {
+              "TO": [
+                1,
+                {
+                  "opcode": "motion_goto_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TO": [
+                      "_mouse_"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "motion_goto",
+            "inputs": {
+              "TO": [
+                1,
+                {
+                  "opcode": "motion_goto_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TO": [
+                      "_random_"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "motion_goto",
+            "inputs": {
+              "TO": [
+                1,
+                {
+                  "opcode": "motion_goto_menu",
+                  "shadow": true,
+                  "fields": {
+                    "TO": [
+                      "Ball"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "motion_glidesecstoxy",
+            "inputs": {
+              "SECS": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ],
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_changexby",
+            "inputs": {
+              "DX": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_setx",
+            "inputs": {
+              "X": [
+                3,
+                {
+                  "opcode": "motion_xposition"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_changeyby",
+            "inputs": {
+              "DY": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_sety",
+            "inputs": {
+              "Y": [
+                3,
+                {
+                  "opcode": "motion_yposition"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_ifonedgebounce"
+          },
+          {
+            "opcode": "motion_setrotationstyle",
+            "fields": {
+              "STYLE": [
+                "left-right"
+              ]
+            }
+          },
+          {
+            "opcode": "event_broadcast",
+            "inputs": {
+              "BROADCAST_INPUT": [
+                1,
+                [
+                  11,
+                  "message1",
+                  "broadcast:m"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenbroadcastreceived",
+            "fields": {
+              "BROADCAST_OPTION": [
+                "message1",
+                "broadcast:m"
+              ]
+            }
+          },
+          {
+            "opcode": "motion_pointindirection",
+            "inputs": {
+              "DIRECTION": [
+                3,
+                {
+                  "opcode": "operator_random",
+                  "inputs": {
+                    "FROM": [
+                      1,
+                      [
+                        4,
+                        0
+                      ]
+                    ],
+                    "TO": [
+                      1,
+                      [
+                        4,
+                        360
+                      ]
+                    ]
+                  }
+                },
+                [
+                  8,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "motion_movesteps",
+                    "inputs": {
+                      "STEPS": [
+                        1,
+                        [
+                          4,
+                          250
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "motion_ifonedgebounce"
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Ball",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "ball-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "2a67c00718696196304265e6d44f1b57",
+          "md5ext": "2a67c00718696196304265e6d44f1b57.svg",
+          "rotationCenterX": 22,
+          "rotationCenterY": 22
+        },
+        {
+          "name": "ball-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "6958bd6562917b3d1baa80b471b07868",
+          "md5ext": "6958bd6562917b3d1baa80b471b07868.svg",
+          "rotationCenterX": 22,
+          "rotationCenterY": 22
+        },
+        {
+          "name": "ball-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "3d320d0d33719ba88209d5a7144e1336",
+          "md5ext": "3d320d0d33719ba88209d5a7144e1336.svg",
+          "rotationCenterX": 22,
+          "rotationCenterY": 22
+        },
+        {
+          "name": "ball-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "57d0c98d1acbb8b7e84288fbbedba9c7",
+          "md5ext": "57d0c98d1acbb8b7e84288fbbedba9c7.svg",
+          "rotationCenterX": 22,
+          "rotationCenterY": 22
+        },
+        {
+          "name": "ball-e",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "8f8ef96bb5c4532c796f95039cd06f1a",
+          "md5ext": "8f8ef96bb5c4532c796f95039cd06f1a.svg",
+          "rotationCenterX": 22,
+          "rotationCenterY": 22
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 165,
+      "y": 127,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/offline-custom-assets.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/offline-custom-assets.sb2.json
@@ -1,0 +1,174 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "A_Test_Costume",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1a2c4ff25d0315aa884fc59763b6b6b5",
+          "md5ext": "1a2c4ff25d0315aa884fc59763b6b6b5.svg",
+          "rotationCenterX": 159,
+          "rotationCenterY": 121
+        }
+      ],
+      "sounds": [
+        {
+          "name": "A_Test_Recording",
+          "assetId": "b30084c682f03b58e130988e0f7babf1",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 20224,
+          "md5ext": "b30084c682f03b58e130988e0f7babf1.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": -20,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_glidesecstoxy",
+            "inputs": {
+              "SECS": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ],
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  -20
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  1
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "sound_playuntildone",
+                    "inputs": {
+                      "SOUND_MENU": [
+                        1,
+                        {
+                          "opcode": "sound_sounds_menu",
+                          "shadow": true,
+                          "fields": {
+                            "SOUND_MENU": [
+                              "A_Test_Recording"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/ordering.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/ordering.sb2.json
@@ -1,0 +1,261 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "First",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "bowtie-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "46af5cab1264387b56ebf25fda219a92",
+          "md5ext": "46af5cab1264387b56ebf25fda219a92.svg",
+          "rotationCenterX": 11,
+          "rotationCenterY": 4
+        },
+        {
+          "name": "bowtie-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "397af613cf4285aec5866b4c2700610d",
+          "md5ext": "397af613cf4285aec5866b4c2700610d.svg",
+          "rotationCenterX": 11,
+          "rotationCenterY": 4
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -78,
+      "y": 2,
+      "size": 160,
+      "direction": 90,
+      "draggable": true,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Second",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Third",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "building-a",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "bf77f1e9bee39a5524c614337e13a689",
+          "md5ext": "bf77f1e9bee39a5524c614337e13a689.svg",
+          "rotationCenterX": 40,
+          "rotationCenterY": 30
+        },
+        {
+          "name": "building-b",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "da7320a2f0c3526539f09984fc2337e5",
+          "md5ext": "da7320a2f0c3526539f09984fc2337e5.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": -11
+        },
+        {
+          "name": "building-c",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "fb330cc394593e44513fe8b9d403d1e2",
+          "md5ext": "fb330cc394593e44513fe8b9d403d1e2.svg",
+          "rotationCenterX": 25,
+          "rotationCenterY": 17
+        },
+        {
+          "name": "building-d",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "44da40e33e913b43670d9c7d9dcbd217",
+          "md5ext": "44da40e33e913b43670d9c7d9dcbd217.svg",
+          "rotationCenterX": 59,
+          "rotationCenterY": -10
+        },
+        {
+          "name": "building-e",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "e53726f0501243c0388443a7c1eeac71",
+          "md5ext": "e53726f0501243c0388443a7c1eeac71.svg",
+          "rotationCenterX": 36,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "building-f",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9528e863403bf043a465ac70bd92f90e",
+          "md5ext": "9528e863403bf043a465ac70bd92f90e.svg",
+          "rotationCenterX": 41,
+          "rotationCenterY": 27
+        },
+        {
+          "name": "building-g",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4bc5040c2a7c8ab2ead812a0856b6f6d",
+          "md5ext": "4bc5040c2a7c8ab2ead812a0856b6f6d.svg",
+          "rotationCenterX": 64,
+          "rotationCenterY": -65
+        },
+        {
+          "name": "building-h",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "ae618a97cbe95cb9f7eaef4e033e2fe2",
+          "md5ext": "ae618a97cbe95cb9f7eaef4e033e2fe2.svg",
+          "rotationCenterX": 33,
+          "rotationCenterY": 136
+        },
+        {
+          "name": "building-i",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "046576c3b77288f598f68d27d87f2404",
+          "md5ext": "046576c3b77288f598f68d27d87f2404.svg",
+          "rotationCenterX": 31,
+          "rotationCenterY": -12
+        },
+        {
+          "name": "building-j",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "ba6da12696e4dc5c04aaa5e03182e55a",
+          "md5ext": "ba6da12696e4dc5c04aaa5e03182e55a.svg",
+          "rotationCenterX": 29,
+          "rotationCenterY": 33
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -22,
+      "y": -23,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/origin-absent.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/origin-absent.sb3.json
@@ -1,0 +1,97 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "702d6b19295a4135a0cd6c49606e2a44",
+          "md5ext": "702d6b19295a4135a0cd6c49606e2a44.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "6f0c9b9f05092d28f36191d7e68d84a3",
+          "md5ext": "6f0c9b9f05092d28f36191d7e68d84a3.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/origin.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/origin.sb3.json
@@ -1,0 +1,98 @@
+{
+  "meta": {
+    "semver": "3.0.0",
+    "origin": "test origin"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "702d6b19295a4135a0cd6c49606e2a44",
+          "md5ext": "702d6b19295a4135a0cd6c49606e2a44.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "6f0c9b9f05092d28f36191d7e68d84a3",
+          "md5ext": "6f0c9b9f05092d28f36191d7e68d84a3.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/pen.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/pen.sb2.json
@@ -1,0 +1,357 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "pen"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -49,
+      "y": 115,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "pen_clear"
+          },
+          {
+            "opcode": "pen_setPenHueToNumber",
+            "inputs": {
+              "HUE": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_setPenColorToColor",
+            "inputs": {
+              "COLOR": [
+                1,
+                [
+                  9,
+                  "#5936d1"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_setPenShadeToNumber",
+            "inputs": {
+              "SHADE": [
+                1,
+                [
+                  4,
+                  50
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "pen_setPenSizeTo",
+            "inputs": {
+              "SIZE": [
+                1,
+                [
+                  4,
+                  42
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_create_clone_of",
+            "inputs": {
+              "CLONE_OPTION": [
+                1,
+                {
+                  "opcode": "control_create_clone_of_menu",
+                  "shadow": true,
+                  "fields": {
+                    "CLONE_OPTION": [
+                      "_myself_"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "pen_setPenSizeTo",
+            "inputs": {
+              "SIZE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_repeat",
+            "inputs": {
+              "TIMES": [
+                1,
+                [
+                  6,
+                  50
+                ]
+              ],
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "pen_changePenHueBy",
+                    "inputs": {
+                      "HUE": [
+                        1,
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_changePenSizeBy",
+                    "inputs": {
+                      "SIZE": [
+                        1,
+                        [
+                          4,
+                          1
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_changePenShadeBy",
+                    "inputs": {
+                      "SHADE": [
+                        1,
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_penUp"
+                  },
+                  {
+                    "opcode": "motion_gotoxy",
+                    "inputs": {
+                      "X": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                -240
+                              ]
+                            ],
+                            "TO": [
+                              1,
+                              [
+                                4,
+                                240
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "Y": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                -180
+                              ]
+                            ],
+                            "TO": [
+                              1,
+                              [
+                                4,
+                                180
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_penDown"
+                  },
+                  {
+                    "opcode": "motion_gotoxy",
+                    "inputs": {
+                      "X": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                -240
+                              ]
+                            ],
+                            "TO": [
+                              1,
+                              [
+                                4,
+                                240
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ],
+                      "Y": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                -180
+                              ]
+                            ],
+                            "TO": [
+                              1,
+                              [
+                                4,
+                                180
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "pen_stamp"
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/procedure.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/procedure.sb2.json
@@ -1,0 +1,181 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "procedures_call",
+            "mutation": {
+              "proccode": "foo"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "foo",
+                    "argumentnames": "[]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "procedures_call",
+            "inputs": {
+              "input0": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            },
+            "mutation": {
+              "proccode": "bar %n"
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "procedures_definition",
+            "inputs": {
+              "custom_block": [
+                2,
+                {
+                  "opcode": "procedures_prototype",
+                  "mutation": {
+                    "proccode": "bar %n",
+                    "argumentnames": "[\"color\"]",
+                    "warp": false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "looks_changeeffectby",
+            "fields": {
+              "EFFECT": [
+                "color"
+              ]
+            },
+            "inputs": {
+              "CHANGE": [
+                3,
+                {
+                  "opcode": "argument_reporter_string_number",
+                  "fields": {
+                    "VALUE": [
+                      "color"
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/saythink-and-wait.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/saythink-and-wait.sb2.json
@@ -1,0 +1,108 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "b61b1077b0ea1931abee9dbbfa7903ff",
+          "md5ext": "b61b1077b0ea1931abee9dbbfa7903ff.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "6d1ca6862f00a2bdc3e4ce243795937f",
+          "md5ext": "6d1ca6862f00a2bdc3e4ce243795937f.png",
+          "rotationCenterX": 110,
+          "rotationCenterY": 124
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_sayforsecs",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "Hello!"
+                ]
+              ],
+              "SECS": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_thinkforsecs",
+            "inputs": {
+              "MESSAGE": [
+                1,
+                [
+                  10,
+                  "Hmm..."
+                ]
+              ],
+              "SECS": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/sensing.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/sensing.sb2.json
@@ -1,0 +1,906 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:state": [
+          "state",
+          "touching edge"
+        ],
+        "var:datetime": [
+          "datetime",
+          6213.086965173611
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 162.25595959616442,
+      "y": 117.84387712846177,
+      "size": 100,
+      "direction": 164.4630409730205,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "looks_cleargraphiceffects"
+          },
+          {
+            "opcode": "sensing_resettimer"
+          },
+          {
+            "opcode": "motion_gotoxy",
+            "inputs": {
+              "X": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ],
+              "Y": [
+                1,
+                [
+                  4,
+                  0
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                3,
+                {
+                  "opcode": "operator_random",
+                  "inputs": {
+                    "FROM": [
+                      1,
+                      [
+                        4,
+                        1
+                      ]
+                    ],
+                    "TO": [
+                      1,
+                      [
+                        4,
+                        360
+                      ]
+                    ]
+                  }
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "looks_seteffectto",
+                    "fields": {
+                      "EFFECT": [
+                        "pixelate"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        3,
+                        {
+                          "opcode": "motion_xposition"
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_seteffectto",
+                    "fields": {
+                      "EFFECT": [
+                        "whirl"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        3,
+                        {
+                          "opcode": "motion_yposition"
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_seteffectto",
+                    "fields": {
+                      "EFFECT": [
+                        "color"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        3,
+                        {
+                          "opcode": "operator_mod",
+                          "inputs": {
+                            "NUM1": [
+                              3,
+                              {
+                                "opcode": "sensing_timer"
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ],
+                            "NUM2": [
+                              1,
+                              [
+                                4,
+                                100
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_seteffectto",
+                    "fields": {
+                      "EFFECT": [
+                        "ghost"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        3,
+                        {
+                          "opcode": "sensing_distanceto",
+                          "inputs": {
+                            "DISTANCETOMENU": [
+                              1,
+                              {
+                                "opcode": "sensing_distancetomenu",
+                                "shadow": true,
+                                "fields": {
+                                  "DISTANCETOMENU": [
+                                    "Baseball"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "looks_seteffectto",
+                    "fields": {
+                      "EFFECT": [
+                        "mosaic"
+                      ]
+                    },
+                    "inputs": {
+                      "VALUE": [
+                        3,
+                        {
+                          "opcode": "operator_random",
+                          "inputs": {
+                            "FROM": [
+                              1,
+                              [
+                                4,
+                                0
+                              ]
+                            ],
+                            "TO": [
+                              3,
+                              {
+                                "opcode": "sensing_distanceto",
+                                "inputs": {
+                                  "DISTANCETOMENU": [
+                                    1,
+                                    {
+                                      "opcode": "sensing_distancetomenu",
+                                      "shadow": true,
+                                      "fields": {
+                                        "DISTANCETOMENU": [
+                                          "_mouse_"
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              [
+                                4,
+                                10
+                              ]
+                            ]
+                          }
+                        },
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_touchingobject",
+                          "inputs": {
+                            "TOUCHINGOBJECTMENU": [
+                              1,
+                              {
+                                "opcode": "sensing_touchingobjectmenu",
+                                "shadow": true,
+                                "fields": {
+                                  "TOUCHINGOBJECTMENU": [
+                                    "_edge_"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "touching edge"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_touchingobject",
+                          "inputs": {
+                            "TOUCHINGOBJECTMENU": [
+                              1,
+                              {
+                                "opcode": "sensing_touchingobjectmenu",
+                                "shadow": true,
+                                "fields": {
+                                  "TOUCHINGOBJECTMENU": [
+                                    "_mouse_"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "mouse pointer"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_keypressed",
+                          "inputs": {
+                            "KEY_OPTION": [
+                              1,
+                              {
+                                "opcode": "sensing_keyoptions",
+                                "shadow": true,
+                                "fields": {
+                                  "KEY_OPTION": [
+                                    "space"
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "space key pressed"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_mousedown"
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "mouse down"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_touchingcolor",
+                          "inputs": {
+                            "COLOR": [
+                              1,
+                              [
+                                9,
+                                "#c1c4c7"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "touching color"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "control_if",
+                    "inputs": {
+                      "CONDITION": [
+                        2,
+                        {
+                          "opcode": "sensing_coloristouchingcolor",
+                          "inputs": {
+                            "COLOR": [
+                              1,
+                              [
+                                9,
+                                "#1efa1d"
+                              ]
+                            ],
+                            "COLOR2": [
+                              1,
+                              [
+                                9,
+                                "#ffffff"
+                              ]
+                            ]
+                          }
+                        }
+                      ],
+                      "SUBSTACK": [
+                        2,
+                        [
+                          {
+                            "opcode": "data_setvariableto",
+                            "fields": {
+                              "VARIABLE": [
+                                "state",
+                                "var:state"
+                              ]
+                            },
+                            "inputs": {
+                              "VALUE": [
+                                1,
+                                [
+                                  10,
+                                  "color touching color"
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "motion_movesteps",
+                    "inputs": {
+                      "STEPS": [
+                        1,
+                        [
+                          4,
+                          10
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "motion_ifonedgebounce"
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "YEAR"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "MONTH"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "DATE"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "DAYOFWEEK"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "HOUR"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "MINUTE"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_current",
+                  "fields": {
+                    "CURRENTMENU": [
+                      "SECOND"
+                    ]
+                  }
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "datetime",
+                "var:datetime"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                3,
+                {
+                  "opcode": "sensing_dayssince2000"
+                },
+                [
+                  10,
+                  ""
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Baseball",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "baseball",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "fc2b248ce65363b2aa5f954105ddfc91",
+          "md5ext": "fc2b248ce65363b2aa5f954105ddfc91.svg",
+          "rotationCenterX": 34,
+          "rotationCenterY": 31
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": -7,
+      "y": 6,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"datetime\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "datetime"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 32,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"state\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "state"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/sound.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/sound.sb2.json
@@ -1,0 +1,349 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [
+    "music"
+  ],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "sound_play",
+            "inputs": {
+              "SOUND_MENU": [
+                1,
+                {
+                  "opcode": "sound_sounds_menu",
+                  "shadow": true,
+                  "fields": {
+                    "SOUND_MENU": [
+                      "meow"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "sound_playuntildone",
+            "inputs": {
+              "SOUND_MENU": [
+                1,
+                {
+                  "opcode": "sound_sounds_menu",
+                  "shadow": true,
+                  "fields": {
+                    "SOUND_MENU": [
+                      "meow"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "sound_stopallsounds"
+          },
+          {
+            "opcode": "music_playDrumForBeats",
+            "inputs": {
+              "DRUM": [
+                1,
+                {
+                  "opcode": "music_menu_DRUM",
+                  "shadow": true,
+                  "fields": {
+                    "DRUM": [
+                      1
+                    ]
+                  }
+                }
+              ],
+              "BEATS": [
+                1,
+                [
+                  4,
+                  0.1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "music_restForBeats",
+            "inputs": {
+              "BEATS": [
+                1,
+                [
+                  4,
+                  0.25
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "music_playNoteForBeats",
+            "inputs": {
+              "NOTE": [
+                1,
+                {
+                  "opcode": "note",
+                  "shadow": true,
+                  "fields": {
+                    "NOTE": [
+                      60
+                    ]
+                  }
+                }
+              ],
+              "BEATS": [
+                1,
+                [
+                  4,
+                  0.1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "music_setInstrument",
+            "inputs": {
+              "INSTRUMENT": [
+                1,
+                {
+                  "opcode": "music_menu_INSTRUMENT",
+                  "shadow": true,
+                  "fields": {
+                    "INSTRUMENT": [
+                      1
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "sound_changevolumeby",
+            "inputs": {
+              "VOLUME": [
+                1,
+                [
+                  4,
+                  -10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "sound_setvolumeto",
+            "inputs": {
+              "VOLUME": [
+                3,
+                {
+                  "opcode": "music_getTempo"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "music_changeTempo",
+            "inputs": {
+              "TEMPO": [
+                1,
+                [
+                  4,
+                  20
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "music_setTempo",
+            "inputs": {
+              "TEMPO": [
+                3,
+                {
+                  "opcode": "sound_volume"
+                },
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                2,
+                [
+                  {
+                    "opcode": "sound_playuntildone",
+                    "inputs": {
+                      "SOUND_MENU": [
+                        1,
+                        {
+                          "opcode": "sound_sounds_menu",
+                          "shadow": true,
+                          "fields": {
+                            "SOUND_MENU": [
+                              "meow"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "music_playNoteForBeats",
+                    "inputs": {
+                      "NOTE": [
+                        1,
+                        {
+                          "opcode": "note",
+                          "shadow": true,
+                          "fields": {
+                            "NOTE": [
+                              60
+                            ]
+                          }
+                        }
+                      ],
+                      "BEATS": [
+                        1,
+                        [
+                          4,
+                          0.5
+                        ]
+                      ]
+                    }
+                  },
+                  {
+                    "opcode": "music_playDrumForBeats",
+                    "inputs": {
+                      "DRUM": [
+                        1,
+                        {
+                          "opcode": "music_menu_DRUM",
+                          "shadow": true,
+                          "fields": {
+                            "DRUM": [
+                              1
+                            ]
+                          }
+                        }
+                      ],
+                      "BEATS": [
+                        1,
+                        [
+                          4,
+                          0.25
+                        ]
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/stack-click.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/stack-click.sb2.json
@@ -1,0 +1,125 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whengreaterthan",
+            "fields": {
+              "WHENGREATERTHANMENU": [
+                "timer"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  100000000000
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "motion_movesteps",
+            "inputs": {
+              "STEPS": [
+                1,
+                [
+                  4,
+                  100
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/timer-greater-than-hat.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/timer-greater-than-hat.sb2.json
@@ -1,0 +1,97 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whengreaterthan",
+            "fields": {
+              "WHENGREATERTHANMENU": [
+                "timer"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  -1
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "looks_changeeffectby",
+            "fields": {
+              "EFFECT": [
+                "color"
+              ]
+            },
+            "inputs": {
+              "CHANGE": [
+                1,
+                [
+                  4,
+                  25
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_sensing_timer_{}",
+      "mode": "default",
+      "opcode": "sensing_timer",
+      "params": {},
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/timer-monitor.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/timer-monitor.sb3.json
@@ -1,0 +1,120 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 1123,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 48000,
+          "sampleCount": 40681,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "sensing_timer"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_sensing_timer_{}",
+      "mode": "default",
+      "opcode": "sensing_timer",
+      "params": {},
+      "spriteName": null,
+      "value": 235.639,
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/top-level-reporters.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/top-level-reporters.sb3.json
@@ -1,0 +1,108 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:my variable": [
+          "my variable",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "dataFormat": "svg",
+          "assetId": "87ec29ad216c0074c731d581c7f40c39",
+          "md5ext": "87ec29ad216c0074c731d581c7f40c39.svg",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "on",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a88da48fdc30493c5cc24089f645eb58",
+          "md5ext": "a88da48fdc30493c5cc24089f645eb58.svg",
+          "rotationCenterX": 48,
+          "rotationCenterY": 50
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "a1508ade4cfe8563ec1a148071e609d9",
+          "md5ext": "a1508ade4cfe8563ec1a148071e609d9.svg",
+          "rotationCenterX": 46,
+          "rotationCenterY": 53
+        }
+      ],
+      "sounds": [
+        {
+          "name": "Meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "motion_xposition"
+          }
+        ],
+        [
+          {
+            "opcode": "looks_size"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/top-level-variable-reporter.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/top-level-variable-reporter.sb2.json
@@ -1,0 +1,75 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:myvar": [
+          "myvar",
+          0
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "primitive": 12,
+            "name": "myvar",
+            "varId": "var:myvar"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"myvar\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "myvar"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": false,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode-as-reporter-block.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode-as-reporter-block.sb2.json
@@ -1,0 +1,89 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_wait_until",
+            "inputs": {
+              "CONDITION": [
+                1,
+                null
+              ]
+            }
+          },
+          {
+            "opcode": "sound_setvolumeto",
+            "inputs": {
+              "VOLUME": [
+                1,
+                [
+                  4,
+                  10
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "sound_play",
+            "inputs": {
+              "SOUND_MENU": [
+                1,
+                {
+                  "opcode": "sound_sounds_menu",
+                  "shadow": true,
+                  "fields": {
+                    "SOUND_MENU": [
+                      ""
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode-in-c-block.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode-in-c-block.sb2.json
@@ -1,0 +1,108 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "control_forever",
+            "inputs": {
+              "SUBSTACK": [
+                1,
+                null
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/unknown-opcode.sb2.json
@@ -1,0 +1,82 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "sound_play",
+            "inputs": {
+              "SOUND_MENU": [
+                1,
+                {
+                  "opcode": "sound_sounds_menu",
+                  "shadow": true,
+                  "fields": {
+                    "SOUND_MENU": [
+                      "pop"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "opcode": "sound_play",
+            "inputs": {
+              "SOUND_MENU": [
+                1,
+                {
+                  "opcode": "sound_sounds_menu",
+                  "shadow": true,
+                  "fields": {
+                    "SOUND_MENU": [
+                      "pop"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/variable_characters.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/variable_characters.sb2.json
@@ -1,0 +1,324 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:\"foo": [
+          "\"foo",
+          "foo"
+        ]
+      },
+      "lists": {
+        "list:a&b": [
+          "a&b",
+          [
+            "thing",
+            "thing'1"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "data_listcontainsitem",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "thing"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "data_itemoflist",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "\"foo",
+                "var:\"foo"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "\"foo\""
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "\"foo",
+                "var:\"foo"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "foo"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "thing"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Bananas",
+      "variables": {
+        "var:< Perfect": [
+          "< Perfect",
+          "> perfect"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "bananas",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "119e3ed75355d09259fd56c9d3ac3701",
+          "md5ext": "119e3ed75355d09259fd56c9d3ac3701.svg",
+          "rotationCenterX": 36,
+          "rotationCenterY": 37
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": true,
+      "x": -95,
+      "y": 7,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "< Perfect",
+                "var:< Perfect"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"a&b\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "a&b"
+      },
+      "spriteName": null,
+      "value": "",
+      "width": 106,
+      "height": 206,
+      "x": 5,
+      "y": 5,
+      "visible": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"\\\"foo\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "\"foo"
+      },
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 214,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Bananas_data_variable_{\"VARIABLE\":\"< Perfect\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "< Perfect"
+      },
+      "spriteName": "Bananas",
+      "value": "",
+      "x": 5,
+      "y": 268,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/variable_characters.sb3.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/variable_characters.sb3.json
@@ -1,0 +1,331 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {
+        "var:\"foo": [
+          "\"foo",
+          "foo"
+        ]
+      },
+      "lists": {
+        "list:a&b": [
+          "a&b",
+          [
+            "thing",
+            "thing'1"
+          ]
+        ]
+      },
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 2,
+          "dataFormat": "png",
+          "assetId": "797b03bdb8cf6ccfc30c0692d533d998",
+          "md5ext": "797b03bdb8cf6ccfc30c0692d533d998.png",
+          "rotationCenterX": 480,
+          "rotationCenterY": 360
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 1032,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "data_listcontainsitem",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "thing"
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "data_itemoflist",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "INDEX": [
+                1,
+                [
+                  7,
+                  1
+                ]
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "\"foo",
+                "var:\"foo"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "\"foo\""
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "be4269f29458b8a167da107dd32f7fcb",
+          "md5ext": "be4269f29458b8a167da107dd32f7fcb.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "647af087a73872c7019b594b4419b70c",
+          "md5ext": "647af087a73872c7019b594b4419b70c.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 44100,
+          "sampleCount": 37376,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenflagclicked"
+          },
+          {
+            "opcode": "motion_turnright",
+            "inputs": {
+              "DEGREES": [
+                1,
+                [
+                  4,
+                  15
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_setvariableto",
+            "fields": {
+              "VARIABLE": [
+                "\"foo",
+                "var:\"foo"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  10,
+                  "foo"
+                ]
+              ]
+            }
+          },
+          {
+            "opcode": "data_addtolist",
+            "fields": {
+              "LIST": [
+                "a&b",
+                "list:a&b"
+              ]
+            },
+            "inputs": {
+              "ITEM": [
+                1,
+                [
+                  10,
+                  "thing"
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Bananas",
+      "variables": {
+        "var:< Perfect": [
+          "< Perfect",
+          "> perfect"
+        ]
+      },
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "bananas",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "4631ba8dfd1c2df313a94c44b299c437",
+          "md5ext": "4631ba8dfd1c2df313a94c44b299c437.svg",
+          "rotationCenterX": 36,
+          "rotationCenterY": 37
+        }
+      ],
+      "sounds": [],
+      "volume": 100,
+      "visible": true,
+      "x": -95,
+      "y": 7,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "data_changevariableby",
+            "fields": {
+              "VARIABLE": [
+                "< Perfect",
+                "var:< Perfect"
+              ]
+            },
+            "inputs": {
+              "VALUE": [
+                1,
+                [
+                  4,
+                  1
+                ]
+              ]
+            }
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_data_listcontents_{\"LIST\":\"a&b\"}",
+      "mode": "list",
+      "opcode": "data_listcontents",
+      "params": {
+        "LIST": "a&b"
+      },
+      "spriteName": null,
+      "value": [
+        "thing",
+        "thing'1"
+      ],
+      "width": 106,
+      "height": 206,
+      "x": 5,
+      "y": 5,
+      "visible": true
+    },
+    {
+      "id": "_data_variable_{\"VARIABLE\":\"\\\"foo\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "\"foo"
+      },
+      "spriteName": null,
+      "value": "foo",
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 214,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    },
+    {
+      "id": "Bananas_data_variable_{\"VARIABLE\":\"< Perfect\"}",
+      "mode": "default",
+      "opcode": "data_variable",
+      "params": {
+        "VARIABLE": "< Perfect"
+      },
+      "spriteName": "Bananas",
+      "value": "> perfect",
+      "width": 0,
+      "height": 0,
+      "x": 5,
+      "y": 268,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/visible-tempo-monitor-no-other-music-blocks.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/visible-tempo-monitor-no-other-music-blocks.sb2.json
@@ -1,0 +1,108 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": []
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": []
+    }
+  ],
+  "monitors": [
+    {
+      "id": "_music_getTempo_{}",
+      "mode": "default",
+      "opcode": "music_getTempo",
+      "params": {},
+      "spriteName": null,
+      "value": "",
+      "x": 5,
+      "y": 5,
+      "visible": true,
+      "sliderMin": 0,
+      "sliderMax": 100,
+      "isDiscrete": true
+    }
+  ]
+}

--- a/packages/scratch-vm/tap-snapshots/vm-state-snapshot/when-clicked.sb2.json
+++ b/packages/scratch-vm/tap-snapshots/vm-state-snapshot/when-clicked.sb2.json
@@ -1,0 +1,105 @@
+{
+  "meta": {
+    "semver": "3.0.0"
+  },
+  "extensions": [],
+  "targets": [
+    {
+      "isStage": true,
+      "name": "Stage",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "backdrop1",
+          "bitmapResolution": 1,
+          "dataFormat": "png",
+          "assetId": "739b5e2a2435f6e1ec2993791b423146",
+          "md5ext": "739b5e2a2435f6e1ec2993791b423146.png",
+          "rotationCenterX": 240,
+          "rotationCenterY": 180
+        }
+      ],
+      "sounds": [
+        {
+          "name": "pop",
+          "assetId": "83a9787d4cb6f3b7632b4ddfebf74367",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 11025,
+          "sampleCount": 258,
+          "md5ext": "83a9787d4cb6f3b7632b4ddfebf74367.wav"
+        }
+      ],
+      "volume": 100,
+      "tempo": 60,
+      "videoTransparency": 50,
+      "videoState": "off",
+      "textToSpeechLanguage": null,
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenstageclicked"
+          }
+        ]
+      ]
+    },
+    {
+      "isStage": false,
+      "name": "Sprite1",
+      "variables": {},
+      "lists": {},
+      "broadcasts": {},
+      "currentCostume": 0,
+      "costumes": [
+        {
+          "name": "costume1",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "9f567abe17ba2d13597d1f2e416017ef",
+          "md5ext": "9f567abe17ba2d13597d1f2e416017ef.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        },
+        {
+          "name": "costume2",
+          "bitmapResolution": 1,
+          "dataFormat": "svg",
+          "assetId": "1e4df2581d2d314527775ee43f646b42",
+          "md5ext": "1e4df2581d2d314527775ee43f646b42.svg",
+          "rotationCenterX": 47,
+          "rotationCenterY": 55
+        }
+      ],
+      "sounds": [
+        {
+          "name": "meow",
+          "assetId": "83c36d806dc92327b9e7049a565c6bff",
+          "dataFormat": "wav",
+          "format": "",
+          "rate": 22050,
+          "sampleCount": 18688,
+          "md5ext": "83c36d806dc92327b9e7049a565c6bff.wav"
+        }
+      ],
+      "volume": 100,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "size": 100,
+      "direction": 90,
+      "draggable": false,
+      "rotationStyle": "all around",
+      "scripts": [
+        [
+          {
+            "opcode": "event_whenthisspriteclicked"
+          }
+        ]
+      ]
+    }
+  ],
+  "monitors": []
+}

--- a/packages/scratch-vm/test/fixtures/patch-timers.js
+++ b/packages/scratch-vm/test/fixtures/patch-timers.js
@@ -1,0 +1,72 @@
+/**
+ * Patches global timer functions to track intervals and timeouts created
+ * during a block of code, so callers can detect leaks after cleanup.
+ *
+ * Usage:
+ *   const timers = patchTimers();
+ *   // ... run code that may create timers ...
+ *   vm.quit();
+ *   timers.restore();
+ *   for (const id of timers.getLiveTimers()) { ... }
+ *
+ * @returns {{
+ *   origSetTimeout: typeof setTimeout,
+ *   restore: function(): void,
+ *   getLiveTimers: function(): any[]
+ * }}
+ */
+const patchTimers = function () {
+    const createdIntervals = new Set();
+    const createdTimeouts = new Set();
+    const g = /** @type {any} */ (global);
+    const origSetInterval = g.setInterval;
+    const origClearInterval = g.clearInterval;
+    const origSetTimeout = g.setTimeout;
+    const origClearTimeout = g.clearTimeout;
+
+    g.setInterval = function () {
+        const id = origSetInterval.apply(this, arguments);
+        createdIntervals.add(id);
+        return id;
+    };
+    g.clearInterval = function (/** @type {any} */ id) {
+        createdIntervals.delete(id);
+        return origClearInterval(id);
+    };
+    g.setTimeout = function () {
+        const id = origSetTimeout.apply(this, arguments);
+        createdTimeouts.add(id);
+        return id;
+    };
+    g.clearTimeout = function (/** @type {any} */ id) {
+        createdTimeouts.delete(id);
+        return origClearTimeout(id);
+    };
+
+    return {
+        /** The unpatched setTimeout, safe to use without leak tracking. */
+        origSetTimeout,
+
+        /** Restores the original global timer functions. */
+        restore () {
+            g.setInterval = origSetInterval;
+            g.clearInterval = origClearInterval;
+            g.setTimeout = origSetTimeout;
+            g.clearTimeout = origClearTimeout;
+        },
+
+        /**
+         * Returns timer objects that were created but not cleared.
+         * Call after vm.quit() and restore() to find leaks.
+         * @returns {any[]}
+         */
+        getLiveTimers () {
+            return [
+                ...[...createdIntervals].filter(id => !id._destroyed),
+                ...[...createdTimeouts].filter(id => !id._destroyed)
+            ];
+        }
+    };
+};
+
+module.exports = patchTimers;

--- a/packages/scratch-vm/test/integration/vm-state-snapshot.js
+++ b/packages/scratch-vm/test/integration/vm-state-snapshot.js
@@ -1,0 +1,302 @@
+/**
+ * VM State Snapshot Test
+ *
+ * Loads SB3/SB2 fixtures and compares the resulting VM state against stored
+ * snapshots in tap-snapshots/vm-state-snapshot/.  Intended for cross-version
+ * compatibility testing:
+ *
+ *   1. On the reference version, generate snapshots:
+ *        TAP_SNAPSHOT=1 npm test -- test/integration/vm-state-snapshot.js
+ *
+ *   2. Copy tap-snapshots/vm-state-snapshot/ to the target version.
+ *
+ *   3. Run on the target version — the test fails if VM state differs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const test = require('tap').test;
+const FIXTURES_DIR = path.resolve(__dirname, '../fixtures');
+const SNAPSHOT_DIR = path.resolve(__dirname, '../../tap-snapshots');
+const makeTestStorage = require('../fixtures/make-test-storage');
+const patchTimers = require('../fixtures/patch-timers');
+const readFileToBuffer = require('../fixtures/readProjectFile').readFileToBuffer;
+const VirtualMachine = require('../../src/virtual-machine');
+
+// To test a subset, replace with a literal array of fixture names, e.g.:
+//   const FIXTURES = ['procedure.sb2', 'monitors.sb3'];
+const FIXTURES = fs.readdirSync(FIXTURES_DIR, {recursive: true, withFileTypes: true})
+    .filter(f => f.isFile() && (f.name.endsWith('.sb2') || f.name.endsWith('.sb3')))
+    .map(f => path.relative(FIXTURES_DIR, path.join(f.parentPath, f.name)))
+    // Filter out projects that cause intentional load errors or hang on vm.quit().
+    .filter(name => ![
+        'missing_png.sb2',
+        'missing_png.sb3',
+        'missing_sound.sb3',
+        'missing_svg.sb2',
+        'missing_svg.sb3',
+        'sb2-from-sb1-missing-backdrop-image.sb2',
+        'visible-video-monitor-and-video-blocks.sb2',
+        'visible-video-monitor-no-other-video-blocks.sb2',
+        'load-extensions/music-visible-monitor-no-blocks.sb2',
+        'load-extensions/confirm-load/videoSensing-simple-project.sb2',
+        'load-extensions/confirm-load/videoSensing-simple-project.sb3',
+        'load-extensions/confirm-load/wedo2-simple-project.sb3',
+        'load-extensions/video-state/videoState-off.sb2',
+        'load-extensions/video-state/videoState-on-transparency-0.sb2'
+    ].includes(name))
+    .sort();
+
+/**
+ * Build a single block node with child blocks embedded inline.
+ * Child inputs are embedded recursively; SUBSTACK/SUBSTACK2 inputs become
+ * flat arrays via `buildSeq`. Dropped: id, parent, topLevel, x, y.
+ * @param {string} id - block ID to build
+ * @param {Record<string, any>} blocks - flat block map from vm.toJSON()
+ * @param {Map<string, string>} varIdMap - variable/list/broadcast ID normalization map
+ * @param {Function} buildSeq - callback for building script sequences (avoids forward ref)
+ * @returns {object|null} block node, or null if ID not found
+ */
+const buildBlockNode = function (id, blocks, varIdMap, buildSeq) {
+    const b = blocks[id];
+    if (!b) return null;
+
+    // Compact freestanding primitive block (numeric string keys, no opcode)
+    if (typeof b['2'] === 'string') {
+        return {primitive: b['0'], name: b['1'], varId: varIdMap.get(b['2']) || b['2']};
+    }
+
+    const node = /** @type {Record<string, any>} */ ({opcode: b.opcode});
+    if (b.shadow) node.shadow = true;
+
+    if (b.fields && Object.keys(b.fields).length > 0) {
+        node.fields = {};
+        for (const [key, field] of Object.entries(b.fields)) {
+            const f = [...field];
+            if (typeof f[1] === 'string') f[1] = varIdMap.get(f[1]) || f[1];
+            node.fields[key] = f;
+        }
+    }
+
+    if (b.inputs && Object.keys(b.inputs).length > 0) {
+        node.inputs = {};
+        for (const [key, inp] of Object.entries(b.inputs)) {
+            const embed = (/** @type {any} */ val) => {
+                if (typeof val !== 'string') {
+                    // Inline primitive: null, bare value, or [type, name, varId]
+                    if (Array.isArray(val) && typeof val[2] === 'string') {
+                        const r = [...val];
+                        r[2] = varIdMap.get(r[2]) || r[2];
+                        return r;
+                    }
+                    return val;
+                }
+                if (!blocks[val]) return null; // dangling block reference
+                if (key === 'SUBSTACK' || key === 'SUBSTACK2') {
+                    return buildSeq(val, blocks, varIdMap);
+                }
+                return buildBlockNode(val, blocks, varIdMap, buildSeq);
+            };
+            const entry = [inp[0], embed(inp[1])];
+            if (inp.length > 2) entry.push(embed(inp[2]));
+            node.inputs[key] = entry;
+        }
+    }
+
+    if (b.mutation) {
+        const m = /** @type {Record<string, any>} */ ({});
+        if ('proccode' in b.mutation) m.proccode = b.mutation.proccode;
+        if ('argumentnames' in b.mutation) m.argumentnames = b.mutation.argumentnames;
+        if ('warp' in b.mutation) m.warp = b.mutation.warp;
+        if (Object.keys(m).length > 0) node.mutation = m;
+    }
+
+    return node;
+};
+
+/**
+ * Build a flat array of block nodes by following the `next` chain from startId.
+ * Used for both top-level scripts and C-block SUBSTACK sequences.
+ * @param {string} startId - ID of the first block in the sequence
+ * @param {Record<string, any>} blocks - flat block map from vm.toJSON()
+ * @param {Map<string, string>} varIdMap - variable/list/broadcast ID normalization map
+ * @returns {Array<object>} sequence of block nodes
+ */
+const buildScriptSequence = function (startId, blocks, varIdMap) {
+    const seq = [];
+    let id = startId;
+    while (id && blocks[id]) {
+        seq.push(buildBlockNode(id, blocks, varIdMap, buildScriptSequence));
+        id = blocks[id].next;
+    }
+    return seq;
+};
+
+/**
+ * Capture a deterministic snapshot of the VM's state after loading a project.
+ * Calls vm.toJSON() then restructures blocks into SB2-style nested trees
+ * ordered by vm.runtime.targets[i].blocks._scripts (execution order).
+ * @param {VirtualMachine} vm
+ * @returns {object}
+ */
+const captureVMState = function (vm) {
+    const projectJson = JSON.parse(vm.toJSON());
+
+    delete projectJson.meta.agent;
+    delete projectJson.meta.vm;
+
+    // ── Normalize intentional scratch-blocks@^2 procedure changes ──────────
+    //
+    // 1. procedures_prototype.shadow: true → false (prototype is no longer a shadow)
+    // 2. procedures_definition custom_block input type: 1 → 2 (non-shadow)
+    // 3. Argument reporter children of procedures_prototype: present → absent
+    //    (new scratch-blocks omits them from the VM store; managed by
+    //    Blockly's domToMutation and not part of VM execution state)
+    //
+    // This runs before building the block tree so removed blocks do not appear.
+    for (const target of projectJson.targets) {
+        for (const block of Object.values(target.blocks)) {
+            if (block.opcode === 'procedures_prototype') {
+                delete block.shadow;
+                for (const inp of Object.values(block.inputs || {})) {
+                    const childId = inp[1]; // raw SB3 format: [type, blockId]
+                    const child = childId && target.blocks[childId];
+                    if (child && (child.opcode === 'argument_reporter_string_number' ||
+                                  child.opcode === 'argument_reporter_boolean')) {
+                        delete target.blocks[childId];
+                    }
+                }
+                block.inputs = {};
+            }
+            if (block.opcode === 'procedures_definition' &&
+                block.inputs && block.inputs.custom_block) {
+                const inp = [...block.inputs.custom_block];
+                inp[0] = 2; // 2 = non-shadow (new behavior)
+                block.inputs.custom_block = inp;
+            }
+        }
+    }
+
+    // Build global ID map first — sprites can reference Stage (global) variables.
+    const globalVarIdMap = new Map();
+    for (const target of projectJson.targets) {
+        for (const [id, [name]] of Object.entries(target.variables || {})) {
+            globalVarIdMap.set(id, `var:${name}`);
+        }
+        for (const [id, [name]] of Object.entries(target.lists || {})) {
+            globalVarIdMap.set(id, `list:${name}`);
+        }
+        for (const [id, [name]] of Object.entries(target.broadcasts || {})) {
+            globalVarIdMap.set(id, `broadcast:${name}`);
+        }
+    }
+
+    const rewriteVarKeys = /** @type {(obj: any) => any} */ (obj => Object.fromEntries(
+        Object.entries(obj || {}).map(([id, val]) => [globalVarIdMap.get(id) || id, val])
+    ));
+
+    // Stage first, then sprites in runtime order (execution order — do not sort).
+    const targets = vm.runtime.targets
+        .filter(t => t.isOriginal)
+        .sort((a, b) => (a.isStage === b.isStage ? 0 : a.isStage ? -1 : 1))
+        .flatMap(runtimeTarget => {
+            const name = runtimeTarget.isStage ? 'Stage' : runtimeTarget.sprite.name;
+            const ser = projectJson.targets.find(/** @type {(t: any) => boolean} */ (t =>
+                runtimeTarget.isStage ? t.isStage : t.name === name
+            ));
+            if (!ser) return [];
+
+            const blocks = ser.blocks || {};
+
+            const scriptIds = runtimeTarget.blocks._scripts || [];
+            const scripts = scriptIds
+                .filter(/** @type {(id: string) => boolean} */ (id => Boolean(blocks[id])))
+                .map(/** @type {(id: string) => any[]} */ (id =>
+                    buildScriptSequence(id, blocks, globalVarIdMap)
+                ));
+
+            const {
+                id: _id, // random runtime ID — not stable
+                blocks: _blocks, // replaced by scripts
+                comments: _comments, // layout state, not VM execution state
+                ...rest
+            } = ser;
+
+            return [{
+                ...rest,
+                name,
+                variables: rewriteVarKeys(ser.variables),
+                lists: rewriteVarKeys(ser.lists),
+                broadcasts: rewriteVarKeys(ser.broadcasts),
+                scripts
+            }];
+        });
+
+    // Monitor IDs embed a random target ID; replace with a stable derived key.
+    const snapshot = /** @type {Record<string, any>} */ ({
+        meta: projectJson.meta,
+        extensions: projectJson.extensions,
+        targets
+    });
+    if (projectJson.monitors) {
+        snapshot.monitors = projectJson.monitors
+            .map(/** @type {(m: any) => any} */ (m => ({
+                ...m,
+                id: [m.spriteName || '', m.opcode, JSON.stringify(m.params)].join('_')
+            })))
+            .sort((/** @type {any} */ a, /** @type {any} */ b) => a.id.localeCompare(b.id));
+    }
+    return snapshot;
+};
+
+FIXTURES.forEach(name => {
+    test(`vm-state-snapshot: ${name}`, async t => {
+        const vm = new VirtualMachine();
+        vm.attachStorage(makeTestStorage());
+
+        const projectBuffer = readFileToBuffer(path.resolve(FIXTURES_DIR, name));
+
+        const timers = patchTimers();
+
+        try {
+            await Promise.race([
+                vm.loadProject(projectBuffer),
+                new Promise((_, reject) => {
+                    const timer = timers.origSetTimeout(() => {
+                        reject(new Error(`Timed out loading ${name}`));
+                    }, 10000);
+                    timer.unref(); // don't let this timer keep the process alive
+                })
+            ]);
+        } catch (err) {
+            timers.restore();
+            t.fail(err instanceof Error ? err.message : String(err));
+            vm.quit();
+            return;
+        }
+
+        const state = captureVMState(vm);
+        const snapshotFile = path.join(SNAPSHOT_DIR, 'vm-state-snapshot', `${name}.json`);
+        if (process.env.TAP_SNAPSHOT) {
+            fs.mkdirSync(path.dirname(snapshotFile), {recursive: true});
+            fs.writeFileSync(snapshotFile, JSON.stringify(state, null, 2) + '\n');
+            t.pass(`wrote snapshot for ${name}`);
+        } else {
+            const expected = JSON.parse(fs.readFileSync(snapshotFile, 'utf8'));
+            t.same(state, expected, `VM state for ${name}`);
+        }
+        vm.quit();
+        timers.restore();
+
+        const liveTimers = timers.getLiveTimers();
+        if (liveTimers.length) {
+            const messageLines = [`WARNING: ${name} left ${liveTimers.length} timer(s) alive after vm.quit():`];
+            for (const id of liveTimers) {
+                const fn = (/** @type {any} */ (id))._onTimeout;
+                const fnName = fn ? (fn.name || fn.toString().slice(0, 60)) : '(unknown)';
+                messageLines.push(`  ${id.constructor.name} with callback ${fnName}`);
+            }
+            t.error(messageLines.join('\n'));
+        }
+    });
+});

--- a/packages/scratch-vm/tsconfig.tap.json
+++ b/packages/scratch-vm/tsconfig.tap.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "checkJs": false,
+        "module": "CommonJS",
+        "target": "ESNext",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "lib": [
+            "ESNext",
+            "DOM"
+        ]
+    }
+}


### PR DESCRIPTION
### Proposed Changes

Loads all SB2/SB3 fixtures (with a few exclusions), captures a deterministic nested-block-tree snapshot of the resulting VM state, and compares against per-fixture JSON files in `tap-snapshots/vm-state-snapshot/`. Regenerate with `TAP_SNAPSHOT=1`.

These snapshot files were generated with `scratch-blocks@1.3.0` to help ensure that `scratch-blocks@^2` leads to an identical VM state.

Also adds `test/fixtures/patch-timers.js` for tracking timer leaks across tests.

### Reason for Changes

This is intended to raise confidence in the correctness of `scratch-blocks@^2` as well as the GUI and (especially) VM changes near it. The test verifies that the resulting VM state is identical to what `scratch-blocks@^1` generated.

Timer leaks prevented this test from working correctly with some projects; the timer tracking helped determine which projects to exclude.
