### PR TITLE
fix: Project not being able to save after share

### DIFF
--- a/packages/scratch-gui/src/containers/project-watcher.jsx
+++ b/packages/scratch-gui/src/containers/project-watcher.jsx
@@ -33,7 +33,7 @@ class ProjectWatcher extends React.Component {
     }
     componentDidUpdate (prevProps) {
         if (this.state.saving && this.state.sharing) {
-            if (this.props.isShared && this.props.isShowingWithId) {
+            if (this.props.isShared && (this.props.isShowingWithId && !prevProps.isShowingWithId)) {
                 this.fulfill();
             }
         }


### PR DESCRIPTION
### Resolves

[UEPR-586](https://scratchfoundation.atlassian.net/browse/UEPR-586)

### Proposed Changes

- Wait for the project to become `isShowingWithId` before navigating to www

### Reason for Changes

When sharing a project through the editor, a confirmation modal ("Are you sure you want to share your project with this thumbnail?") is shown before proceeding. Because of this, `ProjectWatcher` must wait until the project is saved and actually shared before navigating to www.

The condition used to detect this was:
`if (this.props.isShared && this.props.isShowingWithId)`

This evaluated to true on every render once the project was already shared and in the `SHOWING_WITH_ID` state, not only when that state was freshly reached. As a result, any subsequent save operation would cause `ProjectWatcher` to call `fulfill()` immediately on the next render, without waiting for the actual save cycle to finish. This caused navigation to www before the project is actually saved and left the Redux loading state permanently stuck in `AUTO_UPDATING`.

The fix is to tighten the check to require `isShowingWithId` to have just transitioned from `false` -> `true`. This is safe even if the save completes before the share API responds. `ProjectSavecHoc` already handles that case - when `isShared` flips to true while the project is in `SHOWING_WITH_ID`, it triggers another save cycle, guaranteeing that this check will always be fulfilled at some point.


[UEPR-586]: https://scratchfoundation.atlassian.net/browse/UEPR-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ