### PR TITLE
[UEPR-579] Additional unnecessary element is focused in choose a sprite modal

### DIFF
--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -381,6 +381,7 @@ class LibraryComponent extends React.Component {
                         [styles.withFilterBar]: this.props.filterable || this.props.tags
                     })}
                     ref={this.setFilteredDataRef}
+                    tabIndex={-1}
                 >
                     {this.state.loaded ? this.renderData(this.getFilteredData()) : (
                         <div className={styles.spinnerWrapper}>


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-579

### Proposed Changes

Explicitly sets tabIndex to -1, so that it is unfocusable by tab.

### Reason for Changes

Part of accessibility initiative.
