### PR TITLE
[UEPR-523] Update Share Modal Flow

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -235,7 +235,7 @@ class MenuBar extends React.Component {
         if (this.props.shouldSaveBeforeTransition()) {
             this.props.autoUpdateProject(); // save before transitioning to project page
             waitForUpdate({
-                isUpdating: true
+                isSaving: true
             }); // queue the transition to project page
         } else {
             waitForUpdate(); // immediately transition to project page
@@ -249,11 +249,9 @@ class MenuBar extends React.Component {
             if (this.props.canSave) { // save before transitioning to project page
                 this.props.autoUpdateProject();
                 waitForUpdate({
-                    isUpdating: true,
+                    isSaving: true,
                     isSharing: true
                 }); // queue the transition to project page
-            } else {
-                waitForUpdate(); // immediately transition to project page
             }
         }
     }

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -234,9 +234,11 @@ class MenuBar extends React.Component {
     handleClickSeeCommunity (waitForUpdate) {
         if (this.props.shouldSaveBeforeTransition()) {
             this.props.autoUpdateProject(); // save before transitioning to project page
-            waitForUpdate(true); // queue the transition to project page
+            waitForUpdate({
+                isUpdating: true
+            }); // queue the transition to project page
         } else {
-            waitForUpdate(false); // immediately transition to project page
+            waitForUpdate(); // immediately transition to project page
         }
     }
     handleClickShare (waitForUpdate) {
@@ -246,9 +248,12 @@ class MenuBar extends React.Component {
             }
             if (this.props.canSave) { // save before transitioning to project page
                 this.props.autoUpdateProject();
-                waitForUpdate(true); // queue the transition to project page
+                waitForUpdate({
+                    isUpdating: true,
+                    isSharing: true
+                }); // queue the transition to project page
             } else {
-                waitForUpdate(false); // immediately transition to project page
+                waitForUpdate(); // immediately transition to project page
             }
         }
     }
@@ -660,7 +665,10 @@ class MenuBar extends React.Component {
                     <div className={classNames(styles.menuBarItem)}>
                         {this.props.canShare ? (
                             (this.props.isShowingProject || this.props.isUpdating) && (
-                                <ProjectWatcher onDoneUpdating={this.props.onSeeCommunity}>
+                                <ProjectWatcher
+                                    onDoneUpdating={this.props.onSeeCommunity}
+                                    isShared={this.props.isShared}
+                                >
                                     {
                                         waitForUpdate => (
                                             <ShareButton

--- a/packages/scratch-gui/src/containers/project-watcher.jsx
+++ b/packages/scratch-gui/src/containers/project-watcher.jsx
@@ -16,7 +16,7 @@ import {
  * project is no longer updating.
  *
  * The waitForUpdate function accepts an object containing:
- * - isUpdating {boolean} Whether the project is currently updating
+ * - isSaving {boolean} Whether the project is currently saving
  * - isSharing {boolean} Whether the project is currently being shared
  */
 class ProjectWatcher extends React.Component {
@@ -32,12 +32,13 @@ class ProjectWatcher extends React.Component {
         };
     }
     componentDidUpdate (prevProps) {
-        if (this.state.saving) {
-            if (!this.state.sharing && this.props.isShowingWithId && !prevProps.isShowingWithId) {
+        if (this.state.saving && this.state.sharing) {
+            if (this.props.isShared && this.props.isShowingWithId) {
                 this.fulfill();
             }
-
-            if (this.state.sharing && this.props.isShared && this.props.isShowingWithId) {
+        }
+        if (this.state.saving && !this.state.sharing) {
+            if (this.props.isShowingWithId && !prevProps.isShowingWithId) {
                 this.fulfill();
             }
         }
@@ -49,12 +50,12 @@ class ProjectWatcher extends React.Component {
             sharing: false
         });
     }
-    waitForUpdate (updates = {isUpdating: false, isSharing: false}) {
-        const {isUpdating = false, isSharing = false} = updates;
+    waitForUpdate (updates = {isSaving: false, isSharing: false}) {
+        const {isSaving = false, isSharing = false} = updates;
 
-        if (isUpdating || isSharing) {
+        if (isSaving || isSharing) {
             this.setState({
-                saving: isUpdating,
+                saving: isSaving,
                 sharing: isSharing
             });
         } else { // fulfill immediately

--- a/packages/scratch-gui/src/containers/project-watcher.jsx
+++ b/packages/scratch-gui/src/containers/project-watcher.jsx
@@ -14,6 +14,10 @@ import {
  * ProjectWatcher passes a waitForUpdate function to its children, which they can call
  * to set ProjectWatcher to request that it call the onDoneUpdating callback when
  * project is no longer updating.
+ *
+ * The waitForUpdate function accepts an object containing:
+ * - isUpdating {boolean} Whether the project is currently updating
+ * - isSharing {boolean} Whether the project is currently being shared
  */
 class ProjectWatcher extends React.Component {
     constructor (props) {
@@ -28,12 +32,14 @@ class ProjectWatcher extends React.Component {
         };
     }
     componentDidUpdate (prevProps) {
-        if (
-            this.state.saving &&
-            (!this.state.sharing || this.props.isShared) &&
-            this.props.isShowingWithId && !prevProps.isShowingWithId
-        ) {
-            this.fulfill();
+        if (this.state.saving) {
+            if (!this.state.sharing && this.props.isShowingWithId && !prevProps.isShowingWithId) {
+                this.fulfill();
+            }
+
+            if (this.state.sharing && this.props.isShared && this.props.isShowingWithId) {
+                this.fulfill();
+            }
         }
     }
     fulfill () {
@@ -44,7 +50,7 @@ class ProjectWatcher extends React.Component {
         });
     }
     waitForUpdate (updates = {isUpdating: false, isSharing: false}) {
-        const {isUpdating, isSharing} = updates;
+        const {isUpdating = false, isSharing = false} = updates;
 
         if (isUpdating || isSharing) {
             this.setState({

--- a/packages/scratch-gui/src/containers/project-watcher.jsx
+++ b/packages/scratch-gui/src/containers/project-watcher.jsx
@@ -23,24 +23,33 @@ class ProjectWatcher extends React.Component {
         ]);
 
         this.state = {
-            waiting: false
+            saving: false,
+            sharing: false
         };
     }
     componentDidUpdate (prevProps) {
-        if (this.state.waiting && this.props.isShowingWithId && !prevProps.isShowingWithId) {
+        if (
+            this.state.saving &&
+            (!this.state.sharing || this.props.isShared) &&
+            this.props.isShowingWithId && !prevProps.isShowingWithId
+        ) {
             this.fulfill();
         }
     }
     fulfill () {
         this.props.onDoneUpdating();
         this.setState({
-            waiting: false
+            saving: false,
+            sharing: false
         });
     }
-    waitForUpdate (isUpdating) {
-        if (isUpdating) {
+    waitForUpdate (updates = {isUpdating: false, isSharing: false}) {
+        const {isUpdating, isSharing} = updates;
+
+        if (isUpdating || isSharing) {
             this.setState({
-                waiting: true
+                saving: isUpdating,
+                sharing: isSharing
             });
         } else { // fulfill immediately
             this.fulfill();
@@ -56,10 +65,12 @@ class ProjectWatcher extends React.Component {
 ProjectWatcher.propTypes = {
     children: PropTypes.func,
     isShowingWithId: PropTypes.bool,
+    isShared: PropTypes.bool,
     onDoneUpdating: PropTypes.func
 };
 
 ProjectWatcher.defaultProps = {
+    isShared: false,
     onDoneUpdating: () => {}
 };
 


### PR DESCRIPTION
### Resolves

- [UEPR-523](https://scratchfoundation.atlassian.net/browse/UEPR-523)

### Proposed Changes

- Wait for project to be shared in Project Watcher before moving to www

### Reason for Changes

- Now that the manual thumbnail update is moved to the editor, we want to display the Share Modal inside the editor and move to www after the project was actually shared

### Test Coverage

Existing tests complete successfully; no new test cases added

[UEPR-523]: https://scratchfoundation.atlassian.net/browse/UEPR-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ