### PR TITLE
fix: select My Blocks category by ID after closing procedure editor

### DIFF
--- a/packages/scratch-gui/src/containers/blocks.jsx
+++ b/packages/scratch-gui/src/containers/blocks.jsx
@@ -657,7 +657,8 @@ class Blocks extends React.Component {
         this.props.onRequestCloseCustomProcedures(data);
         const ws = this.workspace;
         this.updateToolbox();
-        ws.getToolbox().selectCategoryByName('myBlocks');
+        const toolbox = ws.getToolbox();
+        toolbox.setSelectedItem(toolbox.getToolboxItemById('myBlocks'));
     }
     handleDrop (dragInfo) {
         fetch(dragInfo.payload.bodyUrl)
@@ -668,7 +669,7 @@ class Blocks extends React.Component {
             });
     }
     render () {
-         
+
         const {
             anyModalVisible,
             canUseCloud,
@@ -693,7 +694,7 @@ class Blocks extends React.Component {
             colorMode,
             ...props
         } = this.props;
-         
+
         return (
             <React.Fragment>
                 <DroppableBlocks

--- a/packages/scratch-gui/test/unit/containers/blocks.test.js
+++ b/packages/scratch-gui/test/unit/containers/blocks.test.js
@@ -1,5 +1,38 @@
 import {Blocks} from '../../../src/containers/blocks.jsx';
 
+describe('Blocks container handleCustomProceduresClose', () => {
+    test('selects the My Blocks category after closing', () => {
+        // The My Blocks category has toolboxitemid="myBlocks" but its
+        // display name is a translated string like "My Blocks".
+        // A correct implementation must find the category even when the
+        // display name doesn't match the toolbox item ID.
+        const myBlocksItem = {name: 'Mis Bloques'};
+        const toolbox = {
+            selectedItem: null,
+            getToolboxItemById: jest.fn(id => (id === 'myBlocks' ? myBlocksItem : null)),
+            // Simulates real selectCategoryByName: looks up by display name, not ID
+            selectCategoryByName: jest.fn(name => {
+                toolbox.selectedItem = (name === 'Mis Bloques') ? myBlocksItem : null;
+            }),
+            setSelectedItem: jest.fn(item => {
+                toolbox.selectedItem = item;
+            })
+        };
+        const instance = {
+            props: {onRequestCloseCustomProcedures: jest.fn()},
+            workspace: {getToolbox: jest.fn().mockReturnValue(toolbox)},
+            updateToolbox: jest.fn()
+        };
+
+        Blocks.prototype.handleCustomProceduresClose.call(instance, {});
+
+        // The category must actually be resolved and selected.
+        // If the lookup silently fails, selectedItem will be null
+        // and the toolbox won't scroll.
+        expect(toolbox.selectedItem).toBe(myBlocksItem);
+    });
+});
+
 describe('Blocks container onWorkspaceUpdate', () => {
     let instance;
 


### PR DESCRIPTION
### Resolves

- Fixes scratchfoundation/scratch-blocks#3542

### Proposed Changes

`selectCategoryByName('myBlocks')` passes the toolbox item ID, where the method expects a translated display name. It also skips scrolling the flyout. Use `getToolboxItemById` + `setSelectedItem` instead, matching the pattern already used in `handleCategorySelected`.

### Test Coverage

Added a test to verify that the correct item is selected.

### HOLD

Since this is not a release-blocking issue, let's wait to merge this until after the initial release of the new scratch-blocks code.