### PR TITLE
fix(scratch-vm): repair missing variable and broadcast definitions on project load

### DIFF
--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -679,6 +679,13 @@ class Target extends EventEmitter {
         const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
         const conflictIdsToReplace = Object.create(null);
         const conflictNamesToReplace = Object.create(null);
+        // When a dangling reference triggers creation of a new stage variable, remember
+        // the original (pre-bump) name so subsequent dangling references with the same
+        // original name and type coalesce to the same stage variable instead of creating
+        // a second one. Scratchers who pasted scripts referencing what they called
+        // "score" twice almost certainly meant one variable, not two.
+        const createdForOriginalName = Object.create(null);
+        const originalNameKey = (name, type) => `${type}\u0000${name}`;
 
         // Cache the list of all variable names by type so that we don't need to
         // re-calculate this in every iteration of the following loop.
@@ -709,15 +716,38 @@ class Target extends EventEmitter {
                     );
                 }
             } else {
-                const allNames = allVarNames(varType);
-                const freshName = StringUtil.unusedName(varName, allNames);
-                stage.createVariable(varId, freshName, varType);
-                if (!conflictNamesToReplace[varId]) {
-                    conflictNamesToReplace[varId] = freshName;
-                    log.warn(
-                        `Reconciled dangling reference on '${this.getName()}': created stage variable ` +
-                        `'${varId}' (name '${freshName}', type '${varType}').`
-                    );
+                const coalesceKey = originalNameKey(varName, varType);
+                const earlierCreated = createdForOriginalName[coalesceKey];
+                if (earlierCreated) {
+                    // An earlier dangling reference in this pass already triggered creation
+                    // for this original name and type. Coalesce to that stage variable, and
+                    // update this reference's displayed name to match the bumped name so the
+                    // two blocks display consistently.
+                    if (!conflictIdsToReplace[varId]) {
+                        conflictIdsToReplace[varId] = earlierCreated.id;
+                        conflictNamesToReplace[varId] = earlierCreated.freshName;
+                        log.warn(
+                            `Reconciled dangling reference on '${this.getName()}': coalesced id '${varId}' ` +
+                            `(name '${varName}', type '${varType}') with earlier-created stage variable ` +
+                            `'${earlierCreated.id}' (name '${earlierCreated.freshName}').`
+                        );
+                    }
+                } else {
+                    const allNames = allVarNames(varType);
+                    const freshName = StringUtil.unusedName(varName, allNames);
+                    stage.createVariable(varId, freshName, varType);
+                    // Track the new name so unusedName accounts for it on subsequent calls,
+                    // and remember which stage variable served this original name so
+                    // future same-name dangling references coalesce instead of duplicating.
+                    allNames.push(freshName);
+                    createdForOriginalName[coalesceKey] = {id: varId, freshName};
+                    if (!conflictNamesToReplace[varId]) {
+                        conflictNamesToReplace[varId] = freshName;
+                        log.warn(
+                            `Reconciled dangling reference on '${this.getName()}': created stage variable ` +
+                            `'${varId}' (name '${freshName}', type '${varType}').`
+                        );
+                    }
                 }
             }
         }

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -654,58 +654,29 @@ class Target extends EventEmitter {
     }
 
     /**
-     * Reconciles variable, list, and broadcast references on this target with the
-     * variables actually defined in the project, creating any missing definitions
-     * and resolving conflicts.
+     * Reconciles variable, list, and broadcast references on this target against
+     * the variables actually defined in the project, creating definitions on the
+     * stage for any references whose ids are not defined anywhere. Does not
+     * rename any existing variables.
      *
      * For each variable, list, or broadcast referenced by a block on this target:
-     * - If the referenced id exists locally on this sprite and the stage already
-     *   has a variable with the same name and type, the local variable is renamed
-     *   to distinguish it from the pre-existing global, and references are
-     *   updated to use the new name.
-     * - If the referenced id exists on the stage as a global, the reference is
-     *   already correct and nothing is done.
-     * - If the referenced id is not defined anywhere, look for a variable with
-     *   the same name and type on the stage. If one exists, the reference is
-     *   remapped to the existing global. Otherwise, a new global is created on
-     *   the stage and the reference is updated to use the unused name.
+     * - If the referenced id is found locally on this sprite or on the stage,
+     *   the reference is already correct and nothing happens.
+     * - If the referenced id is not defined anywhere, the stage is checked for a
+     *   variable with the same name and type. If one exists, the field id is
+     *   remapped to that existing global. Otherwise, a new global is created on
+     *   the stage with a non-conflicting name and the field name is updated.
      *
-     * Also renames any local variables on this sprite whose name and type
-     * collide with a stage global, even if they aren't referenced by any block.
-     *
-     * Used when importing a sprite into an existing project (where the new
-     * sprite may reference variables that already exist on the stage) and when
-     * pasting blocks from the backpack (where the pasted blocks reference ids
-     * that don't yet exist anywhere in the project). When called on the stage,
-     * only the missing-definition path runs; renames are skipped because the
-     * stage's variables are the global scope.
+     * Used during whole-project load to repair projects corrupted by historical
+     * bugs that left dangling references, and as the definition-creation phase
+     * of `fixUpVariableReferences` for sprite import and backpack paste.
      */
-    // TODO (#1360) This function is too long, add some helpers for the different chunks and cases...
-    fixUpVariableReferences () {
-        if (!this.runtime) return; // There's no runtime context to conflict with
+    reconcileVariableReferences () {
+        if (!this.runtime) return;
         const stage = this.runtime.getTargetForStage();
         if (!stage || !stage.variables) return;
 
-        const renameConflictingLocalVar = (id, name, type) => {
-            const conflict = stage.lookupVariableByNameAndType(name, type);
-            if (conflict) {
-                const newName = StringUtil.unusedName(
-                    `${this.getName()}: ${name}`,
-                    this.getAllVariableNamesInScopeByType(type));
-                this.renameVariable(id, newName);
-                return newName;
-            }
-            return null;
-        };
-
         const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
-        const unreferencedLocalVarIds = [];
-        if (Object.keys(this.variables).length > 0) {
-            for (const localVarId in this.variables) {
-                if (!Object.prototype.hasOwnProperty.call(this.variables, localVarId)) continue;
-                if (!allReferences[localVarId]) unreferencedLocalVarIds.push(localVarId);
-            }
-        }
         const conflictIdsToReplace = Object.create(null);
         const conflictNamesToReplace = Object.create(null);
 
@@ -720,81 +691,46 @@ class Target extends EventEmitter {
         };
 
         for (const varId in allReferences) {
-            // We don't care about which var ref we get, they should all have the same var info
+            if (this.lookupVariableById(varId)) continue;
+            // The referenced id is not defined anywhere. Treat this as a reference
+            // to a global from a different project (or from a backpack paste / sprite
+            // import that lost its definition). Look for a same-name same-type global
+            // on the stage; if found, queue an id remap, otherwise create a fresh one.
             const varRef = allReferences[varId][0];
             const varName = varRef.referencingField.value;
             const varType = varRef.type;
-            if (this.lookupVariableById(varId)) {
-                // Found a variable with the id in either the target or the stage,
-                // figure out which one.
-                if (!this.isStage && Object.prototype.hasOwnProperty.call(this.variables, varId)) {
-                    // If a sprite has the variable, then check whether the stage
-                    // has one with the same name and type. If it does, then rename
-                    // this sprite-specific variable so that there is a distinction.
-                    // On the stage itself, the variable is the global, so skip this.
-                    const newVarName = renameConflictingLocalVar(varId, varName, varType);
-
-                    if (newVarName) {
-                        // We are not calling this.blocks.updateBlocksAfterVarRename
-                        // here because it will search through all the blocks. We already
-                        // have access to all the references for this var id.
-                        allReferences[varId].map(ref => {
-                            ref.referencingField.value = newVarName;
-                            return ref;
-                        });
-                    }
+            const existingVar = stage.lookupVariableByNameAndType(varName, varType);
+            if (existingVar) {
+                if (!conflictIdsToReplace[varId]) {
+                    conflictIdsToReplace[varId] = existingVar.id;
+                    log.warn(
+                        `Reconciled dangling reference on '${this.getName()}': remapped id '${varId}' ` +
+                        `(name '${varName}', type '${varType}') to existing stage variable '${existingVar.id}'.`
+                    );
                 }
             } else {
-                // We didn't find the referenced variable id anywhere,
-                // Treat it as a reference to a global variable (from the original
-                // project this sprite was exported from).
-                // Check for whether a global variable of the same name and type exists,
-                // and if so, track it to merge with the existing global in a second pass of the blocks.
-                const existingVar = stage.lookupVariableByNameAndType(varName, varType);
-                if (existingVar) {
-                    if (!conflictIdsToReplace[varId]) {
-                        conflictIdsToReplace[varId] = existingVar.id;
-                    }
-                } else {
-                    // A global variable with the same name did not already exist,
-                    // create a new one such that it does not conflict with any
-                    // names of local variables of the same type.
-                    const allNames = allVarNames(varType);
-                    const freshName = StringUtil.unusedName(varName, allNames);
-                    stage.createVariable(varId, freshName, varType);
-                    if (!conflictNamesToReplace[varId]) {
-                        conflictNamesToReplace[varId] = freshName;
-                    }
+                const allNames = allVarNames(varType);
+                const freshName = StringUtil.unusedName(varName, allNames);
+                stage.createVariable(varId, freshName, varType);
+                if (!conflictNamesToReplace[varId]) {
+                    conflictNamesToReplace[varId] = freshName;
+                    log.warn(
+                        `Reconciled dangling reference on '${this.getName()}': created stage variable ` +
+                        `'${varId}' (name '${freshName}', type '${varType}').`
+                    );
                 }
             }
         }
-        // Rename any local variables that were missed above because they aren't
-        // referenced by any blocks. Skip on the stage, where variables are the
-        // global scope and have no name conflict with themselves.
-        if (!this.isStage) {
-            for (const id in unreferencedLocalVarIds) {
-                const varId = unreferencedLocalVarIds[id];
-                const name = this.variables[varId].name;
-                const type = this.variables[varId].type;
-                renameConflictingLocalVar(varId, name, type);
-            }
-        }
-        // Handle global var conflicts with existing global vars (e.g. a sprite is uploaded, and has
-        // blocks referencing some variable that the sprite does not own, and this
-        // variable conflicts with a global var)
-        // In this case, we want to merge the new variable referenes with the
-        // existing global variable
+
+        // Apply queued id remaps (merge the dangling references with the existing global).
         for (const conflictId in conflictIdsToReplace) {
             const existingId = conflictIdsToReplace[conflictId];
             const referencesToUpdate = allReferences[conflictId];
             this.mergeVariables(conflictId, existingId, referencesToUpdate);
         }
 
-        // Handle global var conflicts existing local vars (e.g a sprite is uploaded,
-        // and has blocks referencing some variable that the sprite does not own, and this
-        // variable conflcits with another sprite's local var).
-        // In this case, we want to go through the variable references and update
-        // the name of the variable in that reference.
+        // Apply queued field-name updates for newly-created globals whose name was
+        // bumped to avoid a collision.
         for (const conflictId in conflictNamesToReplace) {
             const newName = conflictNamesToReplace[conflictId];
             const referencesToUpdate = allReferences[conflictId];
@@ -802,6 +738,66 @@ class Target extends EventEmitter {
                 ref.referencingField.value = newName;
                 return ref;
             });
+        }
+    }
+
+    /**
+     * Reconciles missing definitions (via `reconcileVariableReferences`) and then
+     * renames sprite-local variables that name-collide with stage globals so they
+     * remain distinguishable after import.
+     *
+     * Used when importing a sprite into an existing project and when pasting
+     * blocks from the backpack. Project load uses `reconcileVariableReferences`
+     * directly so that legitimately-existing local-vs-global name collisions in
+     * a saved project are not renamed.
+     */
+    fixUpVariableReferences () {
+        if (!this.runtime) return;
+        const stage = this.runtime.getTargetForStage();
+        if (!stage || !stage.variables) return;
+
+        // First, ensure every referenced variable, list, or broadcast has a definition.
+        this.reconcileVariableReferences();
+
+        // The stage's variables are the global scope; there's no local-vs-global
+        // distinction to disambiguate.
+        if (this.isStage) return;
+
+        const renameConflictingLocalVar = (id, name, type) => {
+            const conflict = stage.lookupVariableByNameAndType(name, type);
+            if (conflict) {
+                const newName = StringUtil.unusedName(
+                    `${this.getName()}: ${name}`,
+                    this.getAllVariableNamesInScopeByType(type));
+                this.renameVariable(id, newName);
+                return newName;
+            }
+            return null;
+        };
+
+        // Walk the references again and rename any sprite-local variables whose
+        // name and type collide with a stage global. References on this target
+        // that point at the local are updated to use the new name.
+        const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
+        for (const varId in allReferences) {
+            if (!Object.prototype.hasOwnProperty.call(this.variables, varId)) continue;
+            const varRef = allReferences[varId][0];
+            const newVarName = renameConflictingLocalVar(varId, varRef.referencingField.value, varRef.type);
+            if (newVarName) {
+                allReferences[varId].map(ref => {
+                    ref.referencingField.value = newVarName;
+                    return ref;
+                });
+            }
+        }
+
+        // Rename any local variables that aren't referenced by any block but still
+        // collide with a stage global, so the sprite remains internally consistent.
+        for (const localVarId in this.variables) {
+            if (!Object.prototype.hasOwnProperty.call(this.variables, localVarId)) continue;
+            if (allReferences[localVarId]) continue;
+            const v = this.variables[localVarId];
+            renameConflictingLocalVar(localVarId, v.name, v.type);
         }
     }
 

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -698,7 +698,30 @@ class Target extends EventEmitter {
         };
 
         for (const varId in allReferences) {
-            if (this.lookupVariableById(varId)) continue;
+            const existing = this.lookupVariableById(varId);
+            if (existing) {
+                // The id resolves to a real variable. Normalize displayed names so
+                // every block field shows the variable's current name. A previous
+                // target's pass on this load may have created the stage variable with
+                // a bumped name; refs on this target that still show the original
+                // name need to be brought into agreement. Scan all refs (not just
+                // the first) so an inconsistent set of refs to the same id heals
+                // even when the first ref happens to already match.
+                if (!conflictNamesToReplace[varId]) {
+                    const staleRef = allReferences[varId].find(
+                        ref => ref.referencingField.value !== existing.name
+                    );
+                    if (staleRef) {
+                        conflictNamesToReplace[varId] = existing.name;
+                        log.warn(
+                            `Reconciled dangling reference on '${this.getName()}': normalized displayed ` +
+                            `name to '${existing.name}' for id '${varId}' ` +
+                            `(was '${staleRef.referencingField.value}').`
+                        );
+                    }
+                }
+                continue;
+            }
             // The referenced id is not defined anywhere. Treat this as a reference
             // to a global from a different project (or from a backpack paste / sprite
             // import that lost its definition). Look for a same-name same-type global

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -714,8 +714,8 @@ class Target extends EventEmitter {
                     if (staleRef) {
                         conflictNamesToReplace[varId] = existing.name;
                         log.warn(
-                            `Reconciled dangling reference on '${this.getName()}': normalized displayed ` +
-                            `name to '${existing.name}' for id '${varId}' ` +
+                            `Reconciled stale displayed name on '${this.getName()}': updated to ` +
+                            `'${existing.name}' for id '${varId}' ` +
                             `(was '${staleRef.referencingField.value}').`
                         );
                     }

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -560,7 +560,13 @@ class VirtualMachine extends EventEmitter {
                 this.editingTarget = targets[0];
             }
 
-            if (!wholeProject) {
+            if (wholeProject) {
+                // A loaded project may carry dangling variable, list, or broadcast
+                // references baked in by historical bugs. Reconcile each target so
+                // those references resolve cleanly without renaming any legitimate
+                // local-vs-global name collisions.
+                targets.forEach(target => target.reconcileVariableReferences());
+            } else {
                 this.editingTarget.fixUpVariableReferences();
             }
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1191,6 +1191,90 @@ test('reconcileVariableReferences emits log.warn when it remaps a reference', t 
     t.end();
 });
 
+test('reconcileVariableReferences coalesces same-original-name dangling refs to one stage variable', t => {
+    // Regression for an issue caught in review: when two dangling refs share an
+    // original name+type and the name has to be bumped (because some other target
+    // already uses it), the second ref must coalesce with the first rather than
+    // create a second stage variable. A Scratcher who pasted two scripts referencing
+    // what they called "score" almost certainly meant one variable, not two.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    // Another sprite owns a local variable with the same name, forcing unusedName to bump.
+    const otherSprite = new Target(runtime);
+    otherSprite.isStage = false;
+    otherSprite.getName = () => 'Other';
+    otherSprite.createVariable('other local id', 'shared name', Variable.SCALAR_TYPE);
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, otherSprite, target];
+
+    // Two dangling refs with the same original name+type, distinct ids.
+    target.blocks.createBlock({
+        id: 'block A',
+        opcode: 'data_variable',
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: 'dangling A',
+                value: 'shared name',
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+    target.blocks.createBlock({
+        id: 'block B',
+        opcode: 'data_variable',
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: 'dangling B',
+                value: 'shared name',
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    target.reconcileVariableReferences();
+
+    const stageVars = Object.values(stage.variables);
+    t.equal(stageVars.length, 1, 'exactly one new stage variable was created');
+    const created = stageVars[0];
+    t.equal(created.type, Variable.SCALAR_TYPE);
+    t.not(created.name, 'shared name', 'name was bumped to avoid the existing local');
+
+    // Both block fields should now point to the same created stage variable
+    // and display the same (bumped) name, otherwise users see one block named
+    // "shared name" and another named "shared name2" pointing at the same variable.
+    const fieldA = target.blocks.getBlock('block A').fields.VARIABLE;
+    const fieldB = target.blocks.getBlock('block B').fields.VARIABLE;
+    t.equal(fieldA.id, created.id, 'first dangling ref points at the created stage variable');
+    t.equal(fieldB.id, created.id, 'second dangling ref coalesces to the same stage variable');
+    t.equal(fieldA.value, created.name, 'first field displays the bumped name');
+    t.equal(fieldB.value, created.name, 'second field displays the same bumped name');
+
+    t.end();
+});
+
 test('reconcileVariableReferences does not log on clean references', t => {
     const runtime = new Runtime();
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -3,6 +3,7 @@ const Target = require('../../src/engine/target');
 const Variable = require('../../src/engine/variable');
 const adapter = require('../../src/engine/adapter');
 const Runtime = require('../../src/engine/runtime');
+const log = require('../../src/util/log');
 const events = require('../fixtures/events.json');
 
 test('spec', t => {
@@ -962,6 +963,252 @@ test('fixUpVariableReferences on the stage creates broadcasts for undefined refe
     t.ok(broadcast, 'broadcast created on stage');
     t.equal(broadcast.name, 'my message');
     t.equal(broadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+    t.end();
+});
+
+test('reconcileVariableReferences creates a stage variable for an undefined variable reference', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(Object.keys(target.variables).length, 0);
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'variable created on stage');
+    const newVar = stage.variables['mock var id'];
+    t.ok(newVar, 'variable preserves the original id');
+    t.equal(newVar.name, 'a mock variable');
+    t.equal(newVar.type, Variable.SCALAR_TYPE);
+    t.equal(Object.keys(target.variables).length, 0, 'no variable on the sprite');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+
+    t.end();
+});
+
+test('reconcileVariableReferences creates a stage broadcast for an undefined broadcast reference', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1);
+    const broadcast = stage.variables['mock broadcast message id'];
+    t.ok(broadcast, 'broadcast created on stage');
+    t.equal(broadcast.name, 'my message');
+    t.equal(broadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, 'mock broadcast message id');
+
+    t.end();
+});
+
+test('reconcileVariableReferences remaps to an existing same-name stage variable', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'no duplicate created');
+    t.ok(stage.variables['pre-existing global var id'], 'existing variable preserved');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'pre-existing global var id',
+        'block field id remapped to existing variable');
+
+    t.end();
+});
+
+test('reconcileVariableReferences is idempotent', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    target.reconcileVariableReferences();
+    const stageVarsAfterFirst = Object.keys(stage.variables).slice();
+    const fieldIdAfterFirst = target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id;
+
+    target.reconcileVariableReferences();
+
+    t.same(Object.keys(stage.variables), stageVarsAfterFirst, 'no new stage variables on second call');
+    t.equal(target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION.id, fieldIdAfterFirst,
+        'field id unchanged on second call');
+
+    t.end();
+});
+
+test('reconcileVariableReferences does NOT rename a sprite local that name-collides with a stage global', t => {
+    // This is the critical regression test that distinguishes reconcileVariableReferences from
+    // fixUpVariableReferences. Project load runs only the repair-only helper on every target;
+    // legitimate local-vs-global name collisions (a Scratch configuration that has always been
+    // valid) must not be touched.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('global var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.createVariable('mock var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    target.reconcileVariableReferences();
+
+    t.equal(target.variables['mock var id'].name, 'a mock variable',
+        'sprite local variable not renamed by reconcile');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id',
+        'block field id unchanged');
+    t.equal(Object.keys(stage.variables).length, 1, 'no new stage variables created');
+
+    t.end();
+});
+
+test('reconcileVariableReferences on the stage creates broadcasts for undefined references', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    runtime.targets = [stage];
+
+    addBroadcastBlocksTo(stage);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    stage.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1);
+    const broadcast = stage.variables['mock broadcast message id'];
+    t.ok(broadcast);
+    t.equal(broadcast.name, 'my message');
+    t.equal(broadcast.type, Variable.BROADCAST_MESSAGE_TYPE);
+
+    t.end();
+});
+
+const captureLogWarn = (fn) => {
+    const original = log.warn;
+    const messages = [];
+    log.warn = (...args) => messages.push(args.join(' '));
+    try {
+        fn();
+    } finally {
+        log.warn = original;
+    }
+    return messages;
+};
+
+test('reconcileVariableReferences emits log.warn when it creates a stage definition', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+
+    t.equal(messages.length, 1, 'one log.warn fired');
+    t.match(messages[0], /Reconciled.*'Target'.*created.*'mock broadcast message id'/,
+        'log message names the target and the created definition');
+
+    t.end();
+});
+
+test('reconcileVariableReferences emits log.warn when it remaps a reference', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+
+    t.equal(messages.length, 1, 'one log.warn fired');
+    t.match(messages[0], /Reconciled.*remapped.*'mock var id'.*'pre-existing global var id'/,
+        'log message names the remap');
+
+    t.end();
+});
+
+test('reconcileVariableReferences does not log on clean references', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('mock var id', 'a mock variable', Variable.SCALAR_TYPE);
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+
+    t.equal(messages.length, 0, 'no log.warn fired on a clean reference');
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1275,6 +1275,74 @@ test('reconcileVariableReferences coalesces same-original-name dangling refs to 
     t.end();
 });
 
+test('reconcileVariableReferences normalizes field values across targets after a bump', t => {
+    // Regression: when target A's reconcile pass creates a stage variable with a
+    // bumped name (because of an external collision), a later target B that
+    // references the same id by lookup must have its block field's displayed name
+    // normalized too — otherwise the same variable shows different names in
+    // different sprites' blocks.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    // External collision forces unusedName to bump.
+    const otherSprite = new Target(runtime);
+    otherSprite.isStage = false;
+    otherSprite.getName = () => 'Other';
+    otherSprite.createVariable('other local id', 'shared name', Variable.SCALAR_TYPE);
+
+    const targetA = new Target(runtime);
+    targetA.isStage = false;
+    targetA.getName = () => 'TargetA';
+
+    const targetB = new Target(runtime);
+    targetB.isStage = false;
+    targetB.getName = () => 'TargetB';
+
+    runtime.targets = [stage, otherSprite, targetA, targetB];
+
+    const makeBlockReferencing = (blockId, fieldId, fieldValue) => ({
+        id: blockId,
+        opcode: 'data_variable',
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: fieldId,
+                value: fieldValue,
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    targetA.blocks.createBlock(makeBlockReferencing('block A', 'shared dangling id', 'shared name'));
+    targetB.blocks.createBlock(makeBlockReferencing('block B', 'shared dangling id', 'shared name'));
+
+    // Match what installTargets does on whole-project load: reconcile each target in turn.
+    targetA.reconcileVariableReferences();
+    targetB.reconcileVariableReferences();
+
+    const stageVars = Object.values(stage.variables);
+    t.equal(stageVars.length, 1, 'one stage variable created across both targets');
+    const created = stageVars[0];
+    t.not(created.name, 'shared name', 'name was bumped');
+
+    const fieldA = targetA.blocks.getBlock('block A').fields.VARIABLE;
+    const fieldB = targetB.blocks.getBlock('block B').fields.VARIABLE;
+    t.equal(fieldA.value, created.name, 'target A field value matches the resolved variable name');
+    t.equal(fieldB.value, created.name, 'target B field value matches the resolved variable name');
+
+    t.end();
+});
+
 test('reconcileVariableReferences does not log on clean references', t => {
     const runtime = new Runtime();
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -997,6 +997,61 @@ test('reconcileVariableReferences creates a stage variable for an undefined vari
     t.end();
 });
 
+test('reconcileVariableReferences creates a stage list for an undefined list reference', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(adapter(events.mockListBlock)[0]);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(target.blocks.getBlock('another block').fields.LIST.id, 'mock list id');
+    t.equal(target.blocks.getBlock('another block').fields.LIST.value, 'a mock list');
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'list created on stage');
+    const newList = stage.variables['mock list id'];
+    t.ok(newList, 'list preserves the original id');
+    t.equal(newList.name, 'a mock list');
+    t.equal(newList.type, Variable.LIST_TYPE);
+    t.equal(target.blocks.getBlock('another block').fields.LIST.id, 'mock list id');
+
+    t.end();
+});
+
+test('reconcileVariableReferences remaps a list reference to an existing same-name stage list', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('pre-existing list id', 'a mock list', Variable.LIST_TYPE);
+    target.blocks.createBlock(adapter(events.mockListBlock)[0]);
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 1, 'no duplicate list created');
+    t.ok(stage.variables['pre-existing list id'], 'existing list preserved');
+    t.equal(target.blocks.getBlock('another block').fields.LIST.id, 'pre-existing list id',
+        'block field id remapped to existing list');
+
+    t.end();
+});
+
 test('reconcileVariableReferences creates a stage broadcast for an undefined broadcast reference', t => {
     const runtime = new Runtime();
 

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -1128,6 +1128,89 @@ test('installTargets creates a stage broadcast for a sprite import that referenc
     });
 });
 
+test('installTargets repairs dangling variable references on whole-project load', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const stageSprite = new Sprite(null, runtime);
+    const stage = stageSprite.createClone();
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const spriteSprite = new Sprite(null, runtime);
+    const sprite = spriteSprite.createClone();
+    sprite.isStage = false;
+    sprite.getName = () => 'Sprite';
+    // Block with a variable field referencing an id that's not defined anywhere — the
+    // shape produced when a project saved during the missing-definitions bug is loaded.
+    sprite.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+    adapter(events.mockBroadcastBlock).forEach(block => sprite.blocks.createBlock(block));
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(Object.keys(sprite.variables).length, 0);
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, sprite], extensions, true).then(() => {
+        t.equal(Object.keys(stage.variables).length, 2, 'variable and broadcast created on stage');
+        t.ok(stage.variables['mock var id'], 'dangling variable reference reconciled');
+        t.ok(stage.variables['mock broadcast message id'], 'dangling broadcast reference reconciled');
+        t.equal(Object.keys(sprite.variables).length, 0, 'no spurious sprite-local variables');
+
+        t.end();
+    });
+});
+
+test('installTargets does NOT rename clean local-vs-global name collisions on whole-project load', t => {
+    // Regression guard: a project saved with a sprite-local variable that name-collides with
+    // a stage global must load unchanged. The fixUpVariableReferences rename behavior is
+    // for sprite import; project load uses the repair-only helper.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const stageSprite = new Sprite(null, runtime);
+    const stage = stageSprite.createClone();
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+    stage.createVariable('global score id', 'score', Variable.SCALAR_TYPE);
+
+    const spriteSprite = new Sprite(null, runtime);
+    const sprite = spriteSprite.createClone();
+    sprite.isStage = false;
+    sprite.getName = () => 'Sprite';
+    sprite.createVariable('local score id', 'score', Variable.SCALAR_TYPE);
+    // Block referencing the sprite-local variable with the same name as the global.
+    sprite.blocks.createBlock({
+        id: 'a block',
+        opcode: 'data_variable',
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: 'local score id',
+                value: 'score',
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, sprite], extensions, true).then(() => {
+        t.equal(sprite.variables['local score id'].name, 'score',
+            'sprite local variable name unchanged after whole-project load');
+        t.equal(sprite.blocks.getBlock('a block').fields.VARIABLE.id, 'local score id',
+            'block field id unchanged');
+        t.equal(Object.keys(stage.variables).length, 1, 'no new stage variables created');
+
+        t.end();
+    });
+});
+
 test('Setting turbo mode emits events', t => {
     let turboMode = null;
 


### PR DESCRIPTION
### Resolves

Companion to scratchfoundation/scratch-editor#554. That PR stops new occurrences of the missing-definitions bug (backpack paste / sprite import leaving variable, list, or broadcast references that point at ids not defined anywhere in the project). This PR repairs already-corrupted projects on next load, so a Scratcher whose project hit the bug between the unfork release and #554's deploy gets a clean workspace the next time they open it.

### Proposed Changes

`Target` gets a new public method `reconcileVariableReferences` that runs only the missing-definitions phase of `fixUpVariableReferences`: walk every variable, list, and broadcast reference; for each id not found anywhere, look up by name and type on the stage and either remap the field id to an existing global or create a fresh one. When two dangling references in the same target share an original name+type and the name has to be bumped, they coalesce to one stage variable rather than producing two with similar names. When a previous target's pass on the same load created a stage variable with a bumped name, later targets referencing the same id by lookup have their displayed names normalized to match.

`fixUpVariableReferences` now delegates the repair phase to the new helper, keeping its disambiguation phases (rename sprite-local that name-collides with a stage global, rename unreferenced colliding locals) for the sprite-import and backpack-paste callers.

`VirtualMachine.installTargets` now calls `reconcileVariableReferences` on every target during whole-project load (`wholeProject=true`). Idempotent on clean projects; self-heals corrupted ones on next open.

A `log.warn` fires whenever reconciliation modifies project state: when it creates a definition on the stage, remaps a reference to an existing global, coalesces two same-name dangling references, or normalizes a stale displayed name on a block field. Quiet on clean loads. Useful for surfacing the repair in dev tools and telemetry.

### Reason for Changes

The repair-only path matters because running the full `fixUpVariableReferences` on every loaded sprite would also rename any sprite-local variable whose name and type match a stage global. That configuration has been a valid Scratch setup since forever; renaming such variables on project load would be a far worse regression than the bug we're fixing. Splitting the function lets the load path stay conservative while keeping the import path's disambiguation behavior intact.

A reference whose id is missing but whose name+type matches an unrelated stage variable will be remapped to that stage variable rather than create a new one. Same trade-off as sprite import: we can't tell from the saved field whether the original was meant to be a different variable. Flagging this as a known corner case rather than working around it.

### Test Coverage

- `packages/scratch-vm/test/unit/engine_target.js`: new Tap tests covering the reconciliation cases for variables, lists, and broadcasts (creation, same-name remap, idempotency); the critical regression that local-vs-global name collisions are NOT renamed; the stage-as-`this` case; cross-target displayed-name normalization after a bump; same-original-name coalescing within a target; and `log.warn` assertions (fires on create, fires on remap, silent on clean references).
- `packages/scratch-vm/test/unit/virtual-machine.js`: new Tap tests for the `installTargets` wiring on whole-project loads. One covers repair of dangling variable + broadcast references; one is a regression guard that legitimate local-vs-global name collisions survive a whole-project load unchanged.
- `npm test --workspace=packages/scratch-vm` passes (3761 / 3761).
- `npm run build` and `npm test` from the repo root pass on every workspace.