### PR TITLE
Math library accuracy + performance improvements

### DIFF
--- a/packages/scratch-vm/src/blocks/scratch3_operators.js
+++ b/packages/scratch-vm/src/blocks/scratch3_operators.js
@@ -136,8 +136,8 @@ class Scratch3OperatorsBlocks {
         case 'floor': return Math.floor(n);
         case 'ceiling': return Math.ceil(n);
         case 'sqrt': return Math.sqrt(n);
-        case 'sin': return parseFloat(Math.sin((Math.PI * n) / 180).toFixed(10));
-        case 'cos': return parseFloat(Math.cos((Math.PI * n) / 180).toFixed(10));
+        case 'sin': return Math.round(Math.sin((Math.PI * (n % 360)) / 180) * 1e10) / 1e10;
+        case 'cos': return Math.round(Math.cos((Math.PI * (n % 360)) / 180) * 1e10) / 1e10;
         case 'tan': return MathUtil.tan(n);
         case 'asin': return (Math.asin(n) * 180) / Math.PI;
         case 'acos': return (Math.acos(n) * 180) / Math.PI;

--- a/packages/scratch-vm/src/util/cast.js
+++ b/packages/scratch-vm/src/util/cast.js
@@ -161,7 +161,7 @@ class Cast {
                 return true;
             }
             // True if it's "round" (e.g., 2.0 and 2).
-            return val === parseInt(val, 10);
+            return val % 1 === 0;
         } else if (typeof val === 'boolean') {
             // `True` and `false` always represent integer after Scratch cast.
             return true;

--- a/packages/scratch-vm/src/util/math-util.js
+++ b/packages/scratch-vm/src/util/math-util.js
@@ -60,7 +60,7 @@ class MathUtil {
         case 270:
             return -Infinity;
         default:
-            return parseFloat(Math.tan((Math.PI * angle) / 180).toFixed(10));
+            return Math.round(Math.tan((Math.PI * angle) / 180) * 1e10) / 1e10;
         }
     }
 


### PR DESCRIPTION
This corresponds to a [2019 PR](https://github.com/scratchfoundation/scratch-vm/pull/2204) that should have been merged a log time ago.  It addresses two performance & accuracy issues in the previous scratch-vm repository that remain in this repository ([2198](https://github.com/scratchfoundation/scratch-vm/issues/2198) and [2199](https://github.com/scratchfoundation/scratch-vm/issues/2199)) . 

scratch3_operators.js & math-util.js: Floating-point bounding for trigonometric operations (sin/cos/tan) was relying on parseFloat(..., 10). This is replaced with scaled floating-point arithmetic Math.round(... * 1e10) / 1e10. Operators are additionally bounded by % 360 to prevent IEEE-754 precision loss at large scale values.
- This is pretty much a no-brainer in my book. It's better math + performance improvements. The changes shouldn't break any existing projects since only large angles are affected here (the error doesn't exceed 0.01% until 66 trillion degrees). 

cast.js: The Cast.isInt boundary check utilized parseInt(val, 10). For stringified values in scientific notation (e.g. 1e22), parseInt parsed out "1", erroneously evaluating the float as non-integer. Modulo constraint (val % 1 === 0) evaluates correctly without stringification. This change is practically irrelevant but technically a bug fix. 

Verification
Unit parity with Scratch native tests verified (npm run tap:unit).
blocks_operators and blocks_operators_infinity tests fully pass, ensuring proper edge case constraints for non-standard numerics (NaN, Infinity, -0).
