### PR TITLE
fix(add-repo): strip more repo-level metadata on import

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -390,9 +390,12 @@ rm -rf "$BUILD_TMP"
 # 5. Fix up the new package's package.json: rename, version, strip repo-level config.
 echo "==> Fixing up ${PACKAGE_DIR}/package.json..."
 
-# Remove repository-level files that don't belong in a workspace package.
-# Keep things like .github/ around as reference for the eventual CI changes.
-rm -rf "${PACKAGE_PATH}/.husky" \
+# Remove repo-level metadata that doesn't apply inside a workspace. The
+# monorepo provides its own equivalents at the root, and per-package
+# copies (e.g. GitHub workflow YAMLs under packages/*/.github/workflows/)
+# are inert: GitHub Actions only honors workflows at the repo root.
+rm -rf "${PACKAGE_PATH}/.github" \
+       "${PACKAGE_PATH}/.husky" \
        "${PACKAGE_PATH}/package-lock.json" \
        "${PACKAGE_PATH}/renovate.json" \
        "${PACKAGE_PATH}/renovate.json5" \
@@ -413,7 +416,13 @@ rm -rf "${PACKAGE_PATH}/.husky" \
        "${PACKAGE_PATH}/.commitlintrc.js" \
        "${PACKAGE_PATH}/.commitlintrc.json" \
        "${PACKAGE_PATH}/.commitlintrc.yaml" \
-       "${PACKAGE_PATH}/.commitlintrc.yml"
+       "${PACKAGE_PATH}/.commitlintrc.yml" \
+       "${PACKAGE_PATH}/.editorconfig" \
+       "${PACKAGE_PATH}/.gitattributes" \
+       "${PACKAGE_PATH}/.nvmrc" \
+       "${PACKAGE_PATH}/.circleci" \
+       "${PACKAGE_PATH}/.travis.yml" \
+       "${PACKAGE_PATH}/.appveyor.yml"
 
 MONOREPO_VERSION=$(jq -r '.version' "${MONOREPO_ROOT}/package.json")
 if [ -r "${PACKAGE_PATH}/package.json" ]; then
@@ -668,7 +677,7 @@ if ! git diff --cached --quiet; then
     git commit -m "feat: integrate ${REPO_NAME} into monorepo
 
 - Renamed package to ${NPM_ORGANIZATION}/${REPO_NAME}
-- Removed repo-level config (.husky, renovate, commitlint, semantic-release)
+- Removed standalone-repo metadata (CI/release configs, hooks, repo-level dotfiles)
 - Rewired inter-package dependencies to use workspace versions
 - Added to root workspaces list
 - Regenerated package-lock.json"


### PR DESCRIPTION
### Proposed Changes

Extend the strip block in step 5 of `scripts/add-repo.sh` so that imports remove a broader set of standalone-repo metadata that's redundant or inert inside a workspace:

- `.github/` (issue templates, CODEOWNERS, workflow YAMLs)
- `.editorconfig`, `.gitattributes`, `.nvmrc` (the monorepo provides its own at root)
- `.circleci/`, `.travis.yml`, `.appveyor.yml` (old CI scaffolds that don't apply inside the monorepo)

Tightened the comment above the `rm -rf` block to say what the block is for instead of what it leaves behind, and reworded the integrate-commit summary line from `Removed repo-level config (.husky, renovate, commitlint, semantic-release)` to `Removed standalone-repo metadata (CI/release configs, hooks, repo-level dotfiles)` so it doesn't go stale every time the strip list grows.

### Reason for Changes

The four properly-imported existing workspaces (scratch-vm, scratch-render, scratch-svg-renderer, scratch-gui) have none of the now-listed files, confirming the convention. `.github/` in particular was already being removed by hand after every import; per-package GitHub workflows under `packages/*/.github/workflows/` are inert because GitHub Actions only honors workflows at the repo root.

`scratch-storage/develop` shipped the full set (`.github/CODEOWNERS.md`, `.github/CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/ci-cd.yml`, `.github/workflows/commitlint.yml`, `.github/workflows/signature-assistant.yml`, `.editorconfig`, `.gitattributes`, `.nvmrc`). Older candidate repos (e.g. scratch-audio) still carry `.travis.yml` and similar.

### Non-goals

`.browserslistrc` was considered and intentionally **not** stripped. The per-workspace `browserslist` values across the existing monorepo diverge (scratch-render targets Safari 8 / iOS 8; scratch-vm and scratch-svg-renderer target Safari 11 with no mobile; scratch-gui targets Safari 11 / iOS 11 / Android 63), and there is no canonical `browserslist` at the root. Stripping today would silently fall back to browserslist's defaults, which is a much shorter list. Reconciling that needs its own piece of work: pick a canonical target list (the workspace `CLAUDE.md` mentions "Baseline Widely Available"), add it at the root, verify each existing per-workspace value can be removed without regression, and then add `.browserslistrc` to this strip list.

### Test Coverage

- Reset the workspace to `origin/develop`, ran `./scripts/add-repo.sh scratch-storage` end-to-end on this branch. Run completed through the success banner. `packages/scratch-storage/` ends up with no `.github`, `.editorconfig`, `.gitattributes`, or `.nvmrc`. Files that should stay (`.gitignore`, `.npmignore`, `README.md`, `LICENSE`, `TRADEMARK`, `package.json`, `eslint.config.mjs`, `jest.config.js`, `tsconfig.*`, `webpack.config.js`, `src/`, `test/`) are intact.
- `shellcheck scripts/add-repo.sh` is clean.
- `.circleci/`, `.travis.yml`, `.appveyor.yml` paths aren't exercised by this run (scratch-storage doesn't carry them), but `rm -rf` is forgiving of missing paths and the additions are mechanically identical to the existing entries.