### PR TITLE
feat(add-repo): strip semantic-release artifacts on import

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -373,7 +373,25 @@ echo "==> Fixing up ${PACKAGE_DIR}/package.json..."
 rm -rf "${PACKAGE_PATH}/.husky" \
        "${PACKAGE_PATH}/package-lock.json" \
        "${PACKAGE_PATH}/renovate.json" \
-       "${PACKAGE_PATH}/renovate.json5"
+       "${PACKAGE_PATH}/renovate.json5" \
+       "${PACKAGE_PATH}/release.config.js" \
+       "${PACKAGE_PATH}/release.config.cjs" \
+       "${PACKAGE_PATH}/release.config.mjs" \
+       "${PACKAGE_PATH}/release.config.ts" \
+       "${PACKAGE_PATH}/.releaserc" \
+       "${PACKAGE_PATH}/.releaserc.js" \
+       "${PACKAGE_PATH}/.releaserc.json" \
+       "${PACKAGE_PATH}/.releaserc.yaml" \
+       "${PACKAGE_PATH}/.releaserc.yml" \
+       "${PACKAGE_PATH}/commitlint.config.js" \
+       "${PACKAGE_PATH}/commitlint.config.cjs" \
+       "${PACKAGE_PATH}/commitlint.config.mjs" \
+       "${PACKAGE_PATH}/commitlint.config.ts" \
+       "${PACKAGE_PATH}/.commitlintrc" \
+       "${PACKAGE_PATH}/.commitlintrc.js" \
+       "${PACKAGE_PATH}/.commitlintrc.json" \
+       "${PACKAGE_PATH}/.commitlintrc.yaml" \
+       "${PACKAGE_PATH}/.commitlintrc.yml"
 
 MONOREPO_VERSION=$(jq -r '.version' "${MONOREPO_ROOT}/package.json")
 if [ -r "${PACKAGE_PATH}/package.json" ]; then
@@ -390,6 +408,9 @@ if [ -r "${PACKAGE_PATH}/package.json" ]; then
             '.repository.url |= $MONOREPO_URL' \
             'del(.repository.sha)' \
             'if .scripts.prepare == "husky install" then del(.scripts.prepare) else . end' \
+            'del(.scripts."semantic-release")' \
+            'del(.scripts.commitmsg)' \
+            'del(.scripts.version)' \
             'if (.scripts // {}) == {} then del(.scripts) else . end' \
             'del(.config.commitizen)' \
             'if (.config // {}) == {} then del(.config) else . end' \
@@ -398,6 +419,8 @@ if [ -r "${PACKAGE_PATH}/package.json" ]; then
             'del(.devDependencies."@commitlint/travis-cli")' \
             'del(.devDependencies."cz-conventional-changelog")' \
             'del(.devDependencies."husky")' \
+            'del(.devDependencies."semantic-release")' \
+            'del(.devDependencies."scratch-semantic-release-config")' \
             'if (.devDependencies // {}) == {} then del(.devDependencies) else . end' \
         ) "${PACKAGE_PATH}/package.json" | sponge "${PACKAGE_PATH}/package.json"
 fi
@@ -557,7 +580,7 @@ if ! git diff --cached --quiet; then
     git commit -m "feat: integrate ${REPO_NAME} into monorepo
 
 - Renamed package to ${NPM_ORGANIZATION}/${REPO_NAME}
-- Removed repo-level config (.husky, renovate, commitlint)
+- Removed repo-level config (.husky, renovate, commitlint, semantic-release)
 - Rewired inter-package dependencies to use workspace versions
 - Added to root workspaces list
 - Regenerated package-lock.json"


### PR DESCRIPTION
### Proposed Changes

Extend the import-time strip logic in `scripts/add-repo.sh` to remove the per-package semantic-release apparatus that #574 retired at the monorepo level.

- Files: add `release.config.{js,cjs,mjs,ts}`, `.releaserc*`, `commitlint.config.{js,cjs,mjs,ts}`, `.commitlintrc*` to the `rm -rf` block.
- devDependencies: add `semantic-release` and `scratch-semantic-release-config` to the jq strip chain.
- Scripts: add `semantic-release`, `commitmsg`, and `version` to the jq strip chain, all unconditional.
- Update the integrate-commit message body to reflect the new strip list.

`version` is stripped unconditionally because the monorepo's `scripts/npm-version.sh` writes workspace versions directly with `jq` and never invokes per-workspace `version` scripts; any per-workspace `version` script is dead code on arrival. The four already-imported workspaces all have `null` for `version` — this keeps newly-imported packages aligned with that convention.

### Reason for Changes

#574 consolidated semantic-release at the monorepo root and removed the per-package `release.config.js` files, the `semantic-release` and `scratch-semantic-release-config` devDeps, and the related scripts. Without a matching update to `add-repo.sh`, future imports (scratch-paint, scratch-storage, scratch-audio, scratch-l10n, …) would land with all of those artifacts intact, fighting the consolidated root setup.

Three paired items the existing strip from #571 missed even before #574 landed are also handled here: a standalone `commitlint.config.js` file (the script removes the commitlint devDeps but not the file), a `commitmsg` husky-era hook script, and the per-package commit-SHA-baking `version` script seen in scratch-storage.

### Test Coverage

- `shellcheck scripts/add-repo.sh` is clean.
- Unit-tested the extended jq filter chain against two synthetic `package.json` fixtures: one with all strip targets plus survivors (targets removed, survivors preserved, `scripts` / `config` / `devDependencies` keys kept because they had surviving entries); one with only targets (empty-object sweeps fire and all three keys are removed entirely).
- Live-fire run of `./scripts/add-repo.sh scratch-paint` against the local `~/scratch/scratch-paint` checkout: `packages/scratch-paint/` ended up with no `release.config.*`, no `commitlint.config.*`, no targeted devDeps, and only legitimate scripts. The run aborted at the unrelated `npm install` step because scratch-paint's `package.json` pins `scratch-l10n@6.1.77` while the monorepo just moved to `6.1.78` in 015aa6aa90 — that's a registry-side issue for the eventual production import, not something this PR is responsible for fixing.