### PR TITLE
feat: add symlinks:false to webpack config

### DIFF
--- a/packages/scratch-gui/webpack.config.js
+++ b/packages/scratch-gui/webpack.config.js
@@ -50,7 +50,8 @@ const baseConfig = new ScratchWebpackConfigBuilder(
             fallback: {
                 Buffer: require.resolve('buffer/'),
                 stream: require.resolve('stream-browserify')
-            }
+            },
+            symlinks: false
         }
     })
     .addModuleRule({


### PR DESCRIPTION
### Proposed Changes

Enable `symlinks: false` in webpack config

### Reason for Changes

It helps with alleviating issues related to local linking of dependency packages - such as `scratch-paint`
