### PR TITLE
fix(scratch-vm): create missing variable and broadcast definitions on import

### DIFF
--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -654,27 +654,35 @@ class Target extends EventEmitter {
     }
 
     /**
-     * Fixes up variable references in this target avoiding conflicts with
-     * pre-existing variables in the same scope.
-     * This is used when uploading this target as a new sprite into an existing
-     * project, where the new sprite may contain references
-     * to variable names that already exist as global variables in the project
-     * (and thus are in scope for variable references in the given sprite).
+     * Reconciles variable, list, and broadcast references on this target with the
+     * variables actually defined in the project, creating any missing definitions
+     * and resolving conflicts.
      *
-     * If this target has a block that references an existing global variable and that
-     * variable *does not* exist in this target (e.g. it was a global variable in the
-     * project the sprite was originally exported from), merge the variables. This entails
-     * fixing the variable references in this sprite to reference the id of the pre-existing global variable.
+     * For each variable, list, or broadcast referenced by a block on this target:
+     * - If the referenced id exists locally on this sprite and the stage already
+     *   has a variable with the same name and type, the local variable is renamed
+     *   to distinguish it from the pre-existing global, and references are
+     *   updated to use the new name.
+     * - If the referenced id exists on the stage as a global, the reference is
+     *   already correct and nothing is done.
+     * - If the referenced id is not defined anywhere, look for a variable with
+     *   the same name and type on the stage. If one exists, the reference is
+     *   remapped to the existing global. Otherwise, a new global is created on
+     *   the stage and the reference is updated to use the unused name.
      *
-     * If this target has a block that references an existing global variable and that
-     * variable does exist in the target itself (e.g. it's a local variable in the sprite being uploaded),
-     * then the local variable is renamed to distinguish itself from the pre-existing variable.
-     * All blocks that reference the local variable will be updated to use the new name.
+     * Also renames any local variables on this sprite whose name and type
+     * collide with a stage global, even if they aren't referenced by any block.
+     *
+     * Used when importing a sprite into an existing project (where the new
+     * sprite may reference variables that already exist on the stage) and when
+     * pasting blocks from the backpack (where the pasted blocks reference ids
+     * that don't yet exist anywhere in the project). When called on the stage,
+     * only the missing-definition path runs; renames are skipped because the
+     * stage's variables are the global scope.
      */
     // TODO (#1360) This function is too long, add some helpers for the different chunks and cases...
     fixUpVariableReferences () {
         if (!this.runtime) return; // There's no runtime context to conflict with
-        if (this.isStage) return; // Stage can't have variable conflicts with itself (and also can't be uploaded)
         const stage = this.runtime.getTargetForStage();
         if (!stage || !stage.variables) return;
 
@@ -690,7 +698,7 @@ class Target extends EventEmitter {
             return null;
         };
 
-        const allReferences = this.blocks.getAllVariableAndListReferences();
+        const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
         const unreferencedLocalVarIds = [];
         if (Object.keys(this.variables).length > 0) {
             for (const localVarId in this.variables) {
@@ -719,10 +727,11 @@ class Target extends EventEmitter {
             if (this.lookupVariableById(varId)) {
                 // Found a variable with the id in either the target or the stage,
                 // figure out which one.
-                if (Object.prototype.hasOwnProperty.call(this.variables, varId)) {
-                    // If the target has the variable, then check whether the stage
+                if (!this.isStage && Object.prototype.hasOwnProperty.call(this.variables, varId)) {
+                    // If a sprite has the variable, then check whether the stage
                     // has one with the same name and type. If it does, then rename
-                    // this target specific variable so that there is a distinction.
+                    // this sprite-specific variable so that there is a distinction.
+                    // On the stage itself, the variable is the global, so skip this.
                     const newVarName = renameConflictingLocalVar(varId, varName, varType);
 
                     if (newVarName) {
@@ -760,12 +769,15 @@ class Target extends EventEmitter {
             }
         }
         // Rename any local variables that were missed above because they aren't
-        // referenced by any blocks
-        for (const id in unreferencedLocalVarIds) {
-            const varId = unreferencedLocalVarIds[id];
-            const name = this.variables[varId].name;
-            const type = this.variables[varId].type;
-            renameConflictingLocalVar(varId, name, type);
+        // referenced by any blocks. Skip on the stage, where variables are the
+        // global scope and have no name conflict with themselves.
+        if (!this.isStage) {
+            for (const id in unreferencedLocalVarIds) {
+                const varId = unreferencedLocalVarIds[id];
+                const name = this.variables[varId].name;
+                const type = this.variables[varId].type;
+                renameConflictingLocalVar(varId, name, type);
+            }
         }
         // Handle global var conflicts with existing global vars (e.g. a sprite is uploaded, and has
         // blocks referencing some variable that the sprite does not own, and this

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -1280,6 +1280,12 @@ class VirtualMachine extends EventEmitter {
                 target.blocks.createBlock(block);
             });
             target.blocks.updateTargetSpecificBlocks(target.isStage);
+            if (!optFromTargetId) {
+                // No source target means the blocks come from outside the project (e.g. the
+                // backpack). Reconcile any variable, list, or broadcast references against
+                // what's defined in the project, creating missing definitions on the stage.
+                target.fixUpVariableReferences();
+            }
         });
     }
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -811,3 +811,157 @@ test('fixUpVariableReferences does not change variable name if there is no varia
 
     t.end();
 });
+
+const addBroadcastBlocksTo = target => {
+    adapter(events.mockBroadcastBlock).forEach(block => target.blocks.createBlock(block));
+};
+
+test('fixUpVariableReferences creates a stage broadcast for an undefined broadcast reference', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, 'mock broadcast message id');
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.value, 'my message');
+
+    target.fixUpVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1);
+    const broadcast = stage.variables['mock broadcast message id'];
+    t.ok(broadcast, 'broadcast created on stage with original id');
+    t.equal(broadcast.name, 'my message');
+    t.equal(broadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, 'mock broadcast message id');
+
+    t.end();
+});
+
+test('fixUpVariableReferences remaps a broadcast reference to an existing same-name stage broadcast', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('pre-existing broadcast id', 'my message', Variable.BROADCAST_MESSAGE_TYPE);
+    addBroadcastBlocksTo(target);
+
+    t.equal(Object.keys(stage.variables).length, 1);
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, 'mock broadcast message id');
+
+    target.fixUpVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'no duplicate broadcast created');
+    t.ok(stage.variables['pre-existing broadcast id'], 'existing broadcast preserved');
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, 'pre-existing broadcast id',
+        'block field id remapped to existing broadcast');
+
+    t.end();
+});
+
+test('fixUpVariableReferences is idempotent for broadcast references', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    target.fixUpVariableReferences();
+    const stageVarsAfterFirst = Object.keys(stage.variables).slice();
+    const fieldIdAfterFirst = target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id;
+
+    target.fixUpVariableReferences();
+
+    t.same(Object.keys(stage.variables), stageVarsAfterFirst, 'no new stage broadcasts on second call');
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, fieldIdAfterFirst,
+        'field id unchanged on second call');
+
+    t.end();
+});
+
+test('fixUpVariableReferences on the stage does not rename existing stage variables', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    runtime.targets = [stage];
+
+    stage.createVariable('pre-existing global var id', 'a stage variable', Variable.SCALAR_TYPE);
+    stage.blocks.createBlock({
+        id: 'a stage block',
+        opcode: 'data_variable',
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: 'pre-existing global var id',
+                value: 'a stage variable',
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    stage.fixUpVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'no duplicate stage variable');
+    t.equal(stage.variables['pre-existing global var id'].name, 'a stage variable',
+        'existing stage variable name not changed');
+    t.equal(stage.blocks.getBlock('a stage block').fields.VARIABLE.id, 'pre-existing global var id',
+        'block field id unchanged');
+
+    t.end();
+});
+
+test('fixUpVariableReferences on the stage creates broadcasts for undefined references', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    runtime.targets = [stage];
+
+    addBroadcastBlocksTo(stage);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    stage.fixUpVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1);
+    const broadcast = stage.variables['mock broadcast message id'];
+    t.ok(broadcast, 'broadcast created on stage');
+    t.equal(broadcast.name, 'my message');
+    t.equal(broadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+    t.end();
+});

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -948,6 +948,128 @@ test('shareBlocksToTarget chooses a fresh name for a new global variable checkin
     });
 });
 
+test('shareBlocksToTarget without a source target creates a missing variable on the stage', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const spr1 = new Sprite(null, runtime);
+    const stage = spr1.createClone();
+    stage.isStage = true;
+
+    const spr2 = new Sprite(null, runtime);
+    const target = spr2.createClone();
+
+    runtime.targets = [stage, target];
+    vm.editingTarget = target;
+    vm.runtime.setEditingTarget(target);
+
+    const blocksToShare = adapter(events.mockVariableBlock);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(Object.keys(target.variables).length, 0);
+
+    vm.shareBlocksToTarget(blocksToShare, target.id).then(() => {
+        t.equal(Object.keys(stage.variables).length, 1, 'variable created on stage');
+        const newVar = stage.variables['mock var id'];
+        t.ok(newVar, 'variable preserves the original id');
+        t.equal(newVar.name, 'a mock variable');
+        t.equal(newVar.type, Variable.SCALAR_TYPE);
+        t.equal(Object.keys(target.variables).length, 0, 'no variable on the receiving sprite');
+
+        const newBlockId = Object.keys(target.blocks._blocks)[0];
+        t.equal(target.blocks.getBlock(newBlockId).fields.VARIABLE.id, 'mock var id');
+
+        t.end();
+    });
+});
+
+test('shareBlocksToTarget without a source target creates a missing broadcast on the stage', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const spr1 = new Sprite(null, runtime);
+    const stage = spr1.createClone();
+    stage.isStage = true;
+
+    const spr2 = new Sprite(null, runtime);
+    const target = spr2.createClone();
+
+    runtime.targets = [stage, target];
+    vm.editingTarget = target;
+    vm.runtime.setEditingTarget(target);
+
+    const blocksToShare = adapter(events.mockBroadcastBlock);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    vm.shareBlocksToTarget(blocksToShare, target.id).then(() => {
+        t.equal(Object.keys(stage.variables).length, 1, 'broadcast created on stage');
+        const newBroadcast = stage.variables['mock broadcast message id'];
+        t.ok(newBroadcast, 'broadcast preserves the original id');
+        t.equal(newBroadcast.name, 'my message');
+        t.equal(newBroadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+        const menuBlockId = Object.keys(target.blocks._blocks)
+            .find(id => target.blocks.getBlock(id).opcode === 'event_broadcast_menu');
+        t.ok(menuBlockId, 'broadcast menu block exists on the target');
+        t.equal(target.blocks.getBlock(menuBlockId).fields.BROADCAST_OPTION.id, 'mock broadcast message id');
+
+        t.end();
+    });
+});
+
+test('shareBlocksToTarget without a source target remaps a variable to an existing same-name global', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const spr1 = new Sprite(null, runtime);
+    const stage = spr1.createClone();
+    stage.isStage = true;
+
+    const spr2 = new Sprite(null, runtime);
+    const target = spr2.createClone();
+
+    runtime.targets = [stage, target];
+    vm.editingTarget = target;
+    vm.runtime.setEditingTarget(target);
+
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+
+    const blocksToShare = adapter(events.mockVariableBlock);
+
+    vm.shareBlocksToTarget(blocksToShare, target.id).then(() => {
+        t.equal(Object.keys(stage.variables).length, 1, 'no duplicate variable created');
+        t.ok(stage.variables['pre-existing global var id'], 'existing variable preserved');
+
+        const newBlockId = Object.keys(target.blocks._blocks)[0];
+        t.equal(target.blocks.getBlock(newBlockId).fields.VARIABLE.id, 'pre-existing global var id',
+            'block field id remapped to existing variable');
+
+        t.end();
+    });
+});
+
+test('shareBlocksToTarget without a source target creates broadcasts when pasted onto the stage', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const spr1 = new Sprite(null, runtime);
+    const stage = spr1.createClone();
+    stage.isStage = true;
+
+    runtime.targets = [stage];
+    vm.editingTarget = stage;
+    vm.runtime.setEditingTarget(stage);
+
+    const blocksToShare = adapter(events.mockBroadcastBlock);
+
+    vm.shareBlocksToTarget(blocksToShare, stage.id).then(() => {
+        t.equal(Object.keys(stage.variables).length, 1, 'broadcast created on stage when stage is the target');
+        const newBroadcast = stage.variables['mock broadcast message id'];
+        t.ok(newBroadcast);
+        t.equal(newBroadcast.name, 'my message');
+        t.equal(newBroadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+        t.end();
+    });
+});
+
 test('shareBlocksToTarget loads extensions that have not yet been loaded', t => {
     const vm = new VirtualMachine();
     const runtime = vm.runtime;
@@ -973,6 +1095,35 @@ test('shareBlocksToTarget loads extensions that have not yet been loaded', t => 
     vm.shareBlocksToTarget(fakeBlocks, stage.id).then(() => {
         // Verify that only the not-loaded extension gets loaded
         t.same(loadedIds, ['notloaded']);
+        t.end();
+    });
+});
+
+test('installTargets creates a stage broadcast for a sprite import that references one', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const spr1 = new Sprite(null, runtime);
+    const stage = spr1.createClone();
+    stage.isStage = true;
+    runtime.targets = [stage];
+
+    const importedSprite = new Sprite(null, runtime);
+    const importedTarget = importedSprite.createClone();
+    importedTarget.isStage = false;
+    importedTarget.getName = () => 'Imported';
+    adapter(events.mockBroadcastBlock).forEach(block => importedTarget.blocks.createBlock(block));
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([importedTarget], extensions, false).then(() => {
+        t.equal(Object.keys(stage.variables).length, 1, 'broadcast created on stage during sprite import');
+        const newBroadcast = stage.variables['mock broadcast message id'];
+        t.ok(newBroadcast);
+        t.equal(newBroadcast.name, 'my message');
+        t.equal(newBroadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
         t.end();
     });
 });


### PR DESCRIPTION
### Resolves

Part of scratchfoundation/scratch-editor#533. Fixes four related items in the spork tracker:

- Backpack variable corruption (variables blank after paste). Reported by @Joeclinton1 ([comment](https://github.com/scratchfoundation/scratch-editor/issues/533#issuecomment-4277093727)) and replicated by @redspacecat ([comment](https://github.com/scratchfoundation/scratch-editor/issues/533#issuecomment-4277096104)).
- Backpack broadcast non-firing (broadcast not defined in target project). Diagnosed by @nimeratus ([comment](https://github.com/scratchfoundation/scratch-editor/issues/533#issuecomment-4299918124)).
- Broadcasts dropdown empties after sprite import (forum 878352, 878407).
- Backpacked sprites can't talk to others (forum 878434, 879069).

### Proposed Changes

Two gaps in `scratch-vm` had the same shape:

1. `VirtualMachine.shareBlocksToTarget` only ran reference reconciliation when called with a source target ID. The backpack-paste path passes no source target, so pasted scripts referenced ids that weren't defined anywhere in the receiving project.
2. `Target.fixUpVariableReferences` walked variable and list references but skipped broadcasts, because `getAllVariableAndListReferences` was called without `optIncludeBroadcast`. The sprite-import path (`installTargets` with `wholeProject=false`) calls `fixUpVariableReferences`, so imported sprites left broadcast references undefined.

This PR:

- Extends `fixUpVariableReferences` to walk broadcast references and to run safely on the stage. The local-vs-global rename branches that don't apply on the global scope are guarded with `!this.isStage`. Updates the JSDoc.
- Wires `shareBlocksToTarget` to call `target.fixUpVariableReferences()` after creating the new blocks when there is no source target.

### Reason for Changes

Pre-spork, the forked `scratch-blocks` auto-created Blockly variable-model entries for unknown ids referenced by blocks added to the workspace. Those auto-creations fired `var_create` events that `scratch-vm`'s `Blocks.blocklyListen` consumed, materializing the missing definitions on the right target. Upstream Blockly does not auto-create from unknown ids the same way, so the unfork removed that implicit path and the references began to dangle.

Doing the reconciliation in `scratch-vm` itself makes it self-sufficient: the authoritative project state lives there, the existing `fixUpVariableReferences` already handles the merge / create / remap cases for variables and lists, and including broadcasts is a small extension to that logic. The change is also idempotent against any future `scratch-blocks` behavior.

### Test Coverage

- `packages/scratch-vm/test/unit/engine_target.js`: 5 new Tap tests covering broadcast handling in `fixUpVariableReferences` (undefined ref creates a stage broadcast, same-name remap, idempotency) and stage-as-target (no rename of existing stage variables, broadcast creation when stage is the receiving target).
- `packages/scratch-vm/test/unit/virtual-machine.js`: 4 new Tap tests for `shareBlocksToTarget` without a source target (variable creation, broadcast creation, name-collision remap, stage as target) and 1 for `installTargets` covering the sprite-import broadcast path.
- `npm test --workspace=packages/scratch-vm` passes (3698 / 3698).
- `npm run build` and `npm test` from the repo root pass on every workspace.

### Manual Testing

- [x] Sprite import: imported a `.sprite3` that references broadcasts; broadcasts dropdown is populated on the receiving project.
- [x] Sprite import cross-sprite messaging: imported a sprite that broadcasts; another sprite with `when I receive` actually fires at runtime.
- [x] Stage as paste / import target: existing stage variables are not renamed.
- [x] Spot-check existing behavior: regular cross-sprite drag, normal sprite-import without broadcasts, regular workspace use; nothing visibly regressed.
- [ ] Backpack paste with a variable (needs a backpack host).
- [ ] Backpack paste with a broadcast (needs a backpack host).
- [ ] Backpacked sprite cross-sprite messaging (needs a backpack host).