### PR TITLE
Fix/shadow top level scripts

### DIFF
--- a/packages/scratch-vm/src/engine/blocks.js
+++ b/packages/scratch-vm/src/engine/blocks.js
@@ -598,7 +598,7 @@ class Blocks {
         // Push block id to scripts array.
         // Blocks are added as a top-level stack if they are marked as a top-block
         // (if they were top-level XML in the event).
-        if (block.topLevel) {
+        if (block.topLevel && !block.shadow) {
             this._addScript(block.id);
         }
 

--- a/packages/scratch-vm/test/unit/engine_blocks.js
+++ b/packages/scratch-vm/test/unit/engine_blocks.js
@@ -1195,3 +1195,28 @@ test('moveBlock tolerates missing shadow block', t => {
 
     t.end();
 });
+
+// Regression test: when Blockly respawns a shadow block (e.g. after
+// uncovering a duplicated input), the create event arrives with
+// topLevel:true because appendInternal creates the block before
+// connecting it. Shadow blocks must never be added to _scripts —
+// a top-level shadow in _scripts causes "Workspace Update Error"
+// on sprite switch because toXML serializes it as a root <shadow>
+// element that Blockly cannot load.
+test('createBlock does not add shadow blocks to _scripts', t => {
+    const b = new Blocks(new Runtime());
+    b.createBlock({
+        id: 'shadow_1',
+        opcode: 'math_number',
+        next: null,
+        fields: {NUM: {name: 'NUM', value: '0'}},
+        inputs: {},
+        topLevel: true,
+        shadow: true
+    });
+    t.equal(b._scripts.indexOf('shadow_1'), -1,
+        'shadow block should not be in _scripts even with topLevel:true');
+    t.ok(Object.prototype.hasOwnProperty.call(b._blocks, 'shadow_1'),
+        'shadow block should still be in _blocks');
+    t.end();
+});


### PR DESCRIPTION
### Resolves

- Defense-in-depth for the duplicate-block data loss reported by @Joeclinton1 on scratchfoundation/scratch-editor#533 (2026-04-23)
- Companion to scratchfoundation/scratch-blocks#3570

### Proposed Changes

Add a shadow check to `createBlock` in `blocks.js` so that shadow blocks arriving with `topLevel: true` are not added to `_scripts`. `moveBlock` already had this guard, but `createBlock` did not.

### Reason for Changes

When Blockly respawns a shadow block (e.g. after uncovering a duplicated input), `appendInternal` creates the block before connecting it, so the create event arrives with `topLevel: true`. Without the shadow check, `createBlock` adds the shadow to `_scripts`. A shadow in `_scripts` causes `toXML` to serialize it as a root `<shadow>` element on sprite switch, which Blockly cannot load, producing "Workspace Update Error" and preventing all subsequent scripts from rendering.

The root cause (shadow state corruption in `stripIds`) is fixed in scratchfoundation/scratch-blocks#3570. This change is defense-in-depth: even if a future code path creates a top-level shadow, the VM will not add it to `_scripts`.

### Test Coverage

- Regression test in `engine_blocks.js`: `createBlock` with a shadow block that has `topLevel: true` does not add it to `_scripts`, but does add it to `_blocks`
