### PR TITLE
chore(add-repo): drop --prefer-offline from lockfile generation

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -673,8 +673,14 @@ if [ ${#MATCHING_FILES[@]} -gt 0 ]; then
 fi
 
 # 8. Normalize the lockfile after all the dep changes.
+#
+# Lockfile generation deliberately does not use --prefer-offline: that step is
+# discovering which versions to resolve to, and a cached packument predating a
+# freshly published transitive dep will trip ETARGET on a range npm could
+# satisfy from the registry. The follow-up install can keep --prefer-offline
+# because the lockfile pins concrete tarballs by then.
 echo "==> Normalizing package-lock.json..."
-npm install --package-lock-only --prefer-offline --no-audit --no-fund
+npm install --package-lock-only --no-audit --no-fund
 npm install --prefer-offline --no-audit --no-fund
 
 # 9. Commit the integration fixups as one cumulative commit.


### PR DESCRIPTION
## Summary

- `scripts/add-repo.sh` step 8's first `npm install --package-lock-only` no longer passes `--prefer-offline`, so the version-discovery step always uses fresh registry metadata.
- The follow-up `npm install` keeps `--prefer-offline` because the lockfile pins concrete tarballs by then.

## Why

`--prefer-offline` lets npm reuse cached packument metadata. If the cache predates a freshly published transitive dep, npm bails with `ETARGET` on a range it could otherwise satisfy from the registry. Observed importing scratch-storage shortly after `@babel/helper-module-imports@7.29.7` was published:

```
npm error code ETARGET
npm error notarget No matching version found for @babel/helper-module-imports@^7.29.7.
```

Re-running the same install without `--prefer-offline` succeeded. Lockfile generation is the step that needs fresh metadata, and importing a workspace is exactly when the local cache is most likely to be stale relative to the upstream repo's just-bumped deps.

## Test plan

- [x] `shellcheck scripts/add-repo.sh` clean
- [x] Reproduced the failure locally and confirmed dropping `--prefer-offline` from the lockfile-only call lets `npm install --package-lock-only --no-audit --no-fund` complete cleanly against the same tree
- [ ] Next opportunity: run `scripts/add-repo.sh` against another candidate workspace to confirm the broader path is unaffected