### PR TITLE
fix: clear parent when block is removed from input with shadow

### DIFF
--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -763,6 +763,7 @@ class Blocks {
                 if (shadow && e.id !== shadow) {
                     oldParent.inputs[e.oldInput].block = shadow;
                     this._blocks[shadow].parent = oldParent.id;
+                    this._blocks[e.id].parent = null;
                 } else {
                     oldParent.inputs[e.oldInput].block = null;
                     if (e.id !== shadow) {

--- a/packages/scratch-vm/test/unit/engine_blocks.js
+++ b/packages/scratch-vm/test/unit/engine_blocks.js
@@ -415,6 +415,72 @@ test('move - attaching new shadow', t => {
     t.end();
 });
 
+test('move out of input with shadow clears parent', t => {
+    const b = new Blocks(new Runtime());
+    // Create a stack block with an input that has a shadow
+    b.createBlock({
+        id: 'stack',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        parent: null,
+        fields: {},
+        inputs: {
+            myInput: {
+                name: 'myInput',
+                block: 'myShadow',
+                shadow: 'myShadow'
+            }
+        },
+        topLevel: true
+    });
+    b.createBlock({
+        id: 'myShadow',
+        opcode: 'TEST_SHADOW',
+        next: null,
+        parent: 'stack',
+        fields: {},
+        inputs: {},
+        shadow: true
+    });
+    b.createBlock({
+        id: 'reporter',
+        opcode: 'TEST_REPORTER',
+        next: null,
+        parent: null,
+        fields: {},
+        inputs: {},
+        topLevel: true
+    });
+
+    // Move the reporter into the stack's input (covering the shadow)
+    b.moveBlock({
+        id: 'reporter',
+        newParent: 'stack',
+        newInput: 'myInput'
+    });
+    t.equal(b._blocks.reporter.parent, 'stack');
+    t.equal(b.getTopLevelScript('reporter'), 'stack');
+
+    // Detach the reporter from the stack's input
+    b.moveBlock({
+        id: 'reporter',
+        oldParent: 'stack',
+        oldInput: 'myInput',
+        newCoordinate: {x: 100, y: 100}
+    });
+
+    // The shadow should be restored
+    t.equal(b._blocks.stack.inputs.myInput.block, 'myShadow');
+
+    // The reporter's parent must be cleared so it is its own top-level script
+    t.equal(b._blocks.reporter.parent, null,
+        'reporter parent should be null after disconnect');
+    t.equal(b.getTopLevelScript('reporter'), 'reporter',
+        'reporter should be its own top-level script after disconnect');
+
+    t.end();
+});
+
 test('change', t => {
     const b = new Blocks(new Runtime());
     b.createBlock({


### PR DESCRIPTION
### Resolves

- Fixes scratchfoundation/scratch-blocks#3541

### Proposed Changes

When a block was removed from an input that had a shadow block, the shadow was correctly restored, but the moved block's parent reference was not cleared. This change clears that parent reference in this case.

### Reason for Changes

The previous behavior caused `getTopLevelScript` to follow the stale parent pointer back to the old stack, so clicking the detached reporter would run the old stack instead of reporting its value.

### Test Coverage

Added a regression test for scratchfoundation/scratch-blocks#3541