### PR TITLE
[UEPR-577] Fix Save Now button not focusable

### DIFF
--- a/packages/scratch-gui/src/components/alerts/inline-message.jsx
+++ b/packages/scratch-gui/src/components/alerts/inline-message.jsx
@@ -10,10 +10,11 @@ import styles from './inline-message.css';
 const InlineMessageComponent = ({
     content,
     iconSpinner,
-    level
+    level,
+    className
 }) => (
     <div
-        className={classNames(styles.inlineMessage, styles[level])}
+        className={classNames(styles.inlineMessage, styles[level], className)}
         aria-label="inline message"
     >
         {/* TODO: implement Rtl handling */}
@@ -29,6 +30,7 @@ const InlineMessageComponent = ({
 );
 
 InlineMessageComponent.propTypes = {
+    className: PropTypes.string,
     content: PropTypes.element,
     iconSpinner: PropTypes.bool,
     level: PropTypes.string

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -492,7 +492,7 @@ class MenuBar extends React.Component {
                 <div className={styles.accountInfoGroup}>
                     <div className={styles.menuBarItem}>
                         {this.props.canSave && (
-                            <SaveStatus />
+                            <SaveStatus className={classNames(styles.hoverable, styles.menuBarItem)} />
                         )}
                     </div>
 

--- a/packages/scratch-gui/src/components/menu-bar/save-status.css
+++ b/packages/scratch-gui/src/components/menu-bar/save-status.css
@@ -1,6 +1,5 @@
 .save-now {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    cursor: pointer;
 }
 
 .alert {

--- a/packages/scratch-gui/src/components/menu-bar/save-status.css
+++ b/packages/scratch-gui/src/components/menu-bar/save-status.css
@@ -2,3 +2,7 @@
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     cursor: pointer;
 }
+
+.alert {
+    cursor: default;
+}

--- a/packages/scratch-gui/src/components/menu-bar/save-status.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/save-status.jsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+
 import {connect} from 'react-redux';
 import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
@@ -23,13 +25,14 @@ import styles from './save-status.css';
 const SaveStatus = ({
     alertsList,
     projectChanged,
-    onClickSave
+    onClickSave,
+    className
 }) => (
     filterInlineAlerts(alertsList).length > 0 ? (
-        <InlineMessages />
+        <InlineMessages className={styles.alert} />
     ) : projectChanged && (
-        <div
-            className={styles.saveNow}
+        <button
+            className={classNames(styles.saveNow, className)}
             onClick={onClickSave}
         >
             <FormattedMessage
@@ -37,10 +40,11 @@ const SaveStatus = ({
                 description="Title bar link for saving now"
                 id="gui.menuBar.saveNowLink"
             />
-        </div>
+        </button>
     ));
 
 SaveStatus.propTypes = {
+    className: PropTypes.string,
     alertsList: PropTypes.arrayOf(PropTypes.object),
     onClickSave: PropTypes.func,
     projectChanged: PropTypes.bool


### PR DESCRIPTION
### Resolves

[UEPR-577](https://scratchfoundation.atlassian.net/browse/UEPR-577)

### Proposed Changes

- Make Save Now button an actual button
- Apply consistent styling with the other menu buttons (changes background on hover)
- Fix issue with `Project Saved.` alert having `cursor: pointer` (due to it being inherited from `menu-item`, where it was recently added)

### Reason for Changes

- Fix issue with Save Now button not focusable on accessibility branch

[UEPR-577]: https://scratchfoundation.atlassian.net/browse/UEPR-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ