### PR TITLE
fix(add-repo): refresh LICENSE/TRADEMARK on import

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "refresh-gh-workflow": "ts-node scripts/update-gha-workflows.ts",
     "start": "npm --workspace @scratch/scratch-gui start",
     "test": "npm test --workspaces",
-    "update-legal": "npm --workspaces exec -c 'rm -f ./{LICENSE,TRADEMARK} && cp -f ../../{LICENSE,TRADEMARK} .'",
+    "update-legal": "scripts/update-legal.sh",
     "version": "cross-env-shell ./scripts/npm-version.sh"
   },
   "config": {

--- a/packages/task-herder/TRADEMARK
+++ b/packages/task-herder/TRADEMARK
@@ -1,0 +1,1 @@
+The Scratch trademarks, including the Scratch name, logo, the Scratch Cat, Gobo, Pico, Nano, Tera and Giga graphics (the "Marks"), are property of the Scratch Foundation. Marks may not be used to endorse or promote products derived from this software without specific prior written permission.

--- a/packages/task-herder/package.json
+++ b/packages/task-herder/package.json
@@ -28,6 +28,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "TRADEMARK",
     "dist"
   ],
   "scripts": {

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -519,6 +519,13 @@ else
     fi
 fi
 
+# 6a. Refresh the new package's LICENSE/TRADEMARK from the monorepo root so it
+# matches every other workspace. Runs after step 6 because update-legal
+# resolves the target via `npm query .workspace`, which needs the new entry
+# to already be in the root workspaces array.
+echo "==> Refreshing LICENSE/TRADEMARK from monorepo root..."
+npm run update-legal -- "${NPM_ORGANIZATION}/${REPO_NAME}"
+
 # 7. Rewire inter-package dependencies across all packages.
 echo "==> Rewiring inter-package dependencies..."
 
@@ -678,6 +685,7 @@ if ! git diff --cached --quiet; then
 
 - Renamed package to ${NPM_ORGANIZATION}/${REPO_NAME}
 - Removed standalone-repo metadata (CI/release configs, hooks, repo-level dotfiles)
+- Refreshed LICENSE/TRADEMARK from monorepo root
 - Rewired inter-package dependencies to use workspace versions
 - Added to root workspaces list
 - Regenerated package-lock.json"

--- a/scripts/update-legal.sh
+++ b/scripts/update-legal.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# update-legal.sh — Refresh LICENSE and TRADEMARK in workspace packages
+# from the monorepo root so every workspace ships the same legal text.
+#
+# Usage:
+#   scripts/update-legal.sh                                # every workspace
+#   scripts/update-legal.sh <package-name> [<name>...]     # named workspaces
+#
+# Package names can be bare ("scratch-vm") or scoped ("@scratch/scratch-vm").
+# Driven through npm:
+#   npm run update-legal                                   # every workspace
+#   npm run update-legal -- @scratch/scratch-storage       # one workspace
+
+set -e
+
+require_command() {
+    local cmd="$1"
+    if ! command -v "$cmd" &> /dev/null; then
+        echo "Error: '${cmd}' is required but not installed." >&2
+        exit 1
+    fi
+}
+
+require_command jq
+require_command npm
+
+MONOREPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$MONOREPO_ROOT"
+
+# Ask npm where each workspace lives — no assumption about the directory
+# layout. `npm query .workspace` returns a JSON array of workspace nodes;
+# `.location` is the workspace path relative to the monorepo root, the same
+# field scripts/npm-version.sh and scripts/update-gha-workflows.ts read.
+WORKSPACE_JSON=$(npm query .workspace)
+
+target_dirs=()
+if [ "$#" -eq 0 ]; then
+    # Capture jq's output in a command substitution (rather than streaming
+    # through process substitution) so a jq failure propagates through set -e
+    # instead of leaving the while loop with empty input and exit 0.
+    locations=$(jq -r '.[].location' <<<"$WORKSPACE_JSON")
+    while IFS= read -r dir; do
+        target_dirs+=("$dir")
+    done <<<"$locations"
+else
+    for name in "$@"; do
+        # Accept bare ("scratch-vm") or scoped ("@scratch/scratch-vm").
+        dir=$(jq -r --arg n "$name" '
+            (map(select(.name == $n or .name == "@scratch/\($n)"))
+             | first
+             | .location) // empty
+        ' <<<"$WORKSPACE_JSON")
+        if [ -z "$dir" ]; then
+            echo "Error: unknown workspace '$name'" >&2
+            exit 1
+        fi
+        target_dirs+=("$dir")
+    done
+fi
+
+for dir in "${target_dirs[@]}"; do
+    echo "  Updating ${dir}/{LICENSE,TRADEMARK}"
+    rm -f "${dir}/LICENSE" "${dir}/TRADEMARK"
+    cp -f LICENSE TRADEMARK "${dir}/"
+done


### PR DESCRIPTION
### Proposed Changes

Three commits:

1. **`refactor(scripts): scripts/update-legal.sh, optionally per-workspace`** — replaces the inline npm script body with a dedicated bash script. No-arg behavior is unchanged (every workspace's LICENSE/TRADEMARK refreshed from the monorepo root); with one or more package names (bare or `@scratch/`-scoped) it targets just those:

   ```
   npm run update-legal                              # every workspace
   npm run update-legal -- @scratch/scratch-storage  # one workspace
   ```

   Workspace directories are discovered via `npm query .workspace` rather than a hardcoded `packages/*` glob.

2. **`refactor(add-repo): use update-legal to refresh imported LICENSE/TRADEMARK`** — adds a step 6a to `scripts/add-repo.sh` that runs `npm run update-legal -- "${NPM_ORGANIZATION}/${REPO_NAME}"` right after the new workspace is registered in the root workspaces array, so the imported package ships the monorepo's legal text from its first commit instead of the source repo's older copies. Placed after step 6 because the helper resolves its target via `npm query .workspace`, which needs the entry to already exist in the workspaces array. The integrate-commit summary picks up a `Refreshed LICENSE/TRADEMARK from monorepo root` line alongside the existing entries.

3. **`fix(task-herder): publish TRADEMARK alongside LICENSE`** — task-herder was missing `TRADEMARK` in both the working tree (never copied from the monorepo root) and the `files` allowlist, so its published tarball didn't carry the Scratch trademark notice every other workspace publishes. Surfaced while testing (1).

### Reason for Changes

A freshly imported workspace was shipping the source repo's LICENSE/TRADEMARK rather than the monorepo's. If LICENSE or TRADEMARK ever updates at the root, newly imported workspaces would carry stale copies until someone notices and runs `update-legal` by hand. The right place to refresh is during the import itself.

The `update-legal` generalization fell out of the question of how to do that refresh for one workspace without re-running it for the other six. Moving the inline npm-script shell into a dedicated script that takes an optional workspace list gives `add-repo.sh` a clean call site, unlocks ad-hoc single-workspace usage when needed, and stops baking in the `packages/*` directory layout.

### Test Coverage

- `shellcheck scripts/add-repo.sh scripts/update-legal.sh` is clean.
- `npm run update-legal` (no args) refreshes every workspace, same behavior as before.
- `npm run update-legal -- @scratch/scratch-vm scratch-render` resolves both scoped and bare names.
- `npm run update-legal -- bogus-name` exits 1 with `Error: unknown workspace 'bogus-name'`.
- Ran `./scripts/add-repo.sh scratch-storage` end-to-end against `origin/develop`. The new step 6a fired between workspace-registration and dep-rewire; `packages/scratch-storage/LICENSE` and `TRADEMARK` end up byte-identical to the root files. The run later hit an unrelated `npm error notarget` on `@babel/preset-env@7.29.7` in step 8's lockfile normalization — that bump exists on develop already (#914) and the registry doesn't have it; not introduced by this PR.
- `npm pack --dry-run --workspace=@scratch/task-herder`: TRADEMARK now ships; file count 12 → 13.

### Non-goals

- Migrating other workspaces between `.npmignore` (denylist) and `files` (allowlist). Considered while looking at task-herder; the allowlist is the cleaner pattern in this author's read, but the migration is a separate decision.
- Supporting downstream consumers building any workspace from source rather than the prebuilt `dist/`. Discussed during the work that produced this PR; deferred to a separate conversation, since there is no agreed design yet.