### PR TITLE
ci: collapse same-dep Renovate bumps in release notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@commitlint/config-conventional": "17.8.1",
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
+        "conventional-changelog-angular": "8.3.1",
         "cross-env": "7.0.3",
         "globals": "16.5.0",
         "husky": "8.0.3",
@@ -2121,6 +2122,19 @@
       },
       "engines": {
         "node": ">=v14"
+      }
+    },
+    "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@commitlint/read": {
@@ -5415,19 +5429,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
@@ -8121,19 +8122,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
@@ -13968,14 +13956,16 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@commitlint/config-conventional": "17.8.1",
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
+    "conventional-changelog-angular": "8.3.1",
     "cross-env": "7.0.3",
     "globals": "16.5.0",
     "husky": "8.0.3",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -6,7 +6,9 @@
 // No @semantic-release/github: the GitHub release is created by the finalize
 // job, using the commit body as the release notes.
 
-module.exports = {
+import {commitPartial, commitsSort, finalizeContext} from './scripts/release-notes-writer-opts.mjs';
+
+export default {
     branches: [
         'develop',
         '+([0-9])?(.{+([0-9]),x}).x',
@@ -15,7 +17,7 @@ module.exports = {
     ],
     plugins: [
         '@semantic-release/commit-analyzer',
-        '@semantic-release/release-notes-generator',
+        ['@semantic-release/release-notes-generator', { writerOpts: {commitPartial, commitsSort, finalizeContext} }],
         [
             '@semantic-release/exec',
             {

--- a/scripts/release-notes-writer-opts.mjs
+++ b/scripts/release-notes-writer-opts.mjs
@@ -1,0 +1,113 @@
+// Custom writerOpts for @semantic-release/release-notes-generator.
+//
+// commitsSort orders each commit group newest-first by committerDate, so the
+// collapser logic can rely on entries[0] being the most recent commit.
+//
+// finalizeContext walks each commit group and, for any dependency that has
+// 2+ Renovate "update dependency NAME to vVERSION" commits in this release,
+// collapses them onto the most recent entry. Every commit's shortHash lands
+// in the kept subject as a comma-separated list of markdown links (newest
+// first), and any PR references that the angular preset substituted into
+// the dropped subjects ("[#NNN](url)") get pulled back into the kept entry's
+// references so the angular template renders them in its trailing
+// "closes ..." list. Collapsed entries also set skipAutoLink so the
+// (overridden) commitPartial below skips its own commit-link rendering for
+// that entry; lone entries leave skipAutoLink unset and the template
+// renders their SHA exactly as the angular preset would.
+//
+// Renovate group PRs (subjects naming several deps in one commit) don't
+// match the singular-NAME regex and pass through unchanged.
+
+import createAngularPreset from 'conventional-changelog-angular';
+
+// Trailing .* tolerates anything GitHub or Renovate appends after the
+// version (e.g. " (#538)" from a squash-merge, " ([#538](url))" after
+// angular's transform converts it, or future markers).
+const DEP_SUBJECT_RE = /^update dependency (\S+) to v?(\S+).*$/;
+
+// Matches markdown-style PR refs (already substituted by angular's transform)
+// so we can recover them when rebuilding the kept entry's subject.
+const PR_REF_LINK_RE = /\[(#\d+)\]\(([^)]+)\)/g;
+
+// Wrap angular's auto-shortHash block in {{#unless skipAutoLink}}...{{/unless}}
+// so collapsed entries can opt out of the template's commit-link rendering
+// (they embed the full SHA list in the subject instead). Lone entries leave
+// skipAutoLink unset and the template renders their SHA as before. The block
+// sits between the "commit link" and "commit references" comments in the
+// upstream template; if those markers ever move, this throws at module load
+// so the regression is loud rather than silent.
+const COMMIT_LINK_BLOCK_RE = /(\{\{~!-- commit link --\}\}[\s\S]*?)(?=\{\{~!-- commit references --\}\})/;
+const angularCommitPartial = createAngularPreset().writer.commitPartial;
+if (!COMMIT_LINK_BLOCK_RE.test(angularCommitPartial)) {
+    throw new Error('release-notes-writer-opts: could not find the commit-link block in the angular preset\'s commit partial. The upstream template structure may have changed.');
+}
+export const commitPartial = angularCommitPartial.replace(
+    COMMIT_LINK_BLOCK_RE,
+    '{{~#unless skipAutoLink~}}$1{{~/unless~}}'
+);
+
+export function commitsSort(a, b) {
+    return Date.parse(b.committerDate) - Date.parse(a.committerDate);
+}
+
+function buildCommitUrl(context, hash) {
+    const base = context.repository
+        ? [context.host, context.owner, context.repository].filter(Boolean).join('/')
+        : context.repoUrl || '';
+    return `${base}/${context.commit || 'commit'}/${hash}`;
+}
+
+function extractPrRefs(subject) {
+    if (!subject) return [];
+    const refs = [];
+    PR_REF_LINK_RE.lastIndex = 0;
+    let match;
+    while ((match = PR_REF_LINK_RE.exec(subject)) !== null) {
+        const issue = match[1].slice(1); // strip the leading '#'
+        refs.push({raw: match[1], prefix: '#', issue});
+    }
+    return refs;
+}
+
+export function finalizeContext(context) {
+    for (const group of context.commitGroups || []) {
+        const byDep = new Map();
+        for (const entry of group.commits) {
+            const match = entry.subject && entry.subject.match(DEP_SUBJECT_RE);
+            if (!match) continue;
+            const depName = match[1];
+            const depVersion = match[2];
+            const item = {entry, depVersion};
+            if (byDep.has(depName)) {
+                byDep.get(depName).push(item);
+            } else {
+                byDep.set(depName, [item]);
+            }
+        }
+
+        for (const [depName, items] of byDep) {
+            if (items.length < 2) continue;
+            const kept = items[0];
+            const links = items
+                .map(it => `[${it.entry.shortHash}](${buildCommitUrl(context, it.entry.hash)})`)
+                .join(', ');
+            const recoveredRefs = items.flatMap(it => extractPrRefs(it.entry.subject));
+            kept.entry.subject = `update dependency ${depName} to v${kept.depVersion} (${links})`;
+            // Tell the (overridden) commitPartial to skip its auto-shortHash
+            // rendering for this entry; the SHA list above already includes
+            // every commit's link.
+            kept.entry.skipAutoLink = true;
+            const existingRefs = kept.entry.references || [];
+            const seen = new Set();
+            kept.entry.references = existingRefs.concat(recoveredRefs).filter(r => {
+                const key = `${r.prefix || ''}${r.issue}`;
+                if (seen.has(key)) return false;
+                seen.add(key);
+                return true;
+            });
+            const droppedEntries = new Set(items.slice(1).map(it => it.entry));
+            group.commits = group.commits.filter(e => !droppedEntries.has(e));
+        }
+    }
+    return context;
+}


### PR DESCRIPTION
### Resolves

No issue. Internal release-tooling polish. Surfaced while planning #574; deferred to a follow-up to keep that PR scoped.

### Proposed Changes

- Add `scripts/release-notes-writer-opts.js`. Custom writerOpts for `@semantic-release/release-notes-generator`:
  - `commitsSort`: descending by `committerDate`. Globally overrides the angular preset's alphabetical-by-subject sort; every commit group now reads newest-first, matching changelog convention.
  - `finalizeContext`: for each dependency with 2+ Renovate `update dependency NAME to vN` commits in a release, collapses them onto the chronologically-newest entry. The kept subject becomes `update dependency NAME to vNEW ([sha1](url), [sha2](url), ...)` with every commit's short-SHA as a clickable markdown link, newest-first. PR refs the angular preset substituted into the dropped subjects (`[#NNN](url)`) are pulled back into the kept entry's references so the existing template renders them in its trailing `closes …` list.
  - `commitPartial`: angular's `commit.hbs` with its auto-shortHash block wrapped in `{{#unless skipAutoLink}}…{{/unless}}` (loaded from the package and rewritten by regex, not copy-pasted). Collapsed entries set `skipAutoLink` so the template doesn't render the kept SHA a second time; lone entries leave it unset and the template renders their SHA as before.
- Wire the module into `release.config.js` via the array form of the plugin entry. The shallow merge inside `release-notes-generator` preserves the angular preset's other writer options.

**Before / after** (from a real-history dry-run, with seeded scratch-l10n bumps on top of develop):

Before — five separate lines, each with its own auto-rendered commit link:
```
* deps: update dependency scratch-l10n to v6.1.77 ([695442f](...))
* deps: update dependency scratch-l10n to v6.1.76 ([cdc84e3](...))
* deps: update dependency scratch-l10n to v6.1.75 ([4292446](...))
* deps: update dependency scratch-l10n to v6.1.74 ([f1caca9](...))
* deps: update dependency scratch-l10n to v6.1.73 ([#538](...)) ([d70ef73](...))
```

After — one line, every SHA still a clickable markdown link, every PR ref still a clickable markdown link via the existing `closes …` list:
```
* deps: update dependency scratch-l10n to v6.1.77 ([695442f](...), [cdc84e3](...), [4292446](...), [f1caca9](...), [d70ef73](...)), closes [#538](...)
```

**Non-goals / known limits:**

- **Within-group collapse only.** A dep that moves through both a patch (`fix(deps):`) and a minor (`feat(deps):`) in the same release still appears in both groups. Cross-group collapse is doable but out of scope here.
- **Singular-NAME pattern.** Renovate group PRs (subjects naming several deps) don't match and pass through.
- **Trailing `.*$`** in the subject regex tolerates any suffix GitHub or Renovate appends after the version (e.g. `(#NNN)` from squash-merge).
- **Newest-first ordering** is now the global default for every commit group. This is a behavior change beyond the dedup logic itself, called out for review.

### Reason for Changes

When a release picks up several Renovate bumps for the same dependency, the changelog repeats a line per bump. Renovate's `groupName` + `schedule` already keep the steady state tidy; this kicks in when release cadence stretches longer than usual and several bumps for the same dep pile up between releases.

### Test Coverage

- Synthetic-context node script covering four cases: monotonic increasing versions; out-of-order chronological versions (v1.2.1 → v1.2.3 → v1.2.2 in commit order; picks v1.2.2 as the chronological winner rather than v1.2.3 as the semver max); a lone Renovate bump; and a Renovate group-PR subject form with plural deps. All four behaved as expected.
- Real-history dry-run: seeded a test branch with five `fix(deps): update dependency scratch-l10n to vN` empty commits (two with `(#NNN)` PR-ref suffixes, to exercise the recovery path) plus one `fix(deps): update dependency loner-pkg to v9.0.0` plus one `feat:`, ran `npx semantic-release --dry-run --no-ci` against develop's recent history. scratch-l10n, scratch-paint, and scratch-blocks runs all collapsed with all SHAs rendered as markdown links and PR refs preserved in `closes …`; the loner-pkg lone bump and the `feat:` passed through unchanged with their auto-rendered SHA intact. (Test branch and synthetic boundary tag discarded after verification.)
- Pending: first real release after this lands. Visually confirm the changelog in `gh release view` and the commit body produced by `@semantic-release/git`.
