### PR TITLE
fix: update VM field values on intermediate field changes

### DIFF
--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -305,6 +305,20 @@ class Blocks {
             typeof e.commentId !== 'string') {
             return;
         }
+        // Intermediate field changes fire on every keystroke while editing
+        // a text input. Update the field value so running scripts see the
+        // change, but skip project-changed and other side effects. Handle
+        // this before the stage/editingTarget lookups to avoid per-keystroke
+        // overhead from getTargetForStage's linear scan.
+        if (e.type === 'block_field_intermediate_change') {
+            const block = this._blocks[e.blockId];
+            if (block && block.fields && block.fields[e.name]) {
+                block.fields[e.name].value = e.newValue;
+                this._cache._executeCached = {};
+            }
+            return;
+        }
+
         const stage = this.runtime.getTargetForStage();
         const editingTarget = this.runtime.getEditingTarget();
 

--- a/packages/scratch-vm/test/unit/engine_blocks.js
+++ b/packages/scratch-vm/test/unit/engine_blocks.js
@@ -538,6 +538,47 @@ test('change', t => {
     t.end();
 });
 
+test('block_field_intermediate_change updates field value', t => {
+    const rt = new Runtime();
+    rt.addTarget({
+        id: 'target1',
+        isStage: true,
+        blocks: new Blocks(rt, true),
+        variables: {},
+        comments: {}
+    });
+    const b = new Blocks(rt);
+    b.createBlock({
+        id: 'foo',
+        opcode: 'TEST_BLOCK',
+        next: null,
+        fields: {
+            TEXT: {
+                name: 'TEXT',
+                value: 'Hello!'
+            }
+        },
+        inputs: {},
+        topLevel: true
+    });
+
+    t.equal(b._blocks.foo.fields.TEXT.value, 'Hello!');
+
+    // Simulate an intermediate field change (keystroke during editing)
+    b.blocklyListen({
+        type: 'block_field_intermediate_change',
+        blockId: 'foo',
+        name: 'TEXT',
+        oldValue: 'Hello!',
+        newValue: 'Hello world'
+    });
+
+    t.equal(b._blocks.foo.fields.TEXT.value, 'Hello world',
+        'field value should update on intermediate change');
+
+    t.end();
+});
+
 test('delete', t => {
     const b = new Blocks(new Runtime());
     b.createBlock({

--- a/packages/scratch-vm/test/unit/project_changed_state_blocks.js
+++ b/packages/scratch-vm/test/unit/project_changed_state_blocks.js
@@ -104,6 +104,19 @@ test('Changing a block should emit a project changed event', t => {
     t.end();
 });
 
+test('Intermediate field change should not emit a project changed event', t => {
+    blockContainer.blocklyListen({
+        type: 'block_field_intermediate_change',
+        blockId: 'a new block',
+        name: 'A_FIELD',
+        oldValue: 10,
+        newValue: 20
+    });
+
+    t.equal(projectChanged, false);
+    t.end();
+});
+
 test('Moving a block to a new position should emit a project changed event', t => {
     blockContainer.moveBlock({
         id: 'a new block',


### PR DESCRIPTION
### Resolves

- Fixes scratchfoundation/scratch-blocks#3544

### Proposed Changes

Upstream Blockly fires `block_field_intermediate_change` events on each keystroke while editing a text input, and only fires the committed change event when the edit is finalized (Enter, blur, etc.). The VM was not handling the intermediate events, so running scripts did not see field value updates until the edit was committed.

Handle `block_field_intermediate_change` by updating the field value directly, without triggering project-changed or other side effects that are only appropriate for committed changes.

### Test Coverage

Added tests:
- intermediate change events should update the VM's view of the value
- intermediate change events should NOT mark the project as dirty (yet)
