### PR TITLE
chore(add-repo): set canonical prepublishOnly on imported workspace

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -425,15 +425,28 @@ rm -rf "${PACKAGE_PATH}/.github" \
        "${PACKAGE_PATH}/.appveyor.yml"
 
 MONOREPO_VERSION=$(jq -r '.version' "${MONOREPO_ROOT}/package.json")
+# Match the canonical prepublishOnly script used by every workspace in the
+# monorepo: a local `npm publish` should fail loudly, since publishing is a
+# CI-only operation. The standalone repo's prepublishOnly (if any) no longer
+# applies, so overwrite — and log if we're replacing something different.
+CANONICAL_PREPUBLISH_ONLY='echo "Please publish through CI only." && exit 1'
 if [ -r "${PACKAGE_PATH}/package.json" ]; then
+    EXISTING_PREPUBLISH_ONLY=$(jq -r '.scripts.prepublishOnly // ""' "${PACKAGE_PATH}/package.json")
+    if [ -n "$EXISTING_PREPUBLISH_ONLY" ] && [ "$EXISTING_PREPUBLISH_ONLY" != "$CANONICAL_PREPUBLISH_ONLY" ]; then
+        echo "    Note: replacing existing prepublishOnly script."
+        echo "      old: ${EXISTING_PREPUBLISH_ONLY}"
+        echo "      new: ${CANONICAL_PREPUBLISH_ONLY}"
+    fi
     # shellcheck disable=SC2016
     # The single-quoted fragments below are jq filter syntax. $PACKAGE_NAME,
-    # $MONOREPO_URL and $MONOREPO_VERSION are jq variables (bound via --arg),
-    # not shell variables — they must NOT be expanded by the shell.
+    # $MONOREPO_URL, $MONOREPO_VERSION, and $PREPUBLISH_ONLY are jq variables
+    # (bound via --arg), not shell variables — they must NOT be expanded by
+    # the shell.
     jq_in_place "${PACKAGE_PATH}/package.json" \
         --arg PACKAGE_NAME "${NPM_ORGANIZATION}/${REPO_NAME}" \
         --arg MONOREPO_URL "$MONOREPO_URL" \
         --arg MONOREPO_VERSION "$MONOREPO_VERSION" \
+        --arg PREPUBLISH_ONLY "$CANONICAL_PREPUBLISH_ONLY" \
         -f <(join_args ' | ' \
             '.name |= $PACKAGE_NAME' \
             '.version |= $MONOREPO_VERSION' \
@@ -443,6 +456,7 @@ if [ -r "${PACKAGE_PATH}/package.json" ]; then
             'del(.scripts."semantic-release")' \
             'del(.scripts.commitmsg)' \
             'del(.scripts.version)' \
+            '.scripts.prepublishOnly = $PREPUBLISH_ONLY' \
             'if (.scripts // {}) == {} then del(.scripts) else . end' \
             'del(.config.commitizen)' \
             'if (.config // {}) == {} then del(.config) else . end' \


### PR DESCRIPTION
### Resolves

No linked issue — surfaced while reviewing `scripts/add-repo.sh` for follow-ups after #593.

### Proposed Changes

In `scripts/add-repo.sh` step 5 (the `package.json` rewrite for the newly-imported workspace), set the canonical `prepublishOnly` script:

```
"prepublishOnly": "echo \"Please publish through CI only.\" && exit 1"
```

This is added unconditionally:

- If the imported `package.json` has no `prepublishOnly`, it gets added silently.
- If it already has the canonical value, it's a no-op (silent).
- If it has a different value, the new value replaces it and the old/new pair is logged to the script's output so the replacement is discoverable.

### Reason for Changes

All five published workspaces already in the monorepo (`scratch-gui`, `scratch-render`, `scratch-svg-renderer`, `scratch-vm`, `task-herder`) share this exact `prepublishOnly` line — a fail-loud guard that blocks a local `npm publish` since publishing is a CI-only operation.

A freshly-imported workspace inherits whatever the standalone repo had — often nothing, or a leftover from its pre-monorepo publish flow. Adding the guard at import time means newly-added packages match the convention from their first commit, instead of needing a follow-up cleanup PR.

### Test Coverage

`add-repo.sh` is integration-style tooling without a unit test harness, so verification is manual:

- [x] `shellcheck scripts/add-repo.sh` clean.
- [x] Spot-checked the jq setter directly: against `packages/scratch-gui/package.json` (existing canonical value preserved) and against `{}` (creates `.scripts` parent, produces canonical encoded string).
- [ ] End-to-end: next time `scripts/add-repo.sh` is run against a candidate workspace, confirm both the silent-add and the log-on-conflict paths behave as intended in a real import.