### PR TITLE
fix: Report scratch-paint test results

### DIFF
--- a/packages/scratch-paint/.gitignore
+++ b/packages/scratch-paint/.gitignore
@@ -18,4 +18,4 @@ dist/*
 /locale
 
 # tests
-/test/results/*
+/test-results

--- a/packages/scratch-paint/package.json
+++ b/packages/scratch-paint/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "echo \"Please publish through CI only.\" && exit 1",
     "start": "webpack serve",
     "test": "npm run unit",
-    "unit": "jest --reporters=default",
+    "unit": "jest",
     "watch": "webpack --progress --watch"
   },
   "browserslist": [
@@ -49,10 +49,16 @@
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!intl-messageformat|intl-messageformat-parser).+\\.js$"
+    ],
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "outputDirectory": "test-results"
+        }
+      ]
     ]
-  },
-  "jest-junit": {
-    "outputDirectory": "./test/results"
   },
   "dependencies": {
     "@scratch/paper": "0.11.20221201200345",


### PR DESCRIPTION
### Resolves
`scratch-paint` doesn't report test results

### Proposed Changes
Update the reporting directory for test results to be `test-results` rather than `./test/results`, as that is what the CI/CD job expects.

### Reason for Changes
`scratch-paint` was configured to report test results in `./test/results`. However, when running the tests through the CI/CD job, the workflow looks for the results in `test-results`, meaning they were never uploaded and reported.

### Test Coverage
Checked the CI/CD job and verified that results are now successfully reported.