### PR TITLE
fix: OnSuccess and onError added to saveProjectThumbnail

### DIFF
--- a/packages/scratch-gui/src/gui-config.ts
+++ b/packages/scratch-gui/src/gui-config.ts
@@ -32,7 +32,7 @@ export interface GUIStorage {
         }
     ): Promise<{id: ProjectId}>;
 
-    saveProjectThumbnail?(projectId: ProjectId, thumbnail: Blob): void;
+    saveProjectThumbnail?(projectId: ProjectId, thumbnail: Blob, onSuccess?: () => void, onError?: () => void): void;
 }
 
 export interface GUIBackpackStorage {


### PR DESCRIPTION
### Resolves

In the GUIStorage interface adds the onSuccess and onError callbacks for the saveProjectThumbnail

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made_

### Test Coverage

_Please show how you have added tests to cover your changes_
