### PR TITLE
feat: add feature callout for set thumbnail button in editor

### DIFF
--- a/packages/scratch-gui/src/components/confirmation-prompt/confirmation-prompt.jsx
+++ b/packages/scratch-gui/src/components/confirmation-prompt/confirmation-prompt.jsx
@@ -147,7 +147,9 @@ const ConfirmationPrompt = ({
             arrowConfig={arrowConfig}
             title={title}
         >
-            <Box className={classNames(styles.modalContainer, containerClassName)}>
+            <Box
+                className={classNames(styles.modalContainer, containerClassName)}
+            >
                 <Box className={classNames(styles.label, messageClassName)}>
                     {message}
                 </Box>

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
@@ -33,3 +33,28 @@
     font-weight: 400;
     line-height: 1.25rem;
 }
+
+.non-blocking-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 510;
+    background-color: transparent;
+    pointer-events: none;
+}
+
+.non-blocking-content {
+    border: none;
+    border-radius: 0;
+    height: fit-content;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    position: fixed;
+    overflow: visible;
+    z-index: 1000;
+    pointer-events: auto;
+    outline: none;
+}

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
@@ -1,4 +1,5 @@
 @import "../../css/colors.css";
+@import "../../css/z-index.css";
 
 .popover {
     display: flex;
@@ -40,7 +41,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 510;
+    z-index: $z-index-modal-overlay;
     background-color: transparent;
     pointer-events: none;
 }
@@ -54,7 +55,13 @@
     padding: 0;
     margin: 0;
     position: fixed;
-    z-index: 1000;
+    z-index: $z-index-modal;
     pointer-events: auto;
-    outline: none;
 }
+
+/* When opened on first render, the popover will have `focus-visible`, which applies the outline.
+   Ideally, we'd only want to show an outline after the user has interacted with it via keyboard */
+.non-blocking-content:focus-visible {
+    outline: none; 
+}
+

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
@@ -46,6 +46,7 @@
 }
 
 .non-blocking-content {
+    display: flex;
     border: none;
     border-radius: 0;
     height: fit-content;
@@ -53,7 +54,6 @@
     padding: 0;
     margin: 0;
     position: fixed;
-    overflow: visible;
     z-index: 1000;
     pointer-events: auto;
     outline: none;

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.css
@@ -35,18 +35,17 @@
     line-height: 1.25rem;
 }
 
-.non-blocking-overlay {
+.modal-overlay {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: $z-index-modal-overlay;
     background-color: transparent;
     pointer-events: none;
 }
 
-.non-blocking-content {
+.modal-content {
     display: flex;
     border: none;
     border-radius: 0;
@@ -61,7 +60,7 @@
 
 /* When opened on first render, the popover will have `focus-visible`, which applies the outline.
    Ideally, we'd only want to show an outline after the user has interacted with it via keyboard */
-.non-blocking-content:focus-visible {
+.modal-content:focus-visible {
     outline: none; 
 }
 

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.jsx
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.jsx
@@ -55,6 +55,7 @@ const FeatureCalloutPopover = ({
     align,
     title,
     body,
+    nonBlocking,
     layoutConfig
 }) => {
     const {
@@ -91,6 +92,10 @@ const FeatureCalloutPopover = ({
             align={align}
             layoutConfig={memoizedLayoutConfig}
             arrowConfig={arrowConfig}
+            {...(nonBlocking ? {
+                modalOverlayStyle: styles.nonBlockingOverlay,
+                modalContentStyle: styles.nonBlockingContent
+            } : {})}
         >
             <FeatureCalloutContent
                 title={title}
@@ -108,6 +113,7 @@ FeatureCalloutPopover.propTypes = {
     align: PropTypes.oneOf(Object.values(PopupAlign)),
     title: PropTypes.node,
     body: PropTypes.node.isRequired,
+    nonBlocking: PropTypes.bool,
     layoutConfig: PropTypes.shape({
         width: PropTypes.number,
         spaceForArrow: PropTypes.number,

--- a/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.jsx
+++ b/packages/scratch-gui/src/components/feature-callout-popover/feature-callout-popover.jsx
@@ -55,7 +55,6 @@ const FeatureCalloutPopover = ({
     align,
     title,
     body,
-    nonBlocking,
     layoutConfig
 }) => {
     const {
@@ -92,10 +91,9 @@ const FeatureCalloutPopover = ({
             align={align}
             layoutConfig={memoizedLayoutConfig}
             arrowConfig={arrowConfig}
-            {...(nonBlocking ? {
-                modalOverlayStyle: styles.nonBlockingOverlay,
-                modalContentStyle: styles.nonBlockingContent
-            } : {})}
+            arrowStyle={styles.arrow}
+            modalOverlayStyle={styles.modalOverlay}
+            modalContentStyle={styles.modalContent}
         >
             <FeatureCalloutContent
                 title={title}
@@ -113,7 +111,6 @@ FeatureCalloutPopover.propTypes = {
     align: PropTypes.oneOf(Object.values(PopupAlign)),
     title: PropTypes.node,
     body: PropTypes.node.isRequired,
-    nonBlocking: PropTypes.bool,
     layoutConfig: PropTypes.shape({
         width: PropTypes.number,
         spaceForArrow: PropTypes.number,

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -543,6 +543,7 @@ const GUIComponent = props => {
                                 ariaLabel={intl.formatMessage(ariaMessages.stage)}
                                 manuallySaveThumbnails={manuallySaveThumbnails}
                                 userOwnsProject={userOwnsProject}
+                                username={username}
                                 onUpdateProjectThumbnail={onUpdateProjectThumbnail}
                             />
                             <Box

--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -191,6 +191,7 @@ const GUIComponent = props => {
         onTelemetryModalOptOut,
         onUpdateProjectThumbnail,
         showComingSoon,
+        showNewFeatureCallouts,
         soundsTabVisible,
         stageSizeMode,
         targetIsStage,
@@ -537,11 +538,14 @@ const GUIComponent = props => {
                                 isFullScreen={isFullScreen}
                                 isRendererSupported={isRendererSupported}
                                 isRtl={isRtl}
+                                isCreating={isCreating}
                                 stageSize={stageSize}
                                 vm={vm}
                                 ariaRole="region"
                                 ariaLabel={intl.formatMessage(ariaMessages.stage)}
                                 manuallySaveThumbnails={manuallySaveThumbnails}
+                                loading={loading}
+                                showNewFeatureCallouts={showNewFeatureCallouts}
                                 userOwnsProject={userOwnsProject}
                                 username={username}
                                 onUpdateProjectThumbnail={onUpdateProjectThumbnail}

--- a/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.css
+++ b/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.css
@@ -1,3 +1,5 @@
+@import "../../css/z-index.css";
+
 .modal-content {
     border: none;
     border-radius: 0;
@@ -7,10 +9,8 @@
     margin: 0;
     position: fixed;
     overflow-x: hidden;
-    z-index: 1000;
-}
-
-.modal-content:focus {
+    z-index: $z-index-modal;
+    /* Apply an outline to the passed children and not the modal itself */
     outline: none;
 }
 
@@ -24,12 +24,12 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 510;
+    z-index: $z-index-modal-overlay;
     background-color: transparent;
 }
 
 .root .arrow {
     position: fixed;
-    z-index: 501;
+    z-index: $z-index-modal;
     border: none;
 }

--- a/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.css
+++ b/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.css
@@ -10,6 +10,14 @@
     z-index: 1000;
 }
 
+.modal-content:focus {
+    outline: none;
+}
+
+.modal-content:focus-visible {
+    outline: revert;
+}
+
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -18,4 +26,10 @@
     bottom: 0;
     z-index: 510;
     background-color: transparent;
+}
+
+.root .arrow {
+    position: fixed;
+    z-index: 501;
+    border: none;
 }

--- a/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
+++ b/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import calculatePopupPosition, {PopupAlign, PopupSide} from '../../lib/calculatePopupPosition';
 import ReactModal from 'react-modal';
 import ReactDOM from 'react-dom';
+import classNames from 'classnames';
 import styles from './modal-with-arrow.css';
 
 const ModalWithArrow = ({
@@ -94,8 +95,8 @@ const ModalWithArrow = ({
                 isOpen
                 onRequestClose={onRequestClose}
                 contentLabel={title}
-                className={modalContentStyle}
-                overlayClassName={modalOverlayStyle}
+                className={classNames(styles.modalContent, modalContentStyle)}
+                overlayClassName={classNames(styles.modalOverlay, modalOverlayStyle)}
                 onAfterOpen={updatePosition}
                 contentRef={onPopupMount}
                 style={{
@@ -155,9 +156,7 @@ ModalWithArrow.propTypes = {
 
 ModalWithArrow.defaultProps = {
     align: PopupAlign.CENTER,
-    onRequestClose: null,
-    modalContentStyle: styles.modalContent,
-    modalOverlayStyle: styles.modalOverlay
+    onRequestClose: null
 };
 
 export default ModalWithArrow;

--- a/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
+++ b/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
@@ -88,7 +88,7 @@ const ModalWithArrow = ({
     if (!isOpen) return null;
 
     return (
-        <>
+        <div className={styles.root}>
             <ReactModal
                 isOpen
                 onRequestClose={onRequestClose}
@@ -112,19 +112,16 @@ const ModalWithArrow = ({
                     src={arrowIcon}
                     alt=""
                     aria-hidden="true"
+                    className={styles.arrow}
                     style={{
-                        position: 'fixed',
                         top: pos.arrowTop,
                         left: pos.arrowLeft,
                         width: rotatedArrowWidth,
-                        height: rotatedArrowHeight,
-                        zIndex: 1001,
-                        border: 'none',
-                        backgroundColor: 'transparent'
+                        height: rotatedArrowHeight
                     }}
                 />
             )}
-        </>
+        </div>
     );
 };
 

--- a/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
+++ b/packages/scratch-gui/src/components/modal-with-arrow/modal-with-arrow.jsx
@@ -2,6 +2,7 @@ import React, {useRef, useState, useCallback, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import calculatePopupPosition, {PopupAlign, PopupSide} from '../../lib/calculatePopupPosition';
 import ReactModal from 'react-modal';
+import ReactDOM from 'react-dom';
 import styles from './modal-with-arrow.css';
 
 const ModalWithArrow = ({
@@ -87,7 +88,7 @@ const ModalWithArrow = ({
     
     if (!isOpen) return null;
 
-    return (
+    return ReactDOM.createPortal(
         <div className={styles.root}>
             <ReactModal
                 isOpen
@@ -121,7 +122,8 @@ const ModalWithArrow = ({
                     }}
                 />
             )}
-        </div>
+        </div>,
+        document.body
     );
 };
 

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -27,7 +27,7 @@ import classNames from 'classnames';
 import {PopupAlign, PopupSide} from '../../lib/calculatePopupPosition.js';
 import {getLocalStorageValue, setLocalStorageValue} from '../../lib/local-storage.js';
 
-const LOCAL_STORAGE_KEY = 'introducedEditorManualSetThumbnail';
+const LOCAL_STORAGE_KEY = 'hasIntroducedEditorManualSetThumbnail';
 
 const messages = defineMessages({
     largeStageSizeMessage: {
@@ -156,7 +156,12 @@ const StageHeaderComponent = function (props) {
 
     const onThumbnailPromptOpen = useCallback(() => {
         setIsThumbnailPromptOpen(true);
-        setLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '', true);
+        try {
+            setLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '', true);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn('Unable to set thumbnail tooltip local storage value. Check if local storage is enabled.', e);
+        }
         setIsThumbnailTooltipOpen(false);
     }, [username]);
 

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -1,6 +1,6 @@
 import {defineMessages, FormattedMessage, useIntl} from 'react-intl';
 import PropTypes from 'prop-types';
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import VM from '@scratch/scratch-vm';
 
 import Box from '../box/box.jsx';
@@ -25,6 +25,9 @@ import ConfirmationPrompt from '../confirmation-prompt/confirmation-prompt.jsx';
 import FeatureCalloutPopover from '../feature-callout-popover/feature-callout-popover.jsx';
 import classNames from 'classnames';
 import {PopupAlign, PopupSide} from '../../lib/calculatePopupPosition.js';
+import {getLocalStorageValue, setLocalStorageValue} from '../../lib/local-storage.js';
+
+const LOCAL_STORAGE_KEY = 'introducedEditorManualSetThumbnail';
 
 const messages = defineMessages({
     largeStageSizeMessage: {
@@ -92,6 +95,7 @@ const StageHeaderComponent = function (props) {
         vm,
         isProjectLoaded,
         userOwnsProject,
+        username,
         onShowSettingThumbnail,
         onShowThumbnailSuccess,
         onShowThumbnailError
@@ -105,6 +109,18 @@ const StageHeaderComponent = function (props) {
     const [isThumbnailPromptOpen, setIsThumbnailPromptOpen] = useState(false);
     const [isThumbnailTooltipOpen, setIsThumbnailTooltipOpen] = useState(false);
     const [isUpdatingThumbnail, setIsUpdatingThumbnail] = useState(false);
+
+    // TODO: Remove this callout after 60 days of manual thumbnail update release.
+    const shouldShowCallout = manuallySaveThumbnails && isProjectLoaded && userOwnsProject &&
+        getLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '') !== true;
+
+    useEffect(() => {
+        if (shouldShowCallout) {
+            setIsThumbnailTooltipOpen(true);
+        } else {
+            setIsThumbnailTooltipOpen(false);
+        }
+    }, [shouldShowCallout]);
 
     const onUpdateThumbnail = useCallback(
         throttle(() => {
@@ -140,7 +156,9 @@ const StageHeaderComponent = function (props) {
 
     const onThumbnailPromptOpen = useCallback(() => {
         setIsThumbnailPromptOpen(true);
-    }, []);
+        setLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '', true);
+        setIsThumbnailTooltipOpen(false);
+    }, [username]);
 
     const onThumbnailPromptClose = useCallback(() => {
         setIsThumbnailPromptOpen(false);
@@ -150,10 +168,6 @@ const StageHeaderComponent = function (props) {
         onThumbnailPromptClose();
         onUpdateThumbnail();
     }, [onUpdateThumbnail]);
-
-    const onOpenTooltip = useCallback(() => {
-        setIsThumbnailTooltipOpen(true);
-    }, []);
 
     const onCloseTooltip = useCallback(() => {
         setIsThumbnailTooltipOpen(false);
@@ -231,13 +245,13 @@ const StageHeaderComponent = function (props) {
                 <Box className={styles.stageMenuWrapper}>
                     <Controls vm={vm} />
                     <div className={styles.stageSizeRow}>
-                        {/* To remove - new feature awareness tooltip */}
                         <FeatureCalloutPopover
                             isOpen={isThumbnailTooltipOpen}
                             onRequestClose={onCloseTooltip}
                             targetRef={thumbnailButtonRef}
                             side={PopupSide.LEFT}
                             align={PopupAlign.DOWN}
+                            nonBlocking
                             title={intl.formatMessage(messages.thumbnailTooltipTitle)}
                             body={
                                 <FormattedMessage
@@ -316,6 +330,7 @@ StageHeaderComponent.propTypes = {
     vm: PropTypes.instanceOf(VM).isRequired,
     isProjectLoaded: PropTypes.bool,
     userOwnsProject: PropTypes.bool,
+    username: PropTypes.string,
     onShowSettingThumbnail: PropTypes.func,
     onShowThumbnailError: PropTypes.func,
     onShowThumbnailSuccess: PropTypes.func

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -83,6 +83,7 @@ const StageHeaderComponent = function (props) {
         isFullScreen,
         isPlayerOnly,
         manuallySaveThumbnails,
+        loadingOrCreating,
         onKeyPress,
         onSetStageLarge,
         onSetStageSmall,
@@ -91,9 +92,9 @@ const StageHeaderComponent = function (props) {
         onUpdateProjectThumbnail,
         projectId,
         showBranding,
+        showNewFeatureCallouts,
         stageSizeMode,
         vm,
-        isProjectLoaded,
         userOwnsProject,
         username,
         onShowSettingThumbnail,
@@ -110,8 +111,9 @@ const StageHeaderComponent = function (props) {
     const [isThumbnailTooltipOpen, setIsThumbnailTooltipOpen] = useState(false);
     const [isUpdatingThumbnail, setIsUpdatingThumbnail] = useState(false);
 
+    const shouldShowThumbnailSaveButton = manuallySaveThumbnails && userOwnsProject;
     // TODO: Remove this callout after 60 days of manual thumbnail update release.
-    const shouldShowCallout = manuallySaveThumbnails && isProjectLoaded && userOwnsProject &&
+    const shouldShowCallout = shouldShowThumbnailSaveButton && showNewFeatureCallouts && !loadingOrCreating &&
         getLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '') !== true;
 
     useEffect(() => {
@@ -256,7 +258,6 @@ const StageHeaderComponent = function (props) {
                             targetRef={thumbnailButtonRef}
                             side={PopupSide.LEFT}
                             align={PopupAlign.DOWN}
-                            nonBlocking
                             title={intl.formatMessage(messages.thumbnailTooltipTitle)}
                             body={
                                 <FormattedMessage
@@ -267,7 +268,7 @@ const StageHeaderComponent = function (props) {
                                 />
                             }
                         />
-                        {manuallySaveThumbnails && isProjectLoaded && userOwnsProject && (
+                        {shouldShowThumbnailSaveButton && (
                             <Button
                                 title={intl.formatMessage(messages.setThumbnail)}
                                 className={classNames(
@@ -323,17 +324,18 @@ StageHeaderComponent.propTypes = {
     isFullScreen: PropTypes.bool.isRequired,
     isPlayerOnly: PropTypes.bool.isRequired,
     manuallySaveThumbnails: PropTypes.bool,
+    loadingOrCreating: PropTypes.bool,
     onKeyPress: PropTypes.func.isRequired,
     onSetStageFull: PropTypes.func.isRequired,
     onSetStageLarge: PropTypes.func.isRequired,
     onSetStageSmall: PropTypes.func.isRequired,
     onSetStageUnFull: PropTypes.func.isRequired,
     onUpdateProjectThumbnail: PropTypes.func,
-    projectId: PropTypes.number.isRequired,
+    projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     showBranding: PropTypes.bool.isRequired,
+    showNewFeatureCallouts: PropTypes.bool,
     stageSizeMode: PropTypes.oneOf(Object.keys(STAGE_SIZE_MODES)),
     vm: PropTypes.instanceOf(VM).isRequired,
-    isProjectLoaded: PropTypes.bool,
     userOwnsProject: PropTypes.bool,
     username: PropTypes.string,
     onShowSettingThumbnail: PropTypes.func,

--- a/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
@@ -21,6 +21,7 @@ const StageWrapperComponent = function (props) {
         loading,
         manuallySaveThumbnails,
         onUpdateProjectThumbnail,
+        username,
         userOwnsProject,
         stageSize,
         vm
@@ -40,6 +41,7 @@ const StageWrapperComponent = function (props) {
             <Box className={styles.stageMenuWrapper}>
                 <StageHeader
                     manuallySaveThumbnails={manuallySaveThumbnails}
+                    username={username}
                     userOwnsProject={userOwnsProject}
                     onUpdateProjectThumbnail={onUpdateProjectThumbnail}
                     stageSize={stageSize}
@@ -71,6 +73,7 @@ StageWrapperComponent.propTypes = {
     isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,
     manuallySaveThumbnails: PropTypes.bool,
+    username: PropTypes.string,
     userOwnsProject: PropTypes.bool,
     onUpdateProjectThumbnail: PropTypes.func,
     stageSize: PropTypes.oneOf(Object.keys(STAGE_DISPLAY_SIZES)).isRequired,

--- a/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
@@ -15,6 +15,7 @@ const StageWrapperComponent = function (props) {
     const {
         ariaLabel,
         ariaRole,
+        isCreating,
         isFullScreen,
         isRtl,
         isRendererSupported,
@@ -24,9 +25,9 @@ const StageWrapperComponent = function (props) {
         username,
         userOwnsProject,
         stageSize,
+        showNewFeatureCallouts,
         vm
     } = props;
-
     return (
         <Box
             className={classNames(
@@ -43,7 +44,9 @@ const StageWrapperComponent = function (props) {
                     manuallySaveThumbnails={manuallySaveThumbnails}
                     username={username}
                     userOwnsProject={userOwnsProject}
+                    loadingOrCreating={loading || isCreating}
                     onUpdateProjectThumbnail={onUpdateProjectThumbnail}
+                    showNewFeatureCallouts={showNewFeatureCallouts}
                     stageSize={stageSize}
                     vm={vm}
                 />
@@ -68,11 +71,13 @@ const StageWrapperComponent = function (props) {
 StageWrapperComponent.propTypes = {
     ariaLabel: PropTypes.string,
     ariaRole: PropTypes.string,
+    isCreating: PropTypes.bool,
     isFullScreen: PropTypes.bool,
     isRendererSupported: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,
     manuallySaveThumbnails: PropTypes.bool,
+    showNewFeatureCallouts: PropTypes.bool,
     username: PropTypes.string,
     userOwnsProject: PropTypes.bool,
     onUpdateProjectThumbnail: PropTypes.func,

--- a/packages/scratch-gui/src/containers/stage-header.jsx
+++ b/packages/scratch-gui/src/containers/stage-header.jsx
@@ -9,7 +9,6 @@ import {setFullScreen} from '../reducers/mode';
 import {connect} from 'react-redux';
 
 import StageHeaderComponent from '../components/stage-header/stage-header.jsx';
-import {getIsShowingWithId} from '../reducers/project-state.js';
 import {showAlertWithTimeout, showStandardAlert} from '../reducers/alerts.js';
 
 const ALERT_ID = {
@@ -60,7 +59,6 @@ StageHeader.propTypes = {
 
 const mapStateToProps = state => {
     const projectState = state.scratchGui.projectState;
-    const loadingState = projectState.loadingState;
 
     return {
         stageSizeMode: state.scratchGui.stageSize.stageSize,
@@ -68,8 +66,7 @@ const mapStateToProps = state => {
         isFullScreen: state.scratchGui.mode.isFullScreen,
         isPlayerOnly: state.scratchGui.mode.isPlayerOnly,
 
-        projectId: projectState.projectId,
-        isProjectLoaded: getIsShowingWithId(loadingState)
+        projectId: projectState.projectId
     };
 
 };

--- a/packages/scratch-gui/src/css/z-index.css
+++ b/packages/scratch-gui/src/css/z-index.css
@@ -16,6 +16,7 @@ $z-index-card: 480;
 $z-index-alerts: 490;
 $z-index-menu-bar: 491; /* menu-bar should go over monitors, alerts and tutorials */
 $z-index-loader: 500;
+$z-index-modal-overlay: 501;
 $z-index-modal: 510;
 
 $z-index-drag-layer: 1000;


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-522

### Proposed Changes

Adjust logic for visualisation of feature callout for the manual thumbnail button, which now lives in the editor

### Reason for Changes

Part of the effort to move the manual thumbnail update inside the editor (as opposed to the project page)
