### PR TITLE
fix(scratch-vm): repair broken shadow references from cursed inputs bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,21 +1919,6 @@
         "specificity": "bin/cli.js"
       }
     },
-    "node_modules/@bramus/specificity/node_modules/css-tree": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@bramus/specificity/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "license": "CC0-1.0"
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,
@@ -30899,9 +30884,9 @@
       }
     },
     "node_modules/scratch-blocks": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.14.tgz",
-      "integrity": "sha512-J2bO8Ax6Dk2sDiC/TsEY9YNFuffxwPhYtv04arpCQwD+dn0CPJ5cqiE/C8Isu1zgyjI53vxdIviMEMJIje4WyQ==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/scratch-blocks/-/scratch-blocks-2.1.16.tgz",
+      "integrity": "sha512-ilMgL5mXARpA8VtD0KdK61bYpPyLRkMJxuGuTu19w9FceqJ+RiXo/9Ij9sQBnYFIL5dwfQtyFJdUtyCphEieSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@blockly/continuous-toolbox": "^7.0.8",
@@ -34678,6 +34663,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
@@ -36500,7 +36486,7 @@
         "react-visibility-sensor": "5.1.1",
         "redux-throttle": "0.1.1",
         "scratch-audio": "2.0.268",
-        "scratch-blocks": "2.1.14",
+        "scratch-blocks": "2.1.16",
         "scratch-l10n": "6.1.70",
         "scratch-paint": "4.1.50",
         "scratch-render-fonts": "1.0.252",
@@ -38426,7 +38412,7 @@
         "in-publish": "2.0.1",
         "js-md5": "0.7.3",
         "pngjs": "3.4.0",
-        "scratch-blocks": "2.1.14",
+        "scratch-blocks": "2.1.16",
         "scratch-l10n": "6.1.70",
         "scratch-render-fonts": "1.0.252",
         "scratch-semantic-release-config": "4.0.1",

--- a/packages/scratch-gui/package.json
+++ b/packages/scratch-gui/package.json
@@ -180,7 +180,7 @@
     "react-visibility-sensor": "5.1.1",
     "redux-throttle": "0.1.1",
     "scratch-audio": "2.0.268",
-    "scratch-blocks": "2.1.14",
+    "scratch-blocks": "2.1.16",
     "scratch-l10n": "6.1.70",
     "scratch-paint": "4.1.50",
     "scratch-render-fonts": "1.0.252",

--- a/packages/scratch-vm/package.json
+++ b/packages/scratch-vm/package.json
@@ -99,7 +99,7 @@
     "in-publish": "2.0.1",
     "js-md5": "0.7.3",
     "pngjs": "3.4.0",
-    "scratch-blocks": "2.1.14",
+    "scratch-blocks": "2.1.16",
     "scratch-l10n": "6.1.70",
     "scratch-render-fonts": "1.0.252",
     "scratch-semantic-release-config": "4.0.1",

--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -775,8 +775,15 @@ class Blocks {
                 // this input, or null out the input's block.
                 const shadow = oldParent.inputs[e.oldInput].shadow;
                 if (shadow && e.id !== shadow) {
-                    oldParent.inputs[e.oldInput].block = shadow;
-                    this._blocks[shadow].parent = oldParent.id;
+                    if (this._blocks[shadow]) {
+                        oldParent.inputs[e.oldInput].block = shadow;
+                        this._blocks[shadow].parent = oldParent.id;
+                    } else {
+                        // Shadow block is referenced but missing — clear
+                        // the stale reference rather than crashing.
+                        oldParent.inputs[e.oldInput].block = null;
+                        oldParent.inputs[e.oldInput].shadow = null;
+                    }
                     this._blocks[e.id].parent = null;
                 } else {
                     oldParent.inputs[e.oldInput].block = null;

--- a/packages/scratch-vm/src/serialization/sb3.js
+++ b/packages/scratch-vm/src/serialization/sb3.js
@@ -96,6 +96,85 @@ const primitiveOpcodeInfoMap = {
 };
 
 /**
+ * Build the fields object for a replacement shadow block. Simple primitives
+ * (text, numbers, colours) just need {name, value}. Variable, list, and
+ * broadcast shadows also need {id, variableType} for the dropdown to work.
+ * @param {string} shadowOpcode The shadow block's opcode.
+ * @param {?object} template A peer shadow block to copy field values from, or null.
+ * @returns {?object} A fields object for the new shadow, or null if the opcode is unknown.
+ */
+const buildShadowFields = function (shadowOpcode, template) {
+    const info = primitiveOpcodeInfoMap[shadowOpcode];
+    if (!info) return null;
+    const fieldName = info[1];
+    const templateField = template && template.fields && template.fields[fieldName];
+    const value = templateField ? templateField.value : '';
+
+    switch (shadowOpcode) {
+    case 'event_broadcast_menu':
+        return {
+            [fieldName]: {
+                name: fieldName,
+                value: value,
+                id: (templateField && templateField.id) || '',
+                variableType: Variable.BROADCAST_MESSAGE_TYPE
+            }
+        };
+    case 'data_variable':
+        return {
+            [fieldName]: {
+                name: fieldName,
+                value: value,
+                id: (templateField && templateField.id) || '',
+                variableType: Variable.SCALAR_TYPE
+            }
+        };
+    case 'data_listcontents':
+        return {
+            [fieldName]: {
+                name: fieldName,
+                value: value,
+                id: (templateField && templateField.id) || '',
+                variableType: Variable.LIST_TYPE
+            }
+        };
+    default:
+        // Simple primitives: text, math_number, math_angle, colour_picker, etc.
+        return {
+            [fieldName]: {
+                name: fieldName,
+                value: value
+            }
+        };
+    }
+};
+
+/**
+ * Find a working shadow block for the given (opcode, inputName) pair by
+ * looking at other blocks of the same opcode in the project. Returns the
+ * matching shadow block from the blocks map for use as a template, or
+ * null if no peer has a working shadow for that input.
+ * @param {object} blocks The full blocks map for the target.
+ * @param {string} opcode The parent block's opcode.
+ * @param {string} inputName The name of the input.
+ * @returns {?object} A template shadow block from the blocks map, or null.
+ */
+const findPeerShadow = function (blocks, opcode, inputName) {
+    for (const peerId in blocks) {
+        if (!hasOwnProperty.call(blocks, peerId)) continue;
+        const peer = blocks[peerId];
+        if (Array.isArray(peer) || peer.opcode !== opcode) continue;
+        const peerInput = peer.inputs[inputName];
+        if (!peerInput || !peerInput.shadow) continue;
+        const shadowBlock = blocks[peerInput.shadow];
+        if (!shadowBlock || Array.isArray(shadowBlock)) continue;
+        if (!hasOwnProperty.call(primitiveOpcodeInfoMap, shadowBlock.opcode)) continue;
+        return shadowBlock;
+    }
+    return null;
+};
+
+/**
  * Serializes primitives described above into a more compact format
  * @param {object} block the block to serialize
  * @returns {Array} An array representing the information in the block,
@@ -883,6 +962,67 @@ const deserializeBlocks = function (blocks) {
             if (inputInfo.shadow && inputInfo.shadow !== inputInfo.block) delete blocks[inputInfo.shadow];
         }
         block.inputs = {};
+    }
+
+    // Third pass: repair missing or broken shadow blocks. Shadows can be
+    // missing in two ways:
+    //   1. shadow is a stale ID pointing to a nonexistent block
+    //   2. shadow is null when it shouldn't be (lost before save)
+    // Both are leftovers from a serialization bug where shadow blocks were
+    // dropped during save. Recreate the shadow by finding a peer block of
+    // the same opcode with an intact shadow on the same input (peer lookup).
+    // For broken references (case 1), fall back to a text shadow if no peer
+    // is available. For missing shadows (case 2), only create a shadow if a
+    // peer confirms one should exist — otherwise the input probably doesn't
+    // use shadows (e.g. custom procedure inputs).
+    for (const blockId in blocks) {
+        if (!Object.prototype.hasOwnProperty.call(blocks, blockId)) continue;
+        const block = blocks[blockId];
+        if (Array.isArray(block)) continue;
+        for (const inputName in block.inputs) {
+            if (!Object.prototype.hasOwnProperty.call(block.inputs, inputName)) continue;
+            const input = block.inputs[inputName];
+
+            const shadowIsBroken = input.shadow &&
+                !Object.prototype.hasOwnProperty.call(blocks, input.shadow);
+            const shadowIsMissing = !input.shadow && input.block &&
+                Object.prototype.hasOwnProperty.call(blocks, input.block) &&
+                !blocks[input.block].shadow;
+
+            if (!shadowIsBroken && !shadowIsMissing) continue;
+
+            // Try to find a peer block with a working shadow for this input.
+            const template = findPeerShadow(blocks, block.opcode, inputName);
+            if (!template && !shadowIsBroken) {
+                // No peer has a shadow either — this input probably doesn't
+                // use one (e.g. custom procedure inputs). Leave it alone.
+                continue;
+            }
+            const shadowOpcode = template ? template.opcode : 'text';
+            const fields = buildShadowFields(shadowOpcode, template);
+            if (!fields) {
+                // Unknown shadow type — clear any stale reference
+                // so it doesn't cause crashes.
+                if (shadowIsBroken) input.shadow = null;
+                continue;
+            }
+            const newShadowId = uid();
+            blocks[newShadowId] = {
+                id: newShadowId,
+                opcode: shadowOpcode,
+                next: null,
+                parent: blockId,
+                shadow: true,
+                topLevel: false,
+                inputs: Object.create(null),
+                fields: fields
+            };
+            input.shadow = newShadowId;
+            // If no block is connected, also set block to the shadow
+            if (!input.block || !Object.prototype.hasOwnProperty.call(blocks, input.block)) {
+                input.block = newShadowId;
+            }
+        }
     }
 
     return blocks;

--- a/packages/scratch-vm/src/serialization/sb3.js
+++ b/packages/scratch-vm/src/serialization/sb3.js
@@ -974,7 +974,9 @@ const deserializeBlocks = function (blocks) {
     // For broken references (case 1), fall back to a text shadow if no peer
     // is available. For missing shadows (case 2), only create a shadow if a
     // peer confirms one should exist — otherwise the input probably doesn't
-    // use shadows (e.g. custom procedure inputs).
+    // use shadows (e.g. statement inputs like SUBSTACK).
+    // Cache peer lookups per (opcode, inputName) to avoid repeated O(n) scans.
+    const peerShadowCache = Object.create(null);
     for (const blockId in blocks) {
         if (!Object.prototype.hasOwnProperty.call(blocks, blockId)) continue;
         const block = blocks[blockId];
@@ -992,7 +994,11 @@ const deserializeBlocks = function (blocks) {
             if (!shadowIsBroken && !shadowIsMissing) continue;
 
             // Try to find a peer block with a working shadow for this input.
-            const template = findPeerShadow(blocks, block.opcode, inputName);
+            const cacheKey = `${block.opcode}/${inputName}`;
+            if (!Object.prototype.hasOwnProperty.call(peerShadowCache, cacheKey)) {
+                peerShadowCache[cacheKey] = findPeerShadow(blocks, block.opcode, inputName);
+            }
+            const template = peerShadowCache[cacheKey];
             if (!template && !shadowIsBroken) {
                 // No peer has a shadow either — this input probably doesn't
                 // use one (e.g. custom procedure inputs). Leave it alone.

--- a/packages/scratch-vm/test/unit/engine_blocks.js
+++ b/packages/scratch-vm/test/unit/engine_blocks.js
@@ -1145,3 +1145,53 @@ test('getAllVariableAndListReferences returns broadcast when we tell it to', t =
 
     t.end();
 });
+
+// Regression test for bug 878291: moveBlock should not crash when a
+// shadow reference points to a block that does not exist.
+test('moveBlock tolerates missing shadow block', t => {
+    const b = new Blocks(new Runtime());
+
+    // Create a parent block with an input whose shadow reference is stale
+    b.createBlock({
+        id: 'parent',
+        opcode: 'data_setvariableto',
+        next: null,
+        parent: null,
+        shadow: false,
+        topLevel: true,
+        inputs: {
+            VALUE: {
+                name: 'VALUE',
+                block: 'reporter',
+                shadow: 'nonexistent_shadow' // references a block that does not exist
+            }
+        },
+        fields: {}
+    });
+    b.createBlock({
+        id: 'reporter',
+        opcode: 'sensing_answer',
+        next: null,
+        parent: 'parent',
+        shadow: false,
+        topLevel: false,
+        inputs: {},
+        fields: {}
+    });
+
+    // Detaching the reporter should not throw even though the shadow is missing
+    t.doesNotThrow(() => {
+        b.moveBlock({
+            id: 'reporter',
+            oldParent: 'parent',
+            oldInput: 'VALUE',
+            newCoordinate: {x: 0, y: 0}
+        });
+    });
+
+    // The stale shadow reference should be cleared
+    t.equal(b.getBlock('parent').inputs.VALUE.shadow, null);
+    t.equal(b.getBlock('parent').inputs.VALUE.block, null);
+
+    t.end();
+});

--- a/packages/scratch-vm/test/unit/serialization_sb3.js
+++ b/packages/scratch-vm/test/unit/serialization_sb3.js
@@ -464,3 +464,228 @@ test('do not serialize origin value if it is not present', t => {
             t.end();
         });
 });
+
+// Regression test for forum topic 878291: deserializeBlocks should repair
+// broken or missing shadow references by creating a replacement shadow,
+// using a peer block's matching shadow as a template when available.
+test('deserializeBlocks repairs broken shadow references', t => {
+    // Simulate a target with one broken and one intact data_setvariableto.
+    // The peer lookup should find the intact block's shadow as a template.
+    const blocks = {
+        // Broken block: shadow reference points to a nonexistent block
+        brokenBlock: {
+            opcode: 'data_setvariableto',
+            next: null,
+            parent: null,
+            inputs: {
+                VALUE: [3, 'reporterBlock', 'missing_shadow']
+            },
+            fields: {VARIABLE: ['x', 'varId']},
+            shadow: false,
+            topLevel: true,
+            x: 0,
+            y: 0
+        },
+        reporterBlock: {
+            opcode: 'sensing_answer',
+            next: null,
+            parent: 'brokenBlock',
+            inputs: {},
+            fields: {},
+            shadow: false,
+            topLevel: false
+        },
+        // Intact peer: same opcode, working shadow on VALUE
+        peerBlock: {
+            opcode: 'data_setvariableto',
+            next: null,
+            parent: null,
+            inputs: {
+                VALUE: [1, 'peerShadow']
+            },
+            fields: {VARIABLE: ['y', 'varId2']},
+            shadow: false,
+            topLevel: true,
+            x: 200,
+            y: 0
+        },
+        peerShadow: {
+            opcode: 'text',
+            next: null,
+            parent: 'peerBlock',
+            inputs: {},
+            fields: {TEXT: ['hello']},
+            shadow: true,
+            topLevel: false
+        }
+    };
+
+    sb3.deserializeBlocks(blocks);
+
+    // The broken shadow should be replaced using the peer's shadow as template
+    const repairedId = blocks.brokenBlock.inputs.VALUE.shadow;
+    t.not(repairedId, 'missing_shadow', 'broken shadow ID should be replaced');
+    t.not(repairedId, null, 'a replacement shadow should be created');
+    t.ok(blocks[repairedId], 'replacement shadow block should exist');
+    t.equal(blocks[repairedId].opcode, 'text',
+        'shadow type should match the peer (text)');
+    t.equal(blocks[repairedId].shadow, true,
+        'replacement should be marked as shadow');
+    t.equal(blocks[repairedId].parent, 'brokenBlock',
+        'replacement should reference the broken block as parent');
+    t.equal(blocks.brokenBlock.inputs.VALUE.block, 'reporterBlock',
+        'connected block reference should be preserved');
+
+    // The peer's shadow should be untouched
+    t.equal(blocks.peerBlock.inputs.VALUE.shadow, 'peerShadow',
+        'valid shadow reference should be preserved');
+
+    // Test peer lookup across math blocks: broken operator_add should
+    // find a math_number shadow from the intact peer.
+    const mathBlocks = {
+        brokenAdd: {
+            opcode: 'operator_add',
+            next: null,
+            parent: null,
+            inputs: {
+                NUM1: [3, 'numReporter', 'missing_math_shadow'],
+                NUM2: [1, [4, '10']]
+            },
+            fields: {},
+            shadow: false,
+            topLevel: true,
+            x: 0,
+            y: 0
+        },
+        numReporter: {
+            opcode: 'sensing_answer',
+            next: null,
+            parent: 'brokenAdd',
+            inputs: {},
+            fields: {},
+            shadow: false,
+            topLevel: false
+        },
+        // Intact peer with a math_number shadow on NUM1
+        peerAdd: {
+            opcode: 'operator_add',
+            next: null,
+            parent: null,
+            inputs: {
+                NUM1: [1, 'peerMathShadow'],
+                NUM2: [1, [4, '5']]
+            },
+            fields: {},
+            shadow: false,
+            topLevel: true,
+            x: 200,
+            y: 0
+        },
+        peerMathShadow: {
+            opcode: 'math_number',
+            next: null,
+            parent: 'peerAdd',
+            inputs: {},
+            fields: {NUM: {name: 'NUM', value: '3'}},
+            shadow: true,
+            topLevel: false
+        }
+    };
+
+    sb3.deserializeBlocks(mathBlocks);
+
+    const mathShadowId = mathBlocks.brokenAdd.inputs.NUM1.shadow;
+    t.ok(mathBlocks[mathShadowId], 'math shadow should be created');
+    t.equal(mathBlocks[mathShadowId].opcode, 'math_number',
+        'should use math_number from peer, not text fallback');
+    t.equal(mathBlocks[mathShadowId].fields.NUM.name, 'NUM',
+        'math_number shadow should have a NUM field');
+
+    // Test fallback to text when no peer exists
+    const lonelyBlocks = {
+        lonelyBlock: {
+            opcode: 'data_setvariableto',
+            next: null,
+            parent: null,
+            inputs: {VALUE: [1, 'orphan_shadow']},
+            fields: {VARIABLE: ['z', 'varId3']},
+            shadow: false,
+            topLevel: true,
+            x: 0,
+            y: 0
+        }
+        // No peer block, no shadow block — orphan_shadow is missing
+    };
+
+    sb3.deserializeBlocks(lonelyBlocks);
+
+    const fallbackId = lonelyBlocks.lonelyBlock.inputs.VALUE.shadow;
+    t.ok(lonelyBlocks[fallbackId], 'fallback shadow should be created');
+    t.equal(lonelyBlocks[fallbackId].opcode, 'text',
+        'should fall back to text when no peer is available');
+
+    // Test repair of null shadow (INPUT_BLOCK_NO_SHADOW) when peers have shadows.
+    // This covers the case where the shadow was lost before save, so
+    // the input was serialized as [2, blockId] with no shadow reference.
+    const nullShadowBlocks = {
+        // Block with null shadow — reporter is connected but shadow is gone
+        brokenLt: {
+            opcode: 'operator_lt',
+            next: null,
+            parent: null,
+            inputs: {
+                OPERAND1: [2, 'ltReporter'] // INPUT_BLOCK_NO_SHADOW
+            },
+            fields: {},
+            shadow: false,
+            topLevel: true,
+            x: 0,
+            y: 0
+        },
+        ltReporter: {
+            opcode: 'data_variable',
+            next: null,
+            parent: 'brokenLt',
+            inputs: {},
+            fields: {VARIABLE: ['x', 'varId']},
+            shadow: false,
+            topLevel: false
+        },
+        // Intact peer with a shadow on OPERAND1
+        peerLt: {
+            opcode: 'operator_lt',
+            next: null,
+            parent: null,
+            inputs: {
+                OPERAND1: [1, 'peerLtShadow']
+            },
+            fields: {},
+            shadow: false,
+            topLevel: true,
+            x: 200,
+            y: 0
+        },
+        peerLtShadow: {
+            opcode: 'text',
+            next: null,
+            parent: 'peerLt',
+            inputs: {},
+            fields: {TEXT: {name: 'TEXT', value: ''}},
+            shadow: true,
+            topLevel: false
+        }
+    };
+
+    sb3.deserializeBlocks(nullShadowBlocks);
+
+    const repairedNullShadow = nullShadowBlocks.brokenLt.inputs.OPERAND1.shadow;
+    t.ok(repairedNullShadow, 'null shadow should be replaced');
+    t.ok(nullShadowBlocks[repairedNullShadow],
+        'replacement shadow block should exist');
+    t.equal(nullShadowBlocks[repairedNullShadow].opcode, 'text',
+        'replacement should match peer shadow type');
+    t.equal(nullShadowBlocks.brokenLt.inputs.OPERAND1.block, 'ltReporter',
+        'connected block should be preserved');
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

- Crash when dragging reporters out of inputs in corrupted projects (TypeError: Cannot set properties of undefined (setting 'parent') in `moveBlock`)
- Blank/dead inputs in projects affected by the cursed inputs bug (forum topics 878291, 878962)
- Companion to scratchfoundation/scratch-blocks#3560

### Proposed Changes

Projects corrupted by the shared-shadow-ID bug (fixed in scratch-blocks#3560) contain inputs with shadow references that either point to nonexistent blocks or are null when they shouldn't be. This causes crashes when dragging reporters and perpetuates the corruption through save/load cycles. These changes repair corrupted projects at load time and prevent crashes on any remaining edge cases.

**Load-time repair in `deserializeBlocks`** (`sb3.js`): After deserialization, scans all inputs for two forms of shadow corruption:
- **Broken reference:** `shadow` points to a block ID not present in the project
- **Missing shadow:** `shadow` is null when peers of the same opcode have a shadow on the same input

In both cases, recreates the shadow using peer lookup (finds another block of the same opcode with an intact primitive shadow on the same input). Falls back to a `text` shadow if no peer is available (broken references only). Leaves the input alone if no peer has a shadow either (the input probably doesn't use one, e.g. statement inputs like SUBSTACK).

All primitive shadow types are supported, including variable/list/broadcast menu shadows (`data_variable`, `data_listcontents`, `event_broadcast_menu`) — these are created with the correct `id` and `variableType` fields copied from the peer template, or with empty defaults if no peer is available.

**Defensive guard in `moveBlock`** (`blocks.js`): When restoring a shadow after a reporter is disconnected, checks that the shadow block actually exists before accessing it. If missing, clears the stale reference instead of crashing.

**Performance** (`sb3.js`): Peer shadow lookups are cached per `(opcode, inputName)` pair so the blocks map is only scanned once per combination, avoiding O(n^2) cost on projects with many statement inputs.

### Test Coverage

- `engine_blocks.js`: Test that `moveBlock` doesn't crash when shadow reference points to nonexistent block, and that the stale reference is cleared
- `serialization_sb3.js`: Tests for broken shadow reference repair (with peer lookup and `text` fallback), intact shadow preservation, math input peer lookup (`math_number` from peer, not `text`), and null-shadow repair when peers indicate a shadow should exist

### Manual Testing

- [ ] Load project 1296008268. Switch to "Player Costumes" sprite. Find the "Player X Momentum < 0" comparison and pull the reporter out of the block's left operand. Verify the text input appears (not blank).
- [ ] In the same project, pull reporters out of various operator and "set variable to" blocks. Verify inputs are restored in all cases.
- [ ] Verify no crash (was: TypeError in `moveBlock`) when dragging reporters around in corrupted projects.