### PR TITLE
[UEPR-583] Fix Ctrl + S not saving the project

### DIFF
--- a/packages/scratch-gui/src/components/menu-bar/file-menu.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/file-menu.jsx
@@ -14,10 +14,7 @@ import useMenuNavigation from '../../hooks/use-menu-navigation';
 
 import sharedMessages from '../../lib/shared-messages';
 
-import {
-    manualUpdateProject,
-    saveProjectAsCopy
-} from '../../reducers/project-state';
+import {saveProjectAsCopy} from '../../reducers/project-state';
 
 const fileMenu = defineMessage({
     id: 'gui.aria.fileMenu',
@@ -189,7 +186,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    onClickSave: () => dispatch(manualUpdateProject()),
     onClickSaveAsCopy: () => dispatch(saveProjectAsCopy())
 });
 

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -43,6 +43,7 @@ import {
     getIsUpdating,
     getIsShowingProject,
     requestNewProject,
+    manualUpdateProject,
     remixProject
 } from '../../reducers/project-state';
 import {
@@ -355,7 +356,6 @@ class MenuBar extends React.Component {
                             onClickNew={this.handleClickNew}
                             onClickRemix={this.props.onClickRemix}
                             onClickSave={this.props.onClickSave}
-                            onClickSaveAsCopy={this.props.onClickSaveAsCopy}
                             getSaveToComputerHandler={this.getSaveToComputerHandler}
                             canSave={this.props.canSave}
                             canCreateCopy={this.props.canCreateCopy}
@@ -775,6 +775,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     onOpenDebugModal: () => dispatch(openDebugModal()),
     onClickNew: needSave => dispatch(requestNewProject(needSave)),
     onClickLogin: ownProps.onClickLogin ?? (() => dispatch(openLoginMenu())),
+    onClickSave: () => dispatch(manualUpdateProject()),
     onClickRemix: () => dispatch(remixProject()),
     onRequestCloseLogin: () => dispatch(closeLoginMenu()),
     onSeeCommunity: ownProps.onSeeCommunity ?? (() => dispatch(setPlayer(true))),


### PR DESCRIPTION
### Resolves

[UEPR-583](https://scratchfoundation.atlassian.net/browse/UEPR-583)

### Proposed Changes

Move the `onClickSave` function to the parent `MenuBar` component, instead of the child `FileMenu`, as it is used in both

### Reason for Changes

Clicking Ctrl + S triggers page save, instead of saving the project

[UEPR-583]: https://scratchfoundation.atlassian.net/browse/UEPR-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ