### PR TITLE
Add greater & less than or equal to blocks

### DIFF
--- a/packages/scratch-gui/src/lib/make-toolbox-xml.js
+++ b/packages/scratch-gui/src/lib/make-toolbox-xml.js
@@ -635,7 +635,31 @@ const operators = function (isInitialSetup, isStage, targetId, colors) {
                 </shadow>
             </value>
         </block>
+        <block type="operator_gtoet">
+           <value name="OPERAND1">
+             <shadow type="text">
+                 <field name="TEXT"/>
+              </shadow>
+          </value>
+           <value name="OPERAND2">
+               <shadow type="text">
+                   <field name="TEXT">50</field>
+              </shadow>
+          </value>
+        </block>
         <block type="operator_lt">
+            <value name="OPERAND1">
+                <shadow type="text">
+                    <field name="TEXT"/>
+                </shadow>
+            </value>
+            <value name="OPERAND2">
+                <shadow type="text">
+                    <field name="TEXT">50</field>
+                </shadow>
+            </value>
+        </block>
+        <block type="operator_ltoet">
             <value name="OPERAND1">
                 <shadow type="text">
                     <field name="TEXT"/>

--- a/packages/scratch-vm/src/blocks/scratch3_operators.js
+++ b/packages/scratch-vm/src/blocks/scratch3_operators.js
@@ -21,8 +21,10 @@ class Scratch3OperatorsBlocks {
             operator_multiply: this.multiply,
             operator_divide: this.divide,
             operator_lt: this.lt,
+            operator_ltoet: this.ltoet,
             operator_equals: this.equals,
             operator_gt: this.gt,
+            operator_gtoet: this.gtoet,
             operator_and: this.and,
             operator_or: this.or,
             operator_not: this.not,
@@ -57,12 +59,20 @@ class Scratch3OperatorsBlocks {
         return Cast.compare(args.OPERAND1, args.OPERAND2) < 0;
     }
 
+    ltoet (args) {
+        return Cast.compare(args.OPERAND1, args.OPERAND2) <= 0;
+    }
+
     equals (args) {
         return Cast.compare(args.OPERAND1, args.OPERAND2) === 0;
     }
 
     gt (args) {
         return Cast.compare(args.OPERAND1, args.OPERAND2) > 0;
+    }
+
+    gtoet (args) {
+        return Cast.compare(args.OPERAND1, args.OPERAND2) >= 0;
     }
 
     and (args) {


### PR DESCRIPTION
### Resolves

Also see: https://github.com/scratchfoundation/scratch-blocks/pull/3579

https://scratch.mit.edu/discuss/topic/21165/

### Proposed Changes

Scratchers for years when wanting to use greater/less than or equal to blocks:

<(var) = (50) and (var) > (50)>

See below for why.
### Reason for Changes

Adding an operator block for it should help reduce this pain, it's a pain when you have to add this combo to a lot of things. A block should also make it simpler for a younger demographic.

### Test Coverage

If someone can test locally for me, that'd be appreciated.