### PR TITLE
Publish fixups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -215,14 +215,6 @@ jobs:
             echo "Not pushing to develop because the tag we're operating on is behind"
           fi
 
-      - name: Comment on Resolved Issues and Merged PRs
-        if: ${{ !github.event.release.prerelease }}
-        uses: apexskier/github-release-commenter@e7813a9625eabd79a875b4bc4046cfcae377ab34 # v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          comment-template: |
-            :tada: This is included in release {release_link}.
-
       # See https://stackoverflow.com/a/24849501
       - name: Change Connected Commit on Release
         shell: bash
@@ -231,3 +223,13 @@ jobs:
         run: |
           git tag -f "$TAG_NAME" HEAD
           git push -f origin "refs/tags/$TAG_NAME"
+
+      - name: Comment on Resolved Issues and Merged PRs
+        if: ${{ !github.event.release.prerelease }}
+        continue-on-error: true
+        uses: apexskier/github-release-commenter@e7813a9625eabd79a875b4bc4046cfcae377ab34 # v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          skip-label: dependencies
+          comment-template: |
+            :tada: This is included in release {release_link}.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: List Packages
         id: list-packages
         run: |
-          PACKAGES=$(ls -1d packages/*/ | xargs -n1 basename | jq -Rcn '[inputs]')
+          PACKAGES=$(npm query '.workspace' | jq -cr '[.[].location | sub("^packages/"; "")]')
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
 
       - name: Store Build Artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,9 +90,9 @@ jobs:
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # to push the version commit and tag
-      issues: write  # to comment on issues when a fix is released
-      pull-requests: write  # to comment on PRs when a fix is released
+      contents: write # to push the version commit and tag
+      issues: write # to comment on issues when a fix is released
+      pull-requests: write # to comment on PRs when a fix is released
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:


### PR DESCRIPTION
### Proposed Changes

Main change:
- Don't let a `github-release-commenter` failure cause the overall workflow to fail or prevent pushing the tag update.

Supporting changes:
- Move `github-release-commenter` to the end of the `cd` job
- Tell `github-release-commenter` to ignore PRs and issues with the `dependencies` label
- Collect the package list through `npm` rather than using `ls`

### Reason for Changes

Sometimes, `github-release-commenter` gets rate-limited, causing it to fail. Previously, this would cause the overall workflow to fail before the "Change Connected Commit on Release" step. Now, we basically ignore `github-release-commenter` failures (it's a nice-to-have anyway). We now also complete all important steps before `github-release-commenter` to reduce delays and, I guess, in case of some sort of catastrophic failure.

The package list change was just something I ran across along the way. I have a stray subdirectory under `packages/` associated with another project I'm working on. That subdirectory gets picked up by the `ls` and doesn't with the `npm`-based approach. On CI, where the checkout is presumably clean, the difference is probably negligible. When testing with `act` or similar, the difference could be important.

### Test Coverage

I ran it through `shellcheck` and a few other lint-style tools, but the real test will be our next publish.