### PR TITLE
[UEPR-572] Track thumbnail updates

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -160,6 +160,8 @@ const GUIComponent = props => {
         loading,
         logo,
         manuallySaveThumbnails,
+        onSetManualThumbnail,
+        onSetManualThumbnailButtonClick,
         menuBarHidden,
         renderLogin,
         onClickAbout,
@@ -544,6 +546,8 @@ const GUIComponent = props => {
                                 ariaRole="region"
                                 ariaLabel={intl.formatMessage(ariaMessages.stage)}
                                 manuallySaveThumbnails={manuallySaveThumbnails}
+                                onSetManualThumbnail={onSetManualThumbnail}
+                                onSetManualThumbnailButtonClick={onSetManualThumbnailButtonClick}
                                 loading={loading}
                                 showNewFeatureCallouts={showNewFeatureCallouts}
                                 userOwnsProject={userOwnsProject}
@@ -617,6 +621,8 @@ GUIComponent.propTypes = {
     loading: PropTypes.bool,
     logo: PropTypes.string,
     manuallySaveThumbnails: PropTypes.bool,
+    onSetManualThumbnail: PropTypes.func,
+    onSetManualThumbnailButtonClick: PropTypes.func,
     menuBarHidden: PropTypes.bool,
     onActivateCostumesTab: PropTypes.func,
     onActivateSoundsTab: PropTypes.func,

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -83,6 +83,8 @@ const StageHeaderComponent = function (props) {
         isFullScreen,
         isPlayerOnly,
         manuallySaveThumbnails,
+        onSetManualThumbnail,
+        onSetManualThumbnailButtonClick,
         loadingOrCreating,
         onKeyPress,
         onSetStageLarge,
@@ -130,6 +132,7 @@ const StageHeaderComponent = function (props) {
 
             setIsUpdatingThumbnail(true);
             onShowSettingThumbnail();
+            if (onSetManualThumbnail) onSetManualThumbnail(projectId);
 
             storeProjectThumbnail(vm, dataURI => {
                 onUpdateProjectThumbnail(
@@ -152,12 +155,16 @@ const StageHeaderComponent = function (props) {
             vm,
             onShowSettingThumbnail,
             onShowThumbnailSuccess,
-            onShowThumbnailError
+            onShowThumbnailError,
+            onSetManualThumbnail
         ]
     );
 
     const onThumbnailPromptOpen = useCallback(() => {
         setIsThumbnailPromptOpen(true);
+        
+        if (onSetManualThumbnailButtonClick) onSetManualThumbnailButtonClick(projectId);
+        
         try {
             setLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '', true);
         } catch (e) {
@@ -165,7 +172,7 @@ const StageHeaderComponent = function (props) {
             console.warn('Unable to set thumbnail tooltip local storage value. Check if local storage is enabled.', e);
         }
         setIsThumbnailTooltipOpen(false);
-    }, [username]);
+    }, [username, onSetManualThumbnailButtonClick, projectId]);
 
     const onThumbnailPromptClose = useCallback(() => {
         setIsThumbnailPromptOpen(false);
@@ -324,6 +331,8 @@ StageHeaderComponent.propTypes = {
     isFullScreen: PropTypes.bool.isRequired,
     isPlayerOnly: PropTypes.bool.isRequired,
     manuallySaveThumbnails: PropTypes.bool,
+    onSetManualThumbnail: PropTypes.func,
+    onSetManualThumbnailButtonClick: PropTypes.func,
     loadingOrCreating: PropTypes.bool,
     onKeyPress: PropTypes.func.isRequired,
     onSetStageFull: PropTypes.func.isRequired,

--- a/packages/scratch-gui/src/components/stage-header/stage-header.jsx
+++ b/packages/scratch-gui/src/components/stage-header/stage-header.jsx
@@ -132,7 +132,7 @@ const StageHeaderComponent = function (props) {
 
             setIsUpdatingThumbnail(true);
             onShowSettingThumbnail();
-            if (onSetManualThumbnail) onSetManualThumbnail(projectId);
+            onSetManualThumbnail?.(projectId);
 
             storeProjectThumbnail(vm, dataURI => {
                 onUpdateProjectThumbnail(
@@ -163,7 +163,7 @@ const StageHeaderComponent = function (props) {
     const onThumbnailPromptOpen = useCallback(() => {
         setIsThumbnailPromptOpen(true);
         
-        if (onSetManualThumbnailButtonClick) onSetManualThumbnailButtonClick(projectId);
+        onSetManualThumbnailButtonClick?.(projectId);
         
         try {
             setLocalStorageValue(LOCAL_STORAGE_KEY, username ?? '', true);

--- a/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
+++ b/packages/scratch-gui/src/components/stage-wrapper/stage-wrapper.jsx
@@ -21,6 +21,8 @@ const StageWrapperComponent = function (props) {
         isRendererSupported,
         loading,
         manuallySaveThumbnails,
+        onSetManualThumbnail,
+        onSetManualThumbnailButtonClick,
         onUpdateProjectThumbnail,
         username,
         userOwnsProject,
@@ -42,6 +44,8 @@ const StageWrapperComponent = function (props) {
             <Box className={styles.stageMenuWrapper}>
                 <StageHeader
                     manuallySaveThumbnails={manuallySaveThumbnails}
+                    onSetManualThumbnail={onSetManualThumbnail}
+                    onSetManualThumbnailButtonClick={onSetManualThumbnailButtonClick}
                     username={username}
                     userOwnsProject={userOwnsProject}
                     loadingOrCreating={loading || isCreating}
@@ -77,6 +81,8 @@ StageWrapperComponent.propTypes = {
     isRtl: PropTypes.bool.isRequired,
     loading: PropTypes.bool,
     manuallySaveThumbnails: PropTypes.bool,
+    onSetManualThumbnail: PropTypes.func,
+    onSetManualThumbnailButtonClick: PropTypes.func,
     showNewFeatureCallouts: PropTypes.bool,
     username: PropTypes.string,
     userOwnsProject: PropTypes.bool,

--- a/packages/scratch-gui/src/containers/gui.jsx
+++ b/packages/scratch-gui/src/containers/gui.jsx
@@ -143,6 +143,8 @@ GUI.propTypes = {
     isTotallyNormal: PropTypes.bool,
     loadingStateVisible: PropTypes.bool,
     manuallySaveThumbnails: PropTypes.bool,
+    onSetManualThumbnail: PropTypes.func,
+    onSetManualThumbnailButtonClick: PropTypes.func,
     onProjectLoaded: PropTypes.func,
     onSeeCommunity: PropTypes.func,
     onStorageInit: PropTypes.func,


### PR DESCRIPTION
### Resolves

[UEPR-572](https://scratchfoundation.atlassian.net/browse/UEPR-572)

### Proposed Changes

Pass `onSetManualThumbnail`/`onSetManualThumbnailButtonClick`, callbacks to be executed when the Manually set thumbnail button is clicked (before confirming), and when the thumbnail is manually set

### Reason for Changes

Fixes an issue where we used to track all thumbnail updates, including on project creation

[UEPR-572]: https://scratchfoundation.atlassian.net/browse/UEPR-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ