### PR TITLE
chore(add-repo): refresh LICENSE/TRADEMARK after install, not before

### DIFF
--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -533,13 +533,6 @@ else
     fi
 fi
 
-# 6a. Refresh the new package's LICENSE/TRADEMARK from the monorepo root so it
-# matches every other workspace. Runs after step 6 because update-legal
-# resolves the target via `npm query .workspace`, which needs the new entry
-# to already be in the root workspaces array.
-echo "==> Refreshing LICENSE/TRADEMARK from monorepo root..."
-npm run update-legal -- "${NPM_ORGANIZATION}/${REPO_NAME}"
-
 # 7. Rewire inter-package dependencies across all packages.
 echo "==> Rewiring inter-package dependencies..."
 
@@ -696,6 +689,14 @@ fi
 echo "==> Normalizing package-lock.json..."
 npm install --package-lock-only --no-audit --no-fund
 npm install --prefer-offline --no-audit --no-fund
+
+# 8a. Refresh the new package's LICENSE/TRADEMARK from the monorepo root so it
+# matches every other workspace. Runs after step 8 because update-legal
+# resolves the target via `npm query .workspace`, which walks the installed
+# tree — a lockfile-only update isn't enough; the full install above must
+# have populated node_modules with the new workspace symlink first.
+echo "==> Refreshing LICENSE/TRADEMARK from monorepo root..."
+npm run update-legal -- "${NPM_ORGANIZATION}/${REPO_NAME}"
 
 # 9. Commit the integration fixups as one cumulative commit.
 echo "==> Committing fixup changes..."


### PR DESCRIPTION
### Resolves

No linked issue — surfaced while running `scripts/add-repo.sh scratch-storage` end-to-end:

```
==> Refreshing LICENSE/TRADEMARK from monorepo root...

> scratch-editor@14.1.0 update-legal
> scripts/update-legal.sh @scratch/scratch-storage

Error: unknown workspace '@scratch/scratch-storage'
```

### Proposed Changes

Move the LICENSE/TRADEMARK refresh in `scripts/add-repo.sh` from step 6a (right after the workspaces array is updated) to step 8a (right after the full `npm install`).

### Reason for Changes

`scripts/update-legal.sh` resolves workspaces via `npm query .workspace`. That query walks the *installed* dependency tree, not the workspaces array in `package.json`. A freshly-imported workspace doesn't appear there until `npm install` has populated `node_modules` with its symlink.

I verified this empirically against the monorepo on `develop`:

- Added `packages/fake-test-ws` plus a workspaces entry → `npm query .workspace` did not list it.
- Then `npm install --package-lock-only --no-audit --no-fund` (added it to the lockfile) → still not listed.
- Then full `npm install --prefer-offline --no-audit --no-fund` → it appeared.

So `npm query` needs the install step, not just the lockfile regen. The previous ordering ran `update-legal` before either install, which is why it failed for `@scratch/scratch-storage`. Moving the refresh after step 8 makes the step actually work; the end-state of `packages/<new-workspace>/{LICENSE,TRADEMARK}` at commit time is unchanged.

### Test Coverage

`add-repo.sh` has no unit-test harness; verification is manual.

- [x] `shellcheck scripts/add-repo.sh` clean.
- [x] Reproduced the original failure end-to-end against `scratch-storage` on the prior `add-repo.sh`.
- [x] Empirically confirmed the lockfile-only / full-install split via the `fake-test-ws` probe described above.
- [ ] Next end-to-end run of `scripts/add-repo.sh` against a candidate workspace should reach commit time without the `unknown workspace` error.