### PR TITLE
Fix two exceptions thrown for focus-related reasons

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -240,6 +240,20 @@ class Blocks extends React.Component {
     }
     componentWillUnmount () {
         this.detachVM();
+        // Hide any open field editor and move Blockly focus to the workspace
+        // root before disposing. Without this, BlockSvg.dispose() detects the
+        // focused element is inside a block and schedules a stale
+        // setTimeout(() => focusTree(workspace)), which fires after the
+        // workspace is unregistered and throws
+        // "Attempted to focus unregistered tree" (scratch-blocks#3460).
+        //
+        // focusNode(workspace) — not focusTree(workspace) — is used here
+        // because focusTree would restore focus to whatever was previously
+        // focused in this workspace (likely the same block about to be
+        // disposed). focusNode pins focus to the workspace root directly,
+        // ensuring no block is focused when dispose() runs.
+        this.ScratchBlocks.WidgetDiv.hide();
+        this.ScratchBlocks.getFocusManager().focusNode(this.workspace);
         this.workspace.dispose();
         clearTimeout(this.toolboxUpdateTimeout);
 

--- a/packages/scratch-gui/src/containers/custom-procedures.jsx
+++ b/packages/scratch-gui/src/containers/custom-procedures.jsx
@@ -26,6 +26,21 @@ class CustomProcedures extends React.Component {
     }
     componentWillUnmount () {
         if (this.workspace) {
+            // When BlockSvg.dispose() runs with the focused element inside the
+            // block, it schedules setTimeout(() => focusTree(workspace)) to
+            // return focus somewhere sensible.  For procedures_declaration
+            // (no parent block), that setTimeout fires *after* the workspace
+            // is unregistered, throwing "Attempted to focus unregistered tree".
+            //
+            // Fix: hide any open field editor (releases ephemeral focus) then
+            // move Blockly focus to the main workspace before disposing.
+            // BlockSvg.dispose() then sees the focused element is not inside
+            // any dialog block and skips the stale focusTree setTimeout.
+            ScratchBlocks.WidgetDiv.hide();
+            const mainWorkspace = ScratchBlocks.getMainWorkspace();
+            if (mainWorkspace) {
+                ScratchBlocks.getFocusManager().focusTree(mainWorkspace);
+            }
             this.workspace.dispose();
         }
     }


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-blocks#3481
- Resolves scratchfoundation/scratch-blocks#3460 (hopefully)

### Proposed Changes

When a blocks workspace is disposed, reset the focus manager first.

### Reason for Changes

Without this, the focus manager does something like `setTimeout(() => focusTree(workspace))`, which can fire after the workspace is disposed and cause exceptions.

### Test Coverage

Tested according to repro steps in scratchfoundation/scratch-blocks#3481
