### PR TITLE
fix(scratch-vm): clone shared shadows when restoring inputs

### DIFF
--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -9,6 +9,7 @@ const BlocksRuntimeCache = require('./blocks-runtime-cache');
 const log = require('../util/log');
 const Variable = require('./variable');
 const getMonitorIdForBlockWithArgs = require('../util/get-monitor-id');
+const uid = require('../util/uid');
 
 /**
  * @file
@@ -775,9 +776,23 @@ class Blocks {
                 // this input, or null out the input's block.
                 const shadow = oldParent.inputs[e.oldInput].shadow;
                 if (shadow && e.id !== shadow) {
-                    if (this._blocks[shadow]) {
-                        oldParent.inputs[e.oldInput].block = shadow;
-                        this._blocks[shadow].parent = oldParent.id;
+                    const shadowBlock = this._blocks[shadow];
+                    if (shadowBlock) {
+                        let restoredShadowId = shadow;
+                        if (shadowBlock.parent !== oldParent.id) {
+                            log.warn(`Blocks.moveBlock found shared shadow ownership: block=${e.id}, ` +
+                                `oldParent=${oldParent.id}, oldInput=${e.oldInput}, shadow=${shadow}, ` +
+                                `shadowParent=${shadowBlock.parent}`);
+                            const restoredShadow = Clone.simple(shadowBlock);
+                            restoredShadowId = uid();
+                            restoredShadow.id = restoredShadowId;
+                            restoredShadow.parent = oldParent.id;
+                            restoredShadow.topLevel = false;
+                            this._blocks[restoredShadowId] = restoredShadow;
+                            oldParent.inputs[e.oldInput].shadow = restoredShadowId;
+                        }
+                        oldParent.inputs[e.oldInput].block = restoredShadowId;
+                        this._blocks[restoredShadowId].parent = oldParent.id;
                     } else {
                         // Shadow block is referenced but missing — clear
                         // the stale reference rather than crashing.

--- a/packages/scratch-vm/test/unit/engine_blocks.js
+++ b/packages/scratch-vm/test/unit/engine_blocks.js
@@ -1195,3 +1195,93 @@ test('moveBlock tolerates missing shadow block', t => {
 
     t.end();
 });
+
+test('moveBlock clones shared obscured shadow when restoring input', t => {
+    const b = new Blocks(new Runtime());
+
+    b.createBlock({
+        id: 'originalParent',
+        opcode: 'data_setvariableto',
+        next: null,
+        parent: null,
+        shadow: false,
+        topLevel: true,
+        inputs: {
+            VALUE: {
+                name: 'VALUE',
+                block: 'originalReporter',
+                shadow: 'sharedShadow'
+            }
+        },
+        fields: {}
+    });
+    b.createBlock({
+        id: 'copyParent',
+        opcode: 'data_setvariableto',
+        next: null,
+        parent: null,
+        shadow: false,
+        topLevel: true,
+        inputs: {
+            VALUE: {
+                name: 'VALUE',
+                block: 'copyReporter',
+                shadow: 'sharedShadow'
+            }
+        },
+        fields: {}
+    });
+    b.createBlock({
+        id: 'originalReporter',
+        opcode: 'sensing_answer',
+        next: null,
+        parent: 'originalParent',
+        shadow: false,
+        topLevel: false,
+        inputs: {},
+        fields: {}
+    });
+    b.createBlock({
+        id: 'copyReporter',
+        opcode: 'sensing_answer',
+        next: null,
+        parent: 'copyParent',
+        shadow: false,
+        topLevel: false,
+        inputs: {},
+        fields: {}
+    });
+    b.createBlock({
+        id: 'sharedShadow',
+        opcode: 'text',
+        next: null,
+        parent: 'originalParent',
+        shadow: true,
+        topLevel: false,
+        inputs: {},
+        fields: {
+            TEXT: {
+                name: 'TEXT',
+                value: ''
+            }
+        }
+    });
+
+    b.moveBlock({
+        id: 'copyReporter',
+        oldParent: 'copyParent',
+        oldInput: 'VALUE',
+        newCoordinate: {x: 0, y: 0}
+    });
+
+    const copyInput = b.getBlock('copyParent').inputs.VALUE;
+    t.not(copyInput.shadow, 'sharedShadow');
+    t.equal(copyInput.block, copyInput.shadow);
+    t.equal(b.getBlock(copyInput.shadow).parent, 'copyParent');
+    t.equal(b.getBlock(copyInput.shadow).shadow, true);
+    t.equal(b.getBlock('sharedShadow').parent, 'originalParent');
+    t.equal(b.getBlock('originalParent').inputs.VALUE.shadow, 'sharedShadow');
+    t.equal(b.getBlock('copyReporter').parent, null);
+
+    t.end();
+});


### PR DESCRIPTION
### Resolves

Part of #533. Fixes the P0 item where duplicated blocks can still share obscured shadow IDs in some paths, causing duplicated blocks to become corrupted after a reporter is removed from one copy.

Follow-up to #536.

### Proposed Changes

When `moveBlock` restores an obscured shadow after a reporter is disconnected, check whether the referenced shadow block is already parented to a different block. If it is, clone the shadow with a fresh ID for the input being restored instead of reparenting the shared shadow away from the other block.

This keeps each parent input owning its own shadow block and prevents the shared-shadow state from producing top-level/unrenderable shadow blocks after target switches or workspace reloads.

Also logs the repaired state with the relevant block, parent, input, shadow, and shadow parent IDs.

### Reason for Changes

Duplicated blocks affected by the shared-shadow-ID bug can have two inputs pointing at the same obscured shadow block. Removing the inserted reporter from one duplicate used to restore that shared shadow by changing its `parent`, which stole it from the other duplicate and left the VM block graph inconsistent.

Scratch cannot render top-level or incorrectly owned shadow blocks reliably, and this can prevent later scripts from rendering from the project JSON until save/reload removes the bad shadow.

### Test Coverage

- Added `engine_blocks.js` regression coverage for a corrupted shared-shadow state where two parent inputs reference the same obscured shadow ID.
- Verified that removing one reporter clones the shared shadow for that parent, leaves the original parent/shadow relationship intact, and disconnects the reporter cleanly.
- Ran `npx.cmd tap test/unit/engine_blocks.js` from `packages/scratch-vm`.
- Ran `git diff --check`.
- Ran `npx.cmd eslint src/engine/blocks.js test/unit/engine_blocks.js` from `packages/scratch-vm` (0 errors; existing JSDoc warnings in `blocks.js`).

### Manual Testing

- Reproduced the #533 flow locally before the fix: put a block inside another block's input, duplicate both, remove the inner block from one copy, switch sprites, then return.
- Verified locally after the fix that the duplicated block no longer becomes corrupted by the shared shadow ID path.