### PR TITLE
More Scratch Blocks fixes

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -436,11 +436,15 @@ class Blocks extends React.Component {
             this.onWorkspaceMetricsChange();
         }
 
-        // Remove and reattach the workspace listener (but allow flyout events)
-        this.workspace.removeChangeListener(this.props.vm.blockListener);
+        // Disable Blockly events during workspace reload. In Blockly v2, Events.fire()
+        // enqueues events for async dispatch (after rendering), so the old pattern of
+        // removing and re-adding the blockListener no longer prevents spurious events
+        // from reaching the VM — the queued events fire after the listener is re-added.
+        // Disabling events entirely during the load ensures nothing is queued.
         this.workspace.removeChangeListener(this.toolboxUpdateChangeListener);
-        const dom = this.ScratchBlocks.utils.xml.textToDom(data.xml);
         try {
+            this.ScratchBlocks.Events.disable();
+            const dom = this.ScratchBlocks.utils.xml.textToDom(data.xml);
             this.ScratchBlocks.clearWorkspaceAndLoadFromXml(dom, this.workspace);
         } catch (error) {
             // The workspace is likely incomplete. What did update should be
@@ -456,8 +460,9 @@ class Blocks extends React.Component {
                 error.message = `Workspace Update Error: ${error.message}`;
             }
             log.error(error);
+        } finally {
+            this.ScratchBlocks.Events.enable();
         }
-        this.workspace.addChangeListener(this.props.vm.blockListener);
 
         if (this.props.vm.editingTarget && this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id]) {
             const {scrollX, scrollY, scale} = this.props.workspaceMetrics.targets[this.props.vm.editingTarget.id];
@@ -822,6 +827,7 @@ const mapDispatchToProps = dispatch => ({
     }
 });
 
+export {Blocks};
 export default errorBoundaryHOC('Blocks')(
     connect(
         mapStateToProps,

--- a/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
+++ b/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import VM from '@scratch/scratch-vm';
 
 import {connect} from 'react-redux';
-import {isContentNodeFocused} from 'scratch-blocks';
 
 import {updateTargets} from '../reducers/targets';
 import {updateBlockDrag} from '../reducers/block-drag';
@@ -88,15 +87,13 @@ const vmListenerHOC = function (WrappedComponent) {
             }
         }
         handleKeyDown (e) {
-            // Don't capture keys intended for Blockly inputs.
+            // Don't capture keys intended for HTML inputs (e.g. project title).
+            // The Blockly workspace is rendered as SVG, so SVG-targeted events
+            // should always reach the VM for key-sensing — even when a block has
+            // Blockly focus — so that game controls are never silently dropped
+            // while the user is on the Code tab.
             if (e.target !== document && e.target !== document.body) {
-                // Allow events from inside the Blockly workspace when no
-                // specific block or comment has focus — i.e. when the workspace
-                // background itself is focused. In that case key presses should
-                // reach the VM for key-sensing just like any other key press.
-                // The workspace is rendered as SVG, so we check for SVGElement
-                // to avoid swallowing keys from HTML inputs (e.g. project title).
-                if (!(e.target instanceof SVGElement) || isContentNodeFocused()) return;
+                if (!(e.target instanceof SVGElement)) return;
             }
 
             const key = (!e.key || e.key === 'Dead') ? e.keyCode : e.key;

--- a/packages/scratch-gui/test/unit/containers/blocks.test.js
+++ b/packages/scratch-gui/test/unit/containers/blocks.test.js
@@ -1,0 +1,65 @@
+import {Blocks} from '../../../src/containers/blocks.jsx';
+
+describe('Blocks container onWorkspaceUpdate', () => {
+    let instance;
+
+    beforeEach(() => {
+        // Minimal mock instance — just enough for onWorkspaceUpdate to run
+        instance = {
+            getToolboxXML: jest.fn().mockReturnValue(null),
+            onWorkspaceMetricsChange: jest.fn(),
+            toolboxUpdateChangeListener: jest.fn(),
+            props: {
+                vm: {editingTarget: null},
+                workspaceMetrics: {targets: {}},
+                updateToolboxState: jest.fn()
+            },
+            workspace: {
+                removeChangeListener: jest.fn(),
+                addChangeListener: jest.fn(),
+                clearUndo: jest.fn()
+            },
+            ScratchBlocks: {
+                Events: {
+                    disable: jest.fn(),
+                    enable: jest.fn()
+                },
+                utils: {
+                    xml: {
+                        textToDom: jest.fn().mockReturnValue(document.createElement('xml'))
+                    }
+                },
+                clearWorkspaceAndLoadFromXml: jest.fn()
+            }
+        };
+    });
+
+    test('Events.enable() is called after a successful workspace load', () => {
+        Blocks.prototype.onWorkspaceUpdate.call(instance, {xml: '<xml/>'});
+
+        expect(instance.ScratchBlocks.Events.disable).toHaveBeenCalled();
+        expect(instance.ScratchBlocks.Events.enable).toHaveBeenCalled();
+    });
+
+    test('Events.enable() is called even when clearWorkspaceAndLoadFromXml throws', () => {
+        instance.ScratchBlocks.clearWorkspaceAndLoadFromXml.mockImplementation(() => {
+            throw new Error('workspace load failed');
+        });
+
+        Blocks.prototype.onWorkspaceUpdate.call(instance, {xml: '<xml/>'});
+
+        expect(instance.ScratchBlocks.Events.disable).toHaveBeenCalled();
+        expect(instance.ScratchBlocks.Events.enable).toHaveBeenCalled();
+    });
+
+    test('Events.enable() is called even when textToDom throws', () => {
+        instance.ScratchBlocks.utils.xml.textToDom.mockImplementation(() => {
+            throw new Error('XML parse failed');
+        });
+
+        Blocks.prototype.onWorkspaceUpdate.call(instance, {xml: 'invalid xml'});
+
+        expect(instance.ScratchBlocks.Events.disable).toHaveBeenCalled();
+        expect(instance.ScratchBlocks.Events.enable).toHaveBeenCalled();
+    });
+});

--- a/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import {render} from '@testing-library/react';
 import VM from '@scratch/scratch-vm';
-import * as ScratchBlocks from 'scratch-blocks';
 
 import vmListenerHOC from '../../../src/lib/vm-listener-hoc.jsx';
 import '@testing-library/jest-dom';
@@ -174,14 +173,9 @@ describe('VMListenerHOC', () => {
         eventTriggers.keydown({key: 'A', target: inputEl});
         expect(vm.postIOData).not.toHaveBeenLastCalledWith('keyboard', {key: 'A', isDown: true});
 
-        // keydown with an SVG target (Blockly workspace) and a focused content node should not be forwarded
+        // keydown with an SVG target (Blockly workspace) should always be forwarded to VM
+        // even when a block has Blockly focus, so game controls work from the Code tab
         const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        jest.spyOn(ScratchBlocks, 'isContentNodeFocused').mockReturnValueOnce(true);
-        eventTriggers.keydown({key: 'A', target: svgEl});
-        expect(vm.postIOData).not.toHaveBeenLastCalledWith('keyboard', {key: 'A', isDown: true});
-
-        // keydown with an SVG target and no focused content node should be forwarded (workspace background focus)
-        jest.spyOn(ScratchBlocks, 'isContentNodeFocused').mockReturnValueOnce(false);
         eventTriggers.keydown({key: 'A', target: svgEl});
         expect(vm.postIOData).toHaveBeenLastCalledWith('keyboard', {key: 'A', isDown: true});
 


### PR DESCRIPTION
### Resolves

- Resolves an issue with keyboard inputs introduced with aa619169a8414e223af5aa39fa213aacb8421479
- Resolves scratchfoundation/scratch-blocks#3479

### Proposed Changes

- Don't ignore keypresses if a Blockly "content node" is focused
- Disable Blockly events, rather than removing and re-adding the event listener, while switching blocks workspaces due to a sprite switch

### Reason for Changes

- The VM should handle keys relayed from Blockly even if an SVG object is selected, but not if focus is in an input element. As we move toward full keyboard nav support, we may need Blockly / Scratch Blocks to be more careful about when it reports key events to the VM, but the coarse filtering here was rejecting important events.
- Newer Blockly uses async events, so temporarily removing and later re-adding the event handler didn't guarantee suppression of events that were generated before the handler was re-added. Blockly now has an explicit call to disable and re-enable generating events, so use that.

### Test Coverage

Tested locally with the "Eat the Pi!" project, which is sensitive to both of these issues.
