### PR TITLE
fix(add-repo): regenerate package-lock before installing

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -658,8 +658,8 @@ fi
 
 # 8. Normalize the lockfile after all the dep changes.
 echo "==> Normalizing package-lock.json..."
+npm install --package-lock-only --prefer-offline --no-audit --no-fund
 npm install --prefer-offline --no-audit --no-fund
-npm install --package-lock-only 2>/dev/null || true
 
 # 9. Commit the integration fixups as one cumulative commit.
 echo "==> Committing fixup changes..."


### PR DESCRIPTION
### Proposed Changes

In `scripts/add-repo.sh` step 8 (lockfile normalization), swap the two `npm install` calls so `--package-lock-only` runs first, then the real install. Drop the `2>/dev/null || true` that was suppressing the lockfile-only call's stderr, since errors there now matter and should surface.

### Reason for Changes

Reported during a trial `./scripts/add-repo.sh scratch-storage` run: the first `npm install` errored with

> npm error code ERESOLVE
> npm error While resolving: @scratch/scratch-storage@13.7.4-svg
> npm error Found: ts-jest@undefined
> ...
> npm error peer ts-jest@">=20.0.0" from ts-jest-mock-import-meta@1.3.2

`@scratch/scratch-storage` declares both `ts-jest@29.4.11` and `ts-jest-mock-import-meta@1.3.2` as devDeps; the peer is satisfied on paper. The trigger was the on-disk state from before the workspace was added: a hoisted `ts-jest` pinned at an older version (`29.4.9` in this case) while the newly merged workspace declared `29.4.11`. npm's tree resolution can leave a virtual node for `ts-jest` that hasn't yet been assigned a concrete version, and the peer-dep check then fires against that unresolved node, producing the misleading `Found: ts-jest@undefined` ERESOLVE.

This drift is the normal outcome of Renovate's cadence on develop: recent bumps to `ts-jest` (29.4.10 → 29.4.11 in #909 and #912) and `ts-jest-mock-import-meta` (→ 1.3.2 in #903) landed without rerunning install in every workspace. Running `--package-lock-only` first lets npm pick concrete versions cleanly before the peer check fires.

### Test Coverage

- Reset the workspace to `origin/develop`, removed the leftover `packages/scratch-storage/node_modules` from the prior failed run, then ran `./scripts/add-repo.sh scratch-storage` end-to-end. The previous attempt errored at "Normalizing package-lock.json"; this run completed through the success banner, with `package-lock.json` regenerated normally in the integrate-commit.
- `shellcheck scripts/add-repo.sh` is clean.