### PR TITLE
fix(ci): build with new version before testing and publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,7 @@ jobs:
       - if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         uses: ./.github/actions/install-dependencies
 
-      # IMPORTANT: always build all packages or none - never a subset.
-      # The publish workflow reuses these artifacts, so partial artifacts would cause publish
-      # failures for omitted packages.
+      # TODO: Packages currently depend on each other's compiled dist at build time. Fix that and matrix the builds.
       - name: Build packages
         if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         run: npm run build
@@ -89,36 +87,13 @@ jobs:
             packages/**/playground
 
   test:
-    runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.outputs.any-workspace == 'true' && needs.build.outputs.packages != '[]' }}
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: read
-      issues: read
-    strategy:
-      fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.build.outputs.packages) }}
-    name: Test ${{ matrix.package }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          cache: 'npm'
-          node-version-file: '.nvmrc'
-      - uses: ./.github/actions/install-dependencies
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
-        with:
-          name: build
-          path: packages
-      - uses: ./.github/actions/test-package
-        with:
-          package_name: ${{ matrix.package }}
+    uses: ./.github/workflows/test-packages.yml
+    with:
+      packages: ${{ needs.build.outputs.packages }}
 
   preview:
-    runs-on: ubuntu-latest
     needs: build
     # We don't want to give forks free reign to publish to our GitHub Pages, so run this job only if both:
     # - any workspace changed (otherwise there's no work to do)
@@ -135,68 +110,9 @@ jobs:
         ) &&
         (!startsWith((github.head_ref || github.ref_name), 'renovate/'))
       }}
-    name: Publish preview playgrounds to GitHub Pages
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-        with:
-          sparse-checkout: .github/actions/deploy-pages-with-retry/
-          fetch-depth: 1
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-          lfs: false
-          submodules: false
-      - name: Determine GitHub Pages directory name
-        id: branch_dir_name
-        # even `develop` should be published to a subdirectory
-        # that way each branch can be updated or cleaned up independently
-        run: |
-          echo "result=${GITHUB_REF_NAME//[^A-Za-z0-9._-]/_}" | tee --append "$GITHUB_OUTPUT"
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
-        with:
-          name: build
-          path: packages
-      - name: Prepare playgrounds for GitHub Pages
-        working-directory: ./packages
-        run: |
-          mkdir -p ../pages/
-          for pkg in *; do
-            if [ -d "${pkg}/playground" ]; then
-              # using symlinks is quick and artifact generation will dereference them
-              # if the GitHub Pages action stops dereferencing these links, we'll need to copy the files instead
-              ln -s "../packages/${pkg}/playground" "../pages/${pkg}"
-            fi
-          done
-
-          # scratch-gui doesn't follow the pattern above
-          ln -s "../packages/scratch-gui/build" "../pages/scratch-gui"
-
-          ls -l ../pages/
-      - name: Deploy playgrounds to GitHub Pages
-        uses: ./.github/actions/deploy-pages-with-retry
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./pages
-          destination_dir: "${{steps.branch_dir_name.outputs.result}}"
-          full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"
-
-  results:
-    name: Test Results
-    runs-on: ubuntu-latest
-    needs: test
-    if: ${{ !cancelled() && needs.test.result != 'skipped' }}
-    steps:
-      - run: |
-          case "${{ needs.test.result }}" in
-            success)
-              echo "Tests passed successfully."
-              exit 0
-              ;;
-            cancelled)
-              echo "Tests were cancelled."
-              exit 1
-              ;;
-            *)
-              echo "Tests failed. Result: ${{ needs.test.result }}"
-              exit 1
-              ;;
-          esac
+    uses: ./.github/workflows/deploy-playground-preview.yml
+    with:
+      # even `develop` should be published to a subdirectory
+      # that way each branch can be updated or cleaned up independently
+      destination_dir: ${{ github.head_ref || github.ref_name }}
+      full_commit_message: "Build for ${{ github.sha }} ${{ github.event.head_commit.message }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
-      - name: Debug info
+      - name: Debug Info
         # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
         env:
           # `env:` values are printed to the log even without using them in `run:`
@@ -54,7 +54,7 @@ jobs:
         with:
           filters: ./.github/path-filters.yml
 
-      - name: Resolve changed packages
+      - name: Resolve Changed Packages
         id: filter
         run: |
           if [ "${{ inputs.force-full-build }}" = "true" ]; then
@@ -71,11 +71,11 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       # TODO: Packages currently depend on each other's compiled dist at build time. Fix that and matrix the builds.
-      - name: Build packages
+      - name: Build Packages
         if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         run: npm run build
 
-      - name: Store build artifacts
+      - name: Store Build Artifacts
         if: ${{ steps.filter.outputs.any-workspace == 'true' }}
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
@@ -87,6 +87,7 @@ jobs:
             packages/**/playground
 
   test:
+    name: Test
     needs: build
     if: ${{ needs.build.outputs.any-workspace == 'true' && needs.build.outputs.packages != '[]' }}
     uses: ./.github/workflows/test-packages.yml
@@ -94,6 +95,7 @@ jobs:
       packages: ${{ needs.build.outputs.packages }}
 
   preview:
+    name: Preview
     needs: build
     # We don't want to give forks free reign to publish to our GitHub Pages, so run this job only if both:
     # - any workspace changed (otherwise there's no work to do)

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,4 +1,4 @@
-name: Lint commit messages
+name: Lint Commit Messages
 on: [pull_request]
 
 concurrency:

--- a/.github/workflows/deploy-playground-preview.yml
+++ b/.github/workflows/deploy-playground-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy playground preview
+name: Deploy Playground Preview
 
 on:
   workflow_call:
@@ -15,7 +15,7 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    name: Publish preview playgrounds to GitHub Pages
+    name: Publish Preview Playgrounds to GitHub Pages
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
           lfs: false
           submodules: false
-      - name: Sanitize destination directory name
+      - name: Sanitize Destination Directory Name
         id: dir
         env:
           DESTINATION_DIR: ${{ inputs.destination_dir }}
@@ -35,7 +35,7 @@ jobs:
         with:
           name: build
           path: packages
-      - name: Prepare playgrounds for GitHub Pages
+      - name: Prepare Playgrounds for GitHub Pages
         working-directory: ./packages
         run: |
           mkdir -p ../pages/
@@ -51,7 +51,7 @@ jobs:
           ln -s "../packages/scratch-gui/build" "../pages/scratch-gui"
 
           ls -l ../pages/
-      - name: Deploy playgrounds to GitHub Pages
+      - name: Deploy Playgrounds to GitHub Pages
         uses: ./.github/actions/deploy-pages-with-retry
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-playground-preview.yml
+++ b/.github/workflows/deploy-playground-preview.yml
@@ -1,0 +1,60 @@
+name: Deploy playground preview
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        description: 'Destination subdirectory for GitHub Pages (will be sanitized)'
+        type: string
+        required: true
+      full_commit_message:
+        description: 'Commit message for the GitHub Pages deployment'
+        type: string
+        required: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    name: Publish preview playgrounds to GitHub Pages
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          sparse-checkout: .github/actions/deploy-pages-with-retry/
+          fetch-depth: 1
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - name: Sanitize destination directory name
+        id: dir
+        env:
+          DESTINATION_DIR: ${{ inputs.destination_dir }}
+        run: |
+          echo "result=${DESTINATION_DIR//[^A-Za-z0-9._-]/_}" | tee --append "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: build
+          path: packages
+      - name: Prepare playgrounds for GitHub Pages
+        working-directory: ./packages
+        run: |
+          mkdir -p ../pages/
+          for pkg in *; do
+            if [ -d "${pkg}/playground" ]; then
+              # using symlinks is quick and artifact generation will dereference them
+              # if the GitHub Pages action stops dereferencing these links, we'll need to copy the files instead
+              ln -s "../packages/${pkg}/playground" "../pages/${pkg}"
+            fi
+          done
+
+          # scratch-gui doesn't follow the pattern above
+          ln -s "../packages/scratch-gui/build" "../pages/scratch-gui"
+
+          ls -l ../pages/
+      - name: Deploy playgrounds to GitHub Pages
+        uses: ./.github/actions/deploy-pages-with-retry
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./pages
+          destination_dir: "${{ steps.dir.outputs.result }}"
+          full_commit_message: "${{ inputs.full_commit_message }}"

--- a/.github/workflows/gha-debug.yml
+++ b/.github/workflows/gha-debug.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions debug info
+name: GitHub Actions Debug Info
 
 on:
   branch_protection_rule:
@@ -41,7 +41,7 @@ jobs:
   info:
     runs-on: ubuntu-latest
     steps:
-      - name: Output debug info
+      - name: Output Debug Info
         env:
           github: ${{ toJson(github) }}
         run: |

--- a/.github/workflows/ghpages-cleanup.yml
+++ b/.github/workflows/ghpages-cleanup.yml
@@ -15,16 +15,16 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check out GitHub Pages branch
+      - name: Check Out GitHub Pages Branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           # replace `fetch-depth` with `shallow-since` if and when actions/checkout#619 (or an equivalent) gets merged
           # then remove the "Fetch a bit more history" step below
           fetch-depth: 1
           ref: gh-pages
-      - name: Fetch a bit more history
+      - name: Fetch a Bit More History
         run: git fetch --update-shallow --shallow-since="32 days ago" origin gh-pages
-      - name: Mark stale directories for removal
+      - name: Mark Stale Directories for Removal
         run: |
           for dir in */; do
             [ -L "${dir%/}" ] && continue  # skip symlinks (trim trailing slash for test)
@@ -33,7 +33,7 @@ jobs:
               git rm --quiet -r "$dir"
             fi
           done
-      - name: Configure git user
+      - name: Configure Git User
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,81 +5,11 @@ on:
     types: [published]
 
 jobs:
-  find-artifacts:
-    name: Find CI artifacts
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-    outputs:
-      ci-run-id: ${{ steps.find.outputs.run-id }}
-      needs-build: ${{ steps.find.outputs.needs-build }}
-    steps:
-      - name: Find successful CI run for release target
-        id: find
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET: ${{ github.event.release.target_commitish }}
-        shell: bash
-        run: |
-          # Resolve branch name or tag to a commit SHA
-          SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$TARGET" --jq '.sha' 2>/dev/null || echo "$TARGET")
-          echo "Resolved target '$TARGET' to SHA: $SHA"
-
-          # Find the most recent successful CI run for this SHA that has a build artifact
-          RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
-            --method GET \
-            -F "head_sha=$SHA" \
-            -F "status=success" \
-            -F "per_page=10" \
-            --jq '.workflow_runs[].id') || {
-            echo "::error::Failed to query CI workflow runs. If ci.yml was renamed, update the reference in the find-artifacts job in publish.yml."
-            exit 1
-          }
-
-          USABLE_RUN_ID=""
-          for ID in $RUN_ID; do
-            HAS_ARTIFACT=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ID/artifacts" \
-              --jq '[.artifacts[] | select(.name == "build" and .expired == false)] | length')
-            if [ "$HAS_ARTIFACT" -gt 0 ]; then
-              USABLE_RUN_ID="$ID"
-              break
-            fi
-          done
-
-          if [ -z "$USABLE_RUN_ID" ]; then
-            echo "No successful CI run with a valid build artifact found for SHA $SHA. A fresh build will be triggered."
-            echo "run-id=" >> "$GITHUB_OUTPUT"
-            echo "needs-build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Found suitable CI run: $USABLE_RUN_ID"
-            echo "run-id=$USABLE_RUN_ID" >> "$GITHUB_OUTPUT"
-            echo "needs-build=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
-    name: Build (no prior CI run found)
-    needs: find-artifacts
-    if: ${{ needs.find-artifacts.outputs.needs-build == 'true' }}
-    uses: ./.github/workflows/ci.yml
-    with:
-      force-full-build: true
-
-  cd:
-    name: Publish to npm
-    needs:
-      - find-artifacts
-      - build
-    # Run if find-artifacts succeeded AND (build succeeded OR build was skipped because artifacts already exist)
-    if: ${{ !cancelled() && needs.find-artifacts.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
+    name: Build
     runs-on: ubuntu-latest
-    permissions:
-      actions: read  # to download artifacts from the CI run
-      contents: write  # to push the version commit and tag
-      issues: write  # to comment on issues when a fix is released
-      pull-requests: write  # to comment on PRs when a fix is released
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    outputs:
+      packages: ${{ steps.list-packages.outputs.packages }}
     steps:
       - name: Debug info
         # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
@@ -93,6 +23,69 @@ jobs:
           Release target commit-ish: $RELEASE_TARGET_COMMITISH
           EOF
 
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - uses: ./.github/actions/install-dependencies
+
+      - name: Bump version
+        shell: bash
+        env:
+          GIT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          NEW_VERSION="${GIT_TAG/v/}"
+          npm version "$NEW_VERSION" --no-git-tag-version
+
+      - name: Build packages
+        run: npm run build
+
+      - name: List packages
+        id: list-packages
+        run: |
+          PACKAGES=$(ls -1d packages/*/ | xargs -n1 basename | jq -Rcn '[inputs]')
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: build
+          retention-days: 90
+          path: |
+            packages/**/build
+            packages/**/dist
+            packages/**/playground
+
+  test:
+    needs: build
+    uses: ./.github/workflows/test-packages.yml
+    with:
+      packages: ${{ needs.build.outputs.packages }}
+
+  preview:
+    needs: build
+    uses: ./.github/workflows/deploy-playground-preview.yml
+    with:
+      destination_dir: ${{ github.event.release.target_commitish }}
+      full_commit_message: "Build for release ${{ github.event.release.tag_name }}"
+
+  cd:
+    name: Publish to npm
+    needs:
+      - build
+      - test
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # to push the version commit and tag
+      issues: write  # to comment on issues when a fix is released
+      pull-requests: write  # to comment on PRs when a fix is released
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
       - name: Determine NPM tag
         shell: bash
         env:
@@ -140,31 +133,20 @@ jobs:
 
       - uses: ./.github/actions/install-dependencies
 
-      - name: Download build artifacts (from previous CI run)
-        if: ${{ needs.build.result == 'skipped' }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
-        with:
-          name: build
-          path: packages
-          run-id: ${{ needs.find-artifacts.outputs.ci-run-id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download build artifacts (from fallback build in this run)
-        if: ${{ needs.build.result == 'success' }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
-        with:
-          name: build
-          path: packages
-
-      - name: Update the version in the package files
+      - name: Bump version and commit
         shell: bash
         env:
           GIT_TAG: ${{ github.event.release.tag_name }}
         run: |
           NEW_VERSION="${GIT_TAG/v/}"
-
           npm version "$NEW_VERSION" --no-git-tag-version
           git add package* && git commit -m "chore(release): $NEW_VERSION [skip ci]"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: build
+          path: packages
 
       - name: Publish scratch-svg-renderer
         run: npm publish --access=public --tag="$NPM_TAG" --ignore-scripts --workspace=@scratch/scratch-svg-renderer
@@ -207,10 +189,11 @@ jobs:
         run: |
           git fetch origin develop
 
-          LAST_COMMIT_ID="$(git rev-parse "$TAG_NAME")"
+          # HEAD is the version bump commit; HEAD^ is the release target commit
+          RELEASE_TARGET_COMMIT="$(git rev-parse HEAD^)"
           DEVELOP_COMMIT_ID="$(git rev-parse origin/develop)"
 
-          if [ "$LAST_COMMIT_ID" = "$DEVELOP_COMMIT_ID" ]; then
+          if [ "$RELEASE_TARGET_COMMIT" = "$DEVELOP_COMMIT_ID" ]; then
             git push origin HEAD:develop
           else
             echo "Not pushing to develop because the tag we're operating on is behind"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       packages: ${{ steps.list-packages.outputs.packages }}
     steps:
-      - name: Debug info
+      - name: Debug Info
         # https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
         env:
           # `env:` values are printed to the log even without using them in `run:`
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/install-dependencies
 
-      - name: Bump version
+      - name: Bump Version
         shell: bash
         env:
           GIT_TAG: ${{ github.event.release.tag_name }}
@@ -40,16 +40,16 @@ jobs:
           NEW_VERSION="${GIT_TAG/v/}"
           npm version "$NEW_VERSION" --no-git-tag-version
 
-      - name: Build packages
+      - name: Build Packages
         run: npm run build
 
-      - name: List packages
+      - name: List Packages
         id: list-packages
         run: |
           PACKAGES=$(ls -1d packages/*/ | xargs -n1 basename | jq -Rcn '[inputs]')
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
 
-      - name: Store build artifacts
+      - name: Store Build Artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: build
@@ -86,7 +86,7 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - name: Determine NPM tag
+      - name: Determine NPM Tag
         shell: bash
         env:
           TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
@@ -108,14 +108,14 @@ jobs:
           echo "Determined NPM tag: [$npm_tag]"
           echo "NPM_TAG=${npm_tag}" >> "$GITHUB_ENV"
 
-      - name: Check NPM tag
+      - name: Check NPM Tag
         run: |
           if [ -z "$NPM_TAG" ]; then
             echo "Refusing to publish with empty NPM tag."
             exit 1
           fi
 
-      - name: Config GitHub user
+      - name: Configure GitHub User
         shell: bash
         run: |
           git config --global user.name 'GitHub Actions'
@@ -133,7 +133,7 @@ jobs:
 
       - uses: ./.github/actions/install-dependencies
 
-      - name: Bump version and commit
+      - name: Bump Version and Commit
         shell: bash
         env:
           GIT_TAG: ${{ github.event.release.tag_name }}
@@ -142,7 +142,7 @@ jobs:
           npm version "$NEW_VERSION" --no-git-tag-version
           git add package* && git commit -m "chore(release): $NEW_VERSION [skip ci]"
 
-      - name: Download build artifacts
+      - name: Download Build Artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: build
@@ -182,7 +182,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - name: Push to develop
+      - name: Push to Develop
         shell: bash
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
@@ -199,7 +199,7 @@ jobs:
             echo "Not pushing to develop because the tag we're operating on is behind"
           fi
 
-      - name: Comment on resolved issues and merged PRs
+      - name: Comment on Resolved Issues and Merged PRs
         if: ${{ !github.event.release.prerelease }}
         uses: apexskier/github-release-commenter@e7813a9625eabd79a875b4bc4046cfcae377ab34 # v1
         with:
@@ -208,7 +208,7 @@ jobs:
             :tada: This is included in release {release_link}.
 
       # See https://stackoverflow.com/a/24849501
-      - name: Change connected commit on release
+      - name: Change Connected Commit on Release
         shell: bash
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}

--- a/.github/workflows/signature-assistant.yml
+++ b/.github/workflows/signature-assistant.yml
@@ -1,4 +1,4 @@
-name: "Signature Assistant"
+name: Signature Assistant
 on:
   issue_comment:
     types: [created]
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: scratchfoundation/scratch-agreements/.github/actions/cla-allowlist@main
         id: cla-allowlist
-      - name: "CLA Assistant"
+      - name: CLA Assistant
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -1,4 +1,4 @@
-name: Test packages
+name: Test Packages
 
 on:
   workflow_call:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -1,0 +1,59 @@
+name: Test packages
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: 'JSON array of package names to test'
+        type: string
+        required: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(inputs.packages) }}
+    name: Test ${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - uses: ./.github/actions/install-dependencies
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: build
+          path: packages
+      - uses: ./.github/actions/test-package
+        with:
+          package_name: ${{ matrix.package }}
+
+  results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ !cancelled() }}
+    steps:
+      - run: |
+          case "${{ needs.test.result }}" in
+            success)
+              echo "Tests passed successfully."
+              exit 0
+              ;;
+            cancelled)
+              echo "Tests were cancelled."
+              exit 1
+              ;;
+            *)
+              echo "Tests failed. Result: ${{ needs.test.result }}"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
### Resolves

Resolves an issue I introduced with scratchfoundation/scratch-editor#478

### Proposed Changes

The main change is to adjust `publish.yml` to perform these steps in this order (assuming no failures):

1. Check out
2. Apply new version number
3. Build
4. Test
5. Publish

As opposed to the behavior last week:

1. Check out
2. Build
3. Test
4. Apply new version number
5. Build
6. Publish

Or the behavior introduced by scratchfoundation/scratch-editor#478:

1. Check out
2. Build
3. Test
4. Apply new version number
5. Publish the build from step 2, but with the adjusted version metadata

Supporting changes: significant refactoring of `ci.yml` and `publish.yml`, including the creation of separate (called) workflows for testing and publishing to GH Pages.

### Reason for Changes

After merging scratchfoundation/scratch-editor#478, I discovered that packages are published under their intended version number, but _contain_ the previous version number. For example, if you inspect `dist/scratch-gui.js` from [@scratch/scratch-gui@13.4.0-test.3](https://www.npmjs.com/package/@scratch/scratch-gui/v/13.4.0-test.3), you'll notice the version number `13.3.0` embedded within. The changes here fix that. (It's too bad nobody could have [predicted](https://github.com/scratchfoundation/scratch-editor/pull/478#discussion_r2976096516) this problem! :sweat_smile:)

The ~easiest~ natural way to fix that meant rearranging the existing steps so much that calling `ci.yml` from `publish.yml` no longer made sense, so I refactored the workflows to keep things somewhat DRY.

As a bonus, this means `publish.yml` can build everything without worrying about path filters, and lays the groundwork for matrixing the build step in `ci.yml`.

### Test Coverage

Partially tested locally, but I'll also do a test publish or twelve after merging to resolve any issues that are difficult to predict.