### PR TITLE
fix(vm): silence reconcile log on sprite-import / backpack-paste

### DIFF
--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -670,8 +670,19 @@ class Target extends EventEmitter {
      * Used during whole-project load to repair projects corrupted by historical
      * bugs that left dangling references, and as the definition-creation phase
      * of `fixUpVariableReferences` for sprite import and backpack paste.
+     *
+     * @param {object} [options]
+     * @param {boolean} [options.logRepairs=false] When true, emit a `log.warn`
+     * for each repair the helper performs: creating a missing stage definition,
+     * remapping a dangling reference to an existing global, normalizing a stale
+     * displayed name, or coalescing same-original-name dangling references onto
+     * one repaired definition. Reserved for the load-time-repair entry point,
+     * where reconciliation indicates project corruption worth surfacing. Off by
+     * default so that sprite import and backpack paste — both of which
+     * legitimately create stage definitions — stay quiet.
      */
-    reconcileVariableReferences () {
+    reconcileVariableReferences (options) {
+        const {logRepairs = false} = options || {};
         if (!this.runtime) return;
         const stage = this.runtime.getTargetForStage();
         if (!stage || !stage.variables) return;
@@ -713,11 +724,13 @@ class Target extends EventEmitter {
                     );
                     if (staleRef) {
                         conflictNamesToReplace[varId] = existing.name;
-                        log.warn(
-                            `Reconciled stale displayed name on '${this.getName()}': updated to ` +
-                            `'${existing.name}' for id '${varId}' ` +
-                            `(was '${staleRef.referencingField.value}').`
-                        );
+                        if (logRepairs) {
+                            log.warn(
+                                `Reconciled stale displayed name on '${this.getName()}': updated to ` +
+                                `'${existing.name}' for id '${varId}' ` +
+                                `(was '${staleRef.referencingField.value}').`
+                            );
+                        }
                     }
                 }
                 continue;
@@ -733,10 +746,12 @@ class Target extends EventEmitter {
             if (existingVar) {
                 if (!conflictIdsToReplace[varId]) {
                     conflictIdsToReplace[varId] = existingVar.id;
-                    log.warn(
-                        `Reconciled dangling reference on '${this.getName()}': remapped id '${varId}' ` +
-                        `(name '${varName}', type '${varType}') to existing stage variable '${existingVar.id}'.`
-                    );
+                    if (logRepairs) {
+                        log.warn(
+                            `Reconciled dangling reference on '${this.getName()}': remapped id '${varId}' ` +
+                            `(name '${varName}', type '${varType}') to existing stage variable '${existingVar.id}'.`
+                        );
+                    }
                 }
             } else {
                 const coalesceKey = originalNameKey(varName, varType);
@@ -749,11 +764,13 @@ class Target extends EventEmitter {
                     if (!conflictIdsToReplace[varId]) {
                         conflictIdsToReplace[varId] = earlierCreated.id;
                         conflictNamesToReplace[varId] = earlierCreated.freshName;
-                        log.warn(
-                            `Reconciled dangling reference on '${this.getName()}': coalesced id '${varId}' ` +
-                            `(name '${varName}', type '${varType}') with earlier-created stage variable ` +
-                            `'${earlierCreated.id}' (name '${earlierCreated.freshName}').`
-                        );
+                        if (logRepairs) {
+                            log.warn(
+                                `Reconciled dangling reference on '${this.getName()}': coalesced id '${varId}' ` +
+                                `(name '${varName}', type '${varType}') with earlier-created stage variable ` +
+                                `'${earlierCreated.id}' (name '${earlierCreated.freshName}').`
+                            );
+                        }
                     }
                 } else {
                     const allNames = allVarNames(varType);
@@ -766,10 +783,12 @@ class Target extends EventEmitter {
                     createdForOriginalName[coalesceKey] = {id: varId, freshName};
                     if (!conflictNamesToReplace[varId]) {
                         conflictNamesToReplace[varId] = freshName;
-                        log.warn(
-                            `Reconciled dangling reference on '${this.getName()}': created stage variable ` +
-                            `'${varId}' (name '${freshName}', type '${varType}').`
-                        );
+                        if (logRepairs) {
+                            log.warn(
+                                `Reconciled dangling reference on '${this.getName()}': created stage variable ` +
+                                `'${varId}' (name '${freshName}', type '${varType}').`
+                            );
+                        }
                     }
                 }
             }

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -564,8 +564,9 @@ class VirtualMachine extends EventEmitter {
                 // A loaded project may carry dangling variable, list, or broadcast
                 // references baked in by historical bugs. Reconcile each target so
                 // those references resolve cleanly without renaming any legitimate
-                // local-vs-global name collisions.
-                targets.forEach(target => target.reconcileVariableReferences());
+                // local-vs-global name collisions. Logging is on here because a
+                // dangling reference at load time signals project corruption.
+                targets.forEach(target => target.reconcileVariableReferences({logRepairs: true}));
             } else {
                 this.editingTarget.fixUpVariableReferences();
             }

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1199,7 +1199,7 @@ const captureLogWarn = (fn) => {
     return messages;
 };
 
-test('reconcileVariableReferences emits log.warn when it creates a stage definition', t => {
+test('reconcileVariableReferences with {logRepairs: true} emits log.warn on creation', t => {
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -1213,7 +1213,7 @@ test('reconcileVariableReferences emits log.warn when it creates a stage definit
 
     addBroadcastBlocksTo(target);
 
-    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+    const messages = captureLogWarn(() => target.reconcileVariableReferences({logRepairs: true}));
 
     t.equal(messages.length, 1, 'one log.warn fired');
     t.match(messages[0], /Reconciled.*'Target'.*created.*'mock broadcast message id'/,
@@ -1222,7 +1222,7 @@ test('reconcileVariableReferences emits log.warn when it creates a stage definit
     t.end();
 });
 
-test('reconcileVariableReferences emits log.warn when it remaps a reference', t => {
+test('reconcileVariableReferences with {logRepairs: true} emits log.warn on remap', t => {
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -1237,7 +1237,7 @@ test('reconcileVariableReferences emits log.warn when it remaps a reference', t 
     stage.createVariable('pre-existing global var id', 'a mock variable', Variable.SCALAR_TYPE);
     target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
 
-    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+    const messages = captureLogWarn(() => target.reconcileVariableReferences({logRepairs: true}));
 
     t.equal(messages.length, 1, 'one log.warn fired');
     t.match(messages[0], /Reconciled.*remapped.*'mock var id'.*'pre-existing global var id'/,
@@ -1416,6 +1416,77 @@ test('reconcileVariableReferences does not log on clean references', t => {
     const messages = captureLogWarn(() => target.reconcileVariableReferences());
 
     t.equal(messages.length, 0, 'no log.warn fired on a clean reference');
+
+    t.end();
+});
+
+test('reconcileVariableReferences tolerates null options without throwing', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    t.doesNotThrow(() => target.reconcileVariableReferences(null),
+        'destructuring is null-safe for the public API contract');
+    t.ok(stage.variables['mock broadcast message id'], 'broadcast still created on stage');
+
+    t.end();
+});
+
+test('reconcileVariableReferences without {logRepairs} is silent even when it repairs', t => {
+    // Sprite import / backpack paste calls reconcile via fixUpVariableReferences.
+    // Creating a stage broadcast for a backpacked sprite isn't corruption — it's
+    // the normal cross-project reference reconciliation. Default logging is off
+    // so the warning is reserved for the load-time-repair entry point.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    const messages = captureLogWarn(() => target.reconcileVariableReferences());
+
+    t.equal(messages.length, 0, 'no log.warn fired without {logRepairs}');
+    t.ok(stage.variables['mock broadcast message id'], 'broadcast still created on stage');
+
+    t.end();
+});
+
+test('fixUpVariableReferences does not log on sprite-import path', t => {
+    // Regression for the warning firing on every backpack-restore that referenced
+    // a broadcast — the case is normal, not corruption, and shouldn't read as one.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    addBroadcastBlocksTo(target);
+
+    const messages = captureLogWarn(() => target.fixUpVariableReferences());
+
+    t.equal(messages.length, 0, 'no log.warn fired during fixUpVariableReferences');
+    t.ok(stage.variables['mock broadcast message id'], 'broadcast still created on stage');
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -7,6 +7,22 @@ const events = require('../fixtures/events.json');
 const Renderer = require('../fixtures/fake-renderer');
 const Runtime = require('../../src/engine/runtime');
 const RenderedTarget = require('../../src/sprites/rendered-target');
+const log = require('../../src/util/log');
+
+const captureLogWarn = fn => {
+    const original = log.warn;
+    const messages = [];
+    log.warn = (...args) => messages.push(args.join(' '));
+    return Promise.resolve()
+        .then(fn)
+        .then(result => {
+            log.warn = original;
+            return {messages, result};
+        }, err => {
+            log.warn = original;
+            throw err;
+        });
+};
 
 const test = tap.test;
 
@@ -1209,6 +1225,56 @@ test('installTargets does NOT rename clean local-vs-global name collisions on wh
 
         t.end();
     });
+});
+
+test('installTargets does not log on sprite import that creates a stage broadcast', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const stageSprite = new Sprite(null, runtime);
+    const stage = stageSprite.createClone();
+    stage.isStage = true;
+    runtime.targets = [stage];
+
+    const importedSprite = new Sprite(null, runtime);
+    const importedTarget = importedSprite.createClone();
+    importedTarget.isStage = false;
+    importedTarget.getName = () => 'Imported';
+    adapter(events.mockBroadcastBlock).forEach(block => importedTarget.blocks.createBlock(block));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    captureLogWarn(() => vm.installTargets([importedTarget], extensions, false))
+        .then(({messages}) => {
+            t.ok(stage.variables['mock broadcast message id'],
+                'broadcast still created on stage during import');
+            t.equal(messages.length, 0, 'no log.warn fired on sprite import');
+            t.end();
+        });
+});
+
+test('installTargets logs on whole-project repair', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const stageSprite = new Sprite(null, runtime);
+    const stage = stageSprite.createClone();
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const spriteSprite = new Sprite(null, runtime);
+    const sprite = spriteSprite.createClone();
+    sprite.isStage = false;
+    sprite.getName = () => 'Sprite';
+    sprite.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    captureLogWarn(() => vm.installTargets([stage, sprite], extensions, true))
+        .then(({messages}) => {
+            t.ok(stage.variables['mock var id'], 'dangling variable reconciled');
+            t.equal(messages.length, 1, 'one log.warn fired during whole-project repair');
+            t.match(messages[0], /Reconciled.*'Sprite'.*created.*'mock var id'/);
+            t.end();
+        });
 });
 
 test('Setting turbo mode emits events', t => {


### PR DESCRIPTION
## Resolves

Follow-up to #555: the load-time-repair helper's `log.warn` was firing on every sprite-import / backpack-paste that referenced a broadcast not defined in the destination project. The text reads as a corruption alert (\"Reconciled dangling reference\") but the case is mundane — broadcasts live on the stage and naturally aren't carried with a backpacked sprite, so reconcile must create one in the new project's stage.

Confirmed via Playwright on scratch.ly:
- Drag sprite-with-broadcast into backpack
- New project, drag sprite back from backpack
- Console shows: ``Reconciled dangling reference on 'Sprite2': created stage variable 'S9YSR/)K(PHVjM-/xQTU' (name 'awefawef', type 'broadcast_msg').``

## Proposed Changes

- `Target.reconcileVariableReferences` accepts a `{logRepairs}` option (default `false`). All four `log.warn` call sites are gated on the option.
- `VirtualMachine.installTargets` passes `{logRepairs: true}` only on the whole-project branch — where a dangling reference signals corruption from the missing-definitions bug.
- Internal `Target.fixUpVariableReferences` (used for sprite import + backpack paste) calls `reconcileVariableReferences()` without options, so it stays silent.

## Reason for Changes

`fixUpVariableReferences` calls `reconcileVariableReferences` as its missing-definitions phase, so once #555 added logging there, every sprite-import path inherited the log. The warning's wording and severity are correct for project-load repair — those projects really are corrupted — but wrong for backpack-paste, which is normal cross-target reference reconciliation.

The fix keeps all logging in exactly one entry point (`installTargets` whole-project) and leaves the sprite-import path silent, matching pre-#555 behavior on that path.

## Test Coverage

- New: `reconcileVariableReferences without {logRepairs} is silent even when it repairs`
- New: `fixUpVariableReferences does not log on sprite-import path`
- New: `installTargets does not log on sprite import that creates a stage broadcast`
- New: `installTargets logs on whole-project repair`
- Updated existing reconcile log assertions to pass `{logRepairs: true}` so they continue to assert the documented behavior of the load-repair entry point.
- Full scratch-vm tap suite: 3770/3770.

## Related

- Depends on (and is layered atop) #555.
- Spork tracker: #533.