### PR TITLE
fix: pick random scientific notation

### DIFF
--- a/packages/scratch-vm/src/util/cast.js
+++ b/packages/scratch-vm/src/util/cast.js
@@ -167,7 +167,12 @@ class Cast {
             return true;
         } else if (typeof val === 'string') {
             // If it contains a decimal point, don't consider it an int.
-            return val.indexOf('.') < 0;
+            if (val.toLowerCase().split('e').length === 2) {
+                return Number(val) === parseInt(Number(val), 10);
+            } else {
+                // If it contains a decimal point, don't consider it an int.
+                return val.indexOf('.') < 0;
+            }
         }
         return false;
     }

--- a/packages/scratch-vm/test/unit/util_cast.js
+++ b/packages/scratch-vm/test/unit/util_cast.js
@@ -151,7 +151,7 @@ test('isInt', t => {
     t.equal(cast.isInt('0'), true);
     t.equal(cast.isInt('1'), true);
     t.equal(cast.isInt('0.0'), false);
-    t.equal(cast.isInt('0.1e10'), false);
+    t.equal(cast.isInt('0.1e10'), true);
     t.equal(cast.isInt('3.14'), false);
 
     // Boolean


### PR DESCRIPTION
### Resolves
Fix #160

### Proposed Changes
- Updated `Cast.isInt` string branch to handle scientific notation: if the string contains an `e`, parse it numerically to check if it's truly a whole number, otherwise fall back to the dot check.
- Updated the existing test for `'0.1e10'` from `false` to `true`, since `0.1e10` equals `1000000000` which is a whole number.

### Reason for Changes
`Cast.isInt` only checked for a `.` to decide if a string was an integer. This broke with scientific notation — `5e-1` has no dot but is `0.5` (a float), causing `pick random (5e-1) to (10)` to return offset values like `1.5`, `3.5` instead of proper floats.

### Test Coverage
Updated `util_cast.js` — changed `cast.isInt('0.1e10')` expected value from `false` to `true`, since `0.1e10` (`1000000000`) is a whole number and should be treated as an int.