### PR TITLE
[UEPR-580] Fix remix button not working on accessibility branch

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/file-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/file-menu.jsx
@@ -16,7 +16,6 @@ import sharedMessages from '../../lib/shared-messages';
 
 import {
     manualUpdateProject,
-    remixProject,
     saveProjectAsCopy
 } from '../../reducers/project-state';
 
@@ -190,7 +189,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    onClickRemix: () => dispatch(remixProject()),
     onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy())
 });

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -42,7 +42,8 @@ import {
     autoUpdateProject,
     getIsUpdating,
     getIsShowingProject,
-    requestNewProject
+    requestNewProject,
+    remixProject
 } from '../../reducers/project-state';
 import {
     openLoginMenu,
@@ -774,6 +775,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     onOpenDebugModal: () => dispatch(openDebugModal()),
     onClickNew: needSave => dispatch(requestNewProject(needSave)),
     onClickLogin: ownProps.onClickLogin ?? (() => dispatch(openLoginMenu())),
+    onClickRemix: () => dispatch(remixProject()),
     onRequestCloseLogin: () => dispatch(closeLoginMenu()),
     onSeeCommunity: ownProps.onSeeCommunity ?? (() => dispatch(setPlayer(true))),
     onSetTimeTravelMode: mode => dispatch(setTimeTravel(mode))


### PR DESCRIPTION
### Resolves

[UEPR-580](https://scratchfoundation.atlassian.net/browse/UEPR-580)

### Proposed Changes

Pass the `onClickRemix` method through the dispatch props in the menubar component, rather than in its child component FileMenu, because it's used in both components

### Reason for Changes

Fix issue with Remix button not doing anything on click

[UEPR-580]: https://scratchfoundation.atlassian.net/browse/UEPR-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ