### PR TITLE
feat: Update Media Library Assets

### DIFF
--- a/packages/scratch-gui/src/lib/libraries/costumes.json
+++ b/packages/scratch-gui/src/lib/libraries/costumes.json
@@ -3764,8 +3764,8 @@
     },
     {
         "name": "Dog3",
-        "assetId": "e48a2585b317968706308ac841cce0c6",
-        "md5ext": "e48a2585b317968706308ac841cce0c6.png",
+        "assetId": "753cf1b76810b45f70b10bf1c36310bb",
+        "md5ext": "753cf1b76810b45f70b10bf1c36310bb.png",
         "dataFormat": "png",
         "bitmapResolution": 2,
         "rotationCenterX": 190,
@@ -3792,8 +3792,8 @@
     },
     {
         "name": "Dog3 Hoodie",
-        "assetId": "854253ef27c971b1e7e26f9c42219b8d",
-        "md5ext": "854253ef27c971b1e7e26f9c42219b8d.png",
+        "assetId": "839f6d22bb971ab5ba40348d52edbe5d",
+        "md5ext": "839f6d22bb971ab5ba40348d52edbe5d.png",
         "dataFormat": "png",
         "bitmapResolution": 2,
         "rotationCenterX": 258,

--- a/packages/scratch-gui/src/lib/libraries/sprites.json
+++ b/packages/scratch-gui/src/lib/libraries/sprites.json
@@ -6371,8 +6371,8 @@
         "costumes": [
             {
                 "name": "Dog3",
-                "assetId": "e48a2585b317968706308ac841cce0c6",
-                "md5ext": "e48a2585b317968706308ac841cce0c6.png",
+                "assetId": "753cf1b76810b45f70b10bf1c36310bb",
+                "md5ext": "753cf1b76810b45f70b10bf1c36310bb.png",
                 "dataFormat": "png",
                 "bitmapResolution": 2,
                 "rotationCenterX": 190,
@@ -6399,8 +6399,8 @@
             },
             {
                 "name": "Dog3 Hoodie",
-                "assetId": "854253ef27c971b1e7e26f9c42219b8d",
-                "md5ext": "854253ef27c971b1e7e26f9c42219b8d.png",
+                "assetId": "839f6d22bb971ab5ba40348d52edbe5d",
+                "md5ext": "839f6d22bb971ab5ba40348d52edbe5d.png",
                 "dataFormat": "png",
                 "bitmapResolution": 2,
                 "rotationCenterX": 258,


### PR DESCRIPTION
This PR updates the media library assets (sprites, costumes, backdrops, sounds) based on changes in [scratchfoundation/scratch-media-lib-assets](https://github.com/scratchfoundation/scratch-media-lib-assets).

Generated from commit: [`19d9844ebea7ab11e848e1b442e3c9d9105081c2`](https://github.com/scratchfoundation/scratch-media-lib-assets/commit/19d9844ebea7ab11e848e1b442e3c9d9105081c2)