### PR TITLE
chore(deps): remove abandoned xmldom package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35013,6 +35013,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -36598,14 +36599,6 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "license": "MIT"
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "dev": true,
-      "license": "(LGPL-2.0 or MIT)",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -38664,8 +38657,7 @@
         "tap": "21.6.2",
         "webpack": "5.105.4",
         "webpack-cli": "5.1.4",
-        "webpack-dev-server": "5.2.3",
-        "xmldom": "0.1.31"
+        "webpack-dev-server": "5.2.3"
       },
       "peerDependencies": {
         "scratch-render-fonts": "^1.0.0"

--- a/packages/scratch-svg-renderer/package.json
+++ b/packages/scratch-svg-renderer/package.json
@@ -76,8 +76,7 @@
     "tap": "21.6.2",
     "webpack": "5.105.4",
     "webpack-cli": "5.1.4",
-    "webpack-dev-server": "5.2.3",
-    "xmldom": "0.1.31"
+    "webpack-dev-server": "5.2.3"
   },
   "peerDependencies": {
     "scratch-render-fonts": "^1.0.0"

--- a/packages/scratch-svg-renderer/test/fixup-svg-string.js
+++ b/packages/scratch-svg-renderer/test/fixup-svg-string.js
@@ -1,18 +1,20 @@
 const test = require('tap').test;
 const fs = require('fs');
 const path = require('path');
-const DOMParser = require('xmldom').DOMParser;
+const {JSDOM} = require('jsdom');
 const fixupSvgString = require('../src/fixup-svg-string');
 
-// The browser DOMParser throws on errors by default, replicate that here
-// by customizing the error callback to throw (defaults to logging)
-const domParser = new DOMParser({
-    errorHandler: {
-        error: e => {
-            throw new Error(e);
-        }
+const {window} = new JSDOM();
+const domParser = new window.DOMParser();
+
+const parseXml = xmlString => {
+    const doc = domParser.parseFromString(xmlString, 'text/xml');
+    const errorNode = doc.querySelector('parsererror');
+    if (errorNode) {
+        throw new Error(errorNode.textContent);
     }
-});
+    return doc;
+};
 
 test('fixupSvgString should make parsing fixtures not throw', t => {
     const filePath = path.resolve(__dirname, './fixtures/hearts.svg');
@@ -23,7 +25,7 @@ test('fixupSvgString should make parsing fixtures not throw', t => {
     // Make sure undefineds aren't being written into the file
     t.equal(fixed.indexOf('undefined'), -1);
     t.doesNotThrow(() => {
-        domParser.parseFromString(fixed, 'text/xml');
+        parseXml(fixed);
     });
     t.end();
 });
@@ -37,7 +39,7 @@ test('fixupSvgString should correct namespace declarations bound to reserved nam
     // Make sure undefineds aren't being written into the file
     t.equal(fixed.indexOf('undefined'), -1);
     t.doesNotThrow(() => {
-        domParser.parseFromString(fixed, 'text/xml');
+        parseXml(fixed);
     });
     t.end();
 });
@@ -70,10 +72,10 @@ test('fixupSvgString should strip `svg:` prefix from tag names', t => {
     // Make sure undefineds aren't being written into the file
     t.equal(fixed.indexOf('undefined'), -1);
     t.doesNotThrow(() => {
-        domParser.parseFromString(fixed, 'text/xml');
+        parseXml(fixed);
     });
 
-    checkPrefixes(domParser.parseFromString(fixed, 'text/xml'));
+    checkPrefixes(parseXml(fixed));
 
     t.end();
 });
@@ -131,7 +133,7 @@ test('fixupSvgString should correct invalid mime type', t => {
     t.not(svgString.indexOf('img/png'), -1);
     t.equal(fixed.indexOf('img/png'), -1);
     t.doesNotThrow(() => {
-        domParser.parseFromString(fixed, 'text/xml');
+        parseXml(fixed);
     });
     t.end();
 });


### PR DESCRIPTION
### Resolves

- Closes scratchfoundation/scratch-editor#69

### Proposed Changes

Remove `xmldom`, replacing its single use with `jsdom` instead.

### Reason for Changes

We could move to `@xmldom/xmldom`, but we're already using the more-complete `jsdom` anyway, so there's no reason to also use the lighter-weight `@xmldom/xmldom`.

### Test Coverage

Tests updated.