### PR TITLE
fix(add-repo): husky v9 prepare strip and explicit publish.yml anchor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,6 +242,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+    # update-gha-workflows.ts: insert new "Publish <package>" steps before this line.
+
   finalize:
     name: Push release to origin
     needs:

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -407,7 +407,7 @@ if [ -r "${PACKAGE_PATH}/package.json" ]; then
             '.version |= $MONOREPO_VERSION' \
             '.repository.url |= $MONOREPO_URL' \
             'del(.repository.sha)' \
-            'if .scripts.prepare == "husky install" then del(.scripts.prepare) else . end' \
+            'if (.scripts.prepare == "husky install") or (.scripts.prepare == "husky") then del(.scripts.prepare) else . end' \
             'del(.scripts."semantic-release")' \
             'del(.scripts.commitmsg)' \
             'del(.scripts.version)' \

--- a/scripts/update-gha-workflows.ts
+++ b/scripts/update-gha-workflows.ts
@@ -141,7 +141,8 @@ function generatePathFilters(workspaces: Workspace[], workspaceMap: Map<string, 
 
 // ─── publish.yml update ──────────────────────────────────────────────────────
 
-const PUBLISH_STEP_MARKER = '      - name: Push to Develop';
+const PUBLISH_STEP_MARKER =
+    '# update-gha-workflows.ts: insert new "Publish <package>" steps before this line.';
 
 /**
  * Scans publish.yml for existing "Publish <name>" steps and adds a default
@@ -184,17 +185,26 @@ function updatePublishWorkflow(content: string, workspaces: Workspace[]): string
         ].join('\n');
     }).join('\n\n');
 
-    // Insert before "Push to Develop"
-    const insertIndex = content.indexOf(PUBLISH_STEP_MARKER);
-    if (insertIndex === -1) {
-        console.warn('Warning: Could not find "Push to Develop" step in publish.yml.');
-        console.warn('New publish steps were NOT added. Please add them manually:');
-        for (const ws of missing) {
-            console.warn(`  - Publish ${ws.bareName}`);
-        }
-        return content;
+    // A missing marker is fatal rather than a warning: silently dropping
+    // publish steps would let workflow drift go unnoticed. The match is
+    // indent-tolerant so the YAML formatter is free to pick a column.
+    const markerRegex = new RegExp(
+        `^[ \\t]*${PUBLISH_STEP_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[ \\t]*$`,
+        'm',
+    );
+    const markerMatch = markerRegex.exec(content);
+    if (!markerMatch) {
+        const wanted = missing.map(ws => `  - Publish ${ws.bareName}`).join('\n');
+        throw new Error(
+            `Could not find the insert marker in publish.yml. ` +
+            `Expected to find a line containing:\n  ${PUBLISH_STEP_MARKER}\n` +
+            `Add it back (at the bottom of the cd: job's steps, before the next job) ` +
+            `or update PUBLISH_STEP_MARKER in scripts/update-gha-workflows.ts.\n` +
+            `New publish steps that were NOT added:\n${wanted}`,
+        );
     }
 
+    const insertIndex = markerMatch.index;
     return content.slice(0, insertIndex) + newSteps + '\n\n' + content.slice(insertIndex);
 }
 


### PR DESCRIPTION
### Proposed Changes

Two robustness fixes for `scripts/add-repo.sh`, each on its own commit:

- **Husky v9 strip** (`scripts/add-repo.sh`): the import-time strip removes `husky` from `devDependencies` unconditionally but only matched `prepare: "husky install"` (v6–v8). The bare `"husky"` form used by v9 (e.g. upstream `scratch-storage`) slipped through, leaving a `prepare: "husky"` script with no `husky` dep. The jq condition now matches both forms.
- **Explicit publish.yml anchor** (`.github/workflows/publish.yml`, `scripts/update-gha-workflows.ts`): the previous insert-point anchor was the literal text of the "Push to Develop" step in publish.yml, removed in 0e6ecee34d when the release pipeline was restructured. With the anchor gone, `npm run refresh-gh-workflow` quietly warned and dropped any new "Publish &lt;pkg&gt;" step, so the next `add-repo.sh` invocation would land a workspace without a publish entry. Adds an explicit comment-marker line in publish.yml at the bottom of the `cd:` job's steps, matched by an indent-tolerant regex; missing marker now throws so future workflow drift surfaces immediately.

### Reason for Changes

Both issues showed up during a trial `./scripts/add-repo.sh scratch-storage` import. `scratch-storage/develop` is on husky v9, so its `prepare` leaked through the v6–v8-only match. The workflow regenerator printed:

> Warning: Could not find "Push to Develop" step in publish.yml. New publish steps were NOT added.

Without these fixes, every future repo import would hit both papercuts.

### Test Coverage

- **Husky strip**: ran the updated jq filter chain against the actual upstream `scratch-storage/develop` `package.json` (`git show origin/develop:package.json | jq …`); both `scripts.prepare` and `devDependencies.husky` are removed cleanly. The existing `"husky install"` form still strips, and a non-husky `prepare` (e.g. `"custom-build"`) is preserved.
- **Workflow anchor**: `npm run refresh-gh-workflow` runs cleanly against the current monorepo (no-op since all current workspaces already have publish steps). Indent tolerance verified by running the marker regex against synthetic lines with 0, 2, 4, and 6-space indents plus tabs; all match. The end-to-end insertion path is covered by the next `add-repo.sh` invocation against a fresh repo.