### PR TITLE
[UEPR-582] Fix menus and modals not allowing keyboard events to propagate to blocks

### DIFF
--- a/packages/scratch-gui/src/components/action-menu/action-menu.jsx
+++ b/packages/scratch-gui/src/components/action-menu/action-menu.jsx
@@ -88,9 +88,11 @@ const ActionMenu = ({
             }
         };
 
-        document.addEventListener('mousedown', handleTouchOutside);
+        // The Blockly workspace suppresses mousedown/click events,
+        // so listen for pointerup instead.
+        document.addEventListener('pointerup', handleTouchOutside);
         return () => {
-            document.removeEventListener('mousedown', handleTouchOutside);
+            document.removeEventListener('pointerup', handleTouchOutside);
         };
     }, [containerRef, setIsExpanded]);
 
@@ -132,7 +134,14 @@ const ActionMenu = ({
             setIsExpanded(false);
             focusItem(buttonRef.current);
         } else if (e.key === KEY.ESCAPE) {
-            focusItem(buttonRef.current);
+            if (document.activeElement === buttonRef.current) {
+                // If focus is on the main button, close the menu and keep focus on the button
+                setIsExpanded(false);
+                document.activeElement.blur();
+            } else {
+                // Otherwise, move focus back to the main button
+                focusItem(buttonRef.current);
+            }
         }
     }, [handleMove, isExpanded, setIsExpanded]);
 

--- a/packages/scratch-gui/src/components/confirmation-prompt/confirmation-prompt.jsx
+++ b/packages/scratch-gui/src/components/confirmation-prompt/confirmation-prompt.jsx
@@ -95,10 +95,18 @@ const ConfirmationPrompt = ({
 
     const handleCancel = React.useCallback(() => {
         cancelButtonConfig.onClick();
+        // Ensure focus is removed from the button so that keyboard events are propagated to the blocks
+        requestAnimationFrame(() => {
+            document.activeElement.blur();
+        });
     }, [cancelButtonConfig]);
 
     const handleConfirm = React.useCallback(() => {
         confirmButtonConfig.onClick();
+        // Ensure focus is removed from the button so that keyboard events are propagated to the blocks
+        requestAnimationFrame(() => {
+            document.activeElement.blur();
+        });
     }, [confirmButtonConfig]);
 
     const cancelButton = (

--- a/packages/scratch-gui/src/contexts/menu-ref-context.jsx
+++ b/packages/scratch-gui/src/contexts/menu-ref-context.jsx
@@ -68,6 +68,9 @@ export const MenuRefProvider = ({children}) => {
     const isInnermostMenu = useCallback(ref => refStack.length > 0 &&
         refStack[refStack.length - 1] === ref, [refStack]);
 
+    const isOutermostMenu = useCallback(ref => refStack.length > 0 &&
+        refStack[0] === ref, [refStack]);
+
     const isOpenMenu = useCallback(ref => refStack.includes(ref), [refStack]);
 
     const value = useMemo(() => ({
@@ -77,6 +80,7 @@ export const MenuRefProvider = ({children}) => {
         closeMenuByRef,
         closeAllMenus,
         isInnermostMenu,
+        isOutermostMenu,
         isOpenMenu,
         outermostMenu
     }), [
@@ -86,6 +90,7 @@ export const MenuRefProvider = ({children}) => {
         closeMenuByRef,
         closeAllMenus,
         isInnermostMenu,
+        isOutermostMenu,
         isOpenMenu,
         outermostMenu
     ]);

--- a/packages/scratch-gui/src/hooks/use-menu-navigation.js
+++ b/packages/scratch-gui/src/hooks/use-menu-navigation.js
@@ -174,6 +174,14 @@ export default function useMenuNavigation ({
             handleMove(-1);
             break;
         case KEY.ESCAPE:
+            e.preventDefault();
+            e.stopPropagation();
+            handleOnClose();
+            if (menuContext.isOutermostMenu(menuRef)) {
+                // If it's the outermost menu, also blur the trigger to remove focus
+                menuRef?.current?.blur();
+            }
+            break;
         case CLOSE_KEY:
             e.preventDefault();
             e.stopPropagation();
@@ -200,6 +208,11 @@ export default function useMenuNavigation ({
     }, [handleMove, handleOnClose, handleOnCloseAllMenus]);
 
     const handleKeyDown = useCallback(e => {
+        if (!isExpanded() && e.key === KEY.ESCAPE) {
+            // If the menu is closed and Escape is pressed, blur the menu trigger to remove focus
+            menuRef?.current?.blur();
+            return;
+        }
         if (isExpanded() && e.key === KEY.TAB) {
             handleOnCloseAllMenus();
             return;

--- a/packages/scratch-gui/test/unit/hooks/use-menu-navigation.test.jsx
+++ b/packages/scratch-gui/test/unit/hooks/use-menu-navigation.test.jsx
@@ -28,7 +28,8 @@ describe('useMenuNavigation', () => {
             closeMenuByRef: jest.fn(),
             closeAllMenus: jest.fn(),
             outermostMenu: {current: document.body},
-            isInnermostMenu: jest.fn(() => false)
+            isInnermostMenu: jest.fn(() => false),
+            isOutermostMenu: jest.fn(() => false)
         };
         menuRef = {current: document.createElement('div')};
         document.body.appendChild(menuRef.current);


### PR DESCRIPTION
### Resolves

[UEPR-582](https://scratchfoundation.atlassian.net/browse/UEPR-582)

### Proposed Changes

- Blur when closing confirmation modals
- Blur when closing navbar menus with `ESC`
- Blur when focused on the main active menu button and `ESC` is pressed
- Fix small issue with clicking on the blockly workspace not closing the action menu

### Reason for Changes

- Menus and modals should not interfere with keyboard events and should allow them to propagate to the blocks

[UEPR-582]: https://scratchfoundation.atlassian.net/browse/UEPR-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ