### PR TITLE
fix(release): set channel for release/* and hotfix/* branches

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,12 +8,17 @@
 
 import {commitPartial, commitsSort, finalizeContext} from './scripts/release-notes-writer-opts.mjs';
 
+// semantic-release template: strips the matched branch's prefix from ${name},
+// keeping channel and prerelease identifier free of '/' (npm dist-tags and
+// semver prerelease identifiers both forbid it).
+const stripPrefix = (prefix) => `\${name.replace(/^${prefix}\\//, "")}`;
+
 export default {
     branches: [
         'develop',
         '+([0-9])?(.{+([0-9]),x}).x',
-        { name: 'release/*', prerelease: '${name.replace(/^release\\//, "")}' },
-        { name: 'hotfix/*', prerelease: '${name.replace(/^hotfix\\//, "")}' }
+        { name: 'release/*', channel: stripPrefix('release'), prerelease: stripPrefix('release') },
+        { name: 'hotfix/*', channel: stripPrefix('hotfix'), prerelease: stripPrefix('hotfix') }
     ],
     plugins: [
         '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Summary

- semantic-release defaults `nextRelease.channel` to the matched branch name when no explicit `channel` is set. For a branch like `release/UEPR-297-accessibility-improvements` that put a `/` in the npm dist-tag passed to `npm publish --tag`, and the registry rejected it with `404 Not Found`.
- Add a matching `channel` template to the `release/*` and `hotfix/*` branch configs that mirrors the existing `prerelease` template (strip the `release/` or `hotfix/` prefix from `${name}`).
- Factor the shared template into a `stripPrefix` helper so the two fields can't drift.

The published version (`13.8.0-UEPR-297-accessibility-improvements.1`) was already correct because the `prerelease` template was in place — only the channel needed fixing. This is the first time the publish workflow has been exercised from a `release/*` branch, so the gap wasn't visible until now.

The currently-blocked release branch will need this cherry-picked (or develop merged into it) before retrying its publish.

## Test plan

- [ ] Re-run the publish workflow on `release/UEPR-297-accessibility-improvements` (after picking up this fix) and confirm `npm publish` succeeds with dist-tag `UEPR-297-accessibility-improvements`.
- [ ] Confirm the published package is installable via `npm install @scratch/scratch-svg-renderer@UEPR-297-accessibility-improvements`.