### PR TITLE
fix(deps): update dependency cookie to v1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13737,10 +13737,16 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-signature": {
@@ -36816,7 +36822,7 @@
         "bowser": "1.9.4",
         "classnames": "2.5.1",
         "computed-style-to-inline-style": "3.0.0",
-        "cookie": "0.6.0",
+        "cookie": "^1.1.1",
         "copy-webpack-plugin": "6.4.1",
         "core-js": "2.6.12",
         "css-loader": "5.2.7",

--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -140,7 +140,7 @@
     "bowser": "1.9.4",
     "classnames": "2.5.1",
     "computed-style-to-inline-style": "3.0.0",
-    "cookie": "0.6.0",
+    "cookie": "^1.1.1",
     "copy-webpack-plugin": "6.4.1",
     "core-js": "2.6.12",
     "css-loader": "5.2.7",

--- a/packages/scratch-gui/src/lib/settings/color-mode/persistence.js
+++ b/packages/scratch-gui/src/lib/settings/color-mode/persistence.js
@@ -1,4 +1,4 @@
-import cookie from 'cookie';
+import {parse} from 'cookie';
 
 import {DEFAULT_MODE, HIGH_CONTRAST_MODE} from '.';
 
@@ -17,7 +17,7 @@ const systemPreferencesColorMode = () => {
 };
 
 const detectColorMode = () => {
-    const obj = cookie.parse(document.cookie) || {};
+    const obj = parse(document.cookie) || {};
     const colorModeCookie = obj.scratchtheme;
 
     if (isValidColorMode(colorModeCookie)) return colorModeCookie;

--- a/packages/scratch-gui/src/lib/settings/theme/persistence.js
+++ b/packages/scratch-gui/src/lib/settings/theme/persistence.js
@@ -1,4 +1,4 @@
-import cookie from 'cookie';
+import {parse} from 'cookie';
 
 import {DEFAULT_THEME, CAT_BLOCKS_THEME} from '.';
 
@@ -12,7 +12,7 @@ const isValidTheme = theme => [DEFAULT_THEME, CAT_BLOCKS_THEME].includes(theme);
 // For now, we'll take the user preference here as-is and switch to default theme if needed,
 // once we have the user info available.
 const detectTheme = () => {
-    const obj = cookie.parse(document.cookie) || {};
+    const obj = parse(document.cookie) || {};
     const themeCookie = obj[COOKIE_KEY];
 
     if (isValidTheme(themeCookie)) return themeCookie;


### PR DESCRIPTION
### Resolves

- Closes scratchfoundation/scratch-editor#293 

### Proposed Changes

Bump dependency `cookie` to v1.1.1

### Reason for Changes

Version 0.6.0 has a security issue, and scratchfoundation/scratch-editor#293 conservatively bumps it to a version that doesn't have that issue. However, that version is still very old. This PR bumps to the latest version, which only required minor adjustments. (The security issue doesn't affect the way we use the package, but it's still best to keep up to date.)

### Test Coverage

Unchanged