### PR TITLE
test: report scratch-storage test results in CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40437,6 +40437,7 @@
         "eslint-config-scratch": "14.1.30",
         "file-loader": "6.2.0",
         "jest": "29.7.0",
+        "jest-junit": "17.0.0",
         "json": "10.0.0",
         "rimraf": "6.1.3",
         "scratch-webpack-configuration": "3.1.2",
@@ -40528,6 +40529,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/scratch-storage/node_modules/jest-junit": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^14.0.0",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/scratch-storage/node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -40578,6 +40595,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/scratch-storage/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "packages/scratch-svg-renderer": {

--- a/packages/scratch-storage/.gitignore
+++ b/packages/scratch-storage/.gitignore
@@ -8,6 +8,7 @@ npm-*
 # Testing
 /.nyc_output
 /coverage
+/test-results
 
 # IDEA
 /.idea

--- a/packages/scratch-storage/jest.config.js
+++ b/packages/scratch-storage/jest.config.js
@@ -33,5 +33,14 @@ module.exports = {
             }
         }).transform,
         '\\.(png|svg|wav)$': '<rootDir>/test/transformers/arraybuffer-loader.js'
-    }
+    },
+    reporters: [
+        'default',
+        [
+            'jest-junit',
+            {
+                outputDirectory: 'test-results'
+            }
+        ]
+    ]
 };

--- a/packages/scratch-storage/package.json
+++ b/packages/scratch-storage/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run clean && webpack --mode=production",
     "clean": "rimraf dist",
-    "coverage": "tap ./test/{unit,integration}/*.js --coverage --coverage-report=lcov",
+    "coverage": "jest \"test[\\\\/](unit|integration)\" --coverage",
     "prepublishOnly": "echo \"Please publish through CI only.\" && exit 1",
     "test": "npm run test:lint && jest \"test[\\\\/](unit|integration)\"",
     "test:build": "jest \"test[\\\\/]build\"",
@@ -23,9 +23,6 @@
     "test:lint": "eslint",
     "test:unit": "jest \"test[\\\\/]unit\"",
     "watch": "webpack --watch"
-  },
-  "tap": {
-    "check-coverage": false
   },
   "dependencies": {
     "@babel/runtime": "7.29.7",
@@ -48,6 +45,7 @@
     "eslint-config-scratch": "14.1.30",
     "file-loader": "6.2.0",
     "jest": "29.7.0",
+    "jest-junit": "17.0.0",
     "json": "10.0.0",
     "rimraf": "6.1.3",
     "scratch-webpack-configuration": "3.1.2",


### PR DESCRIPTION
### Resolves

_No tracking issue; companion to #610 (the same fix for scratch-paint)._

### Proposed Changes

- Add the `jest-junit` reporter to scratch-storage's Jest config, writing to `test-results/` (the path the CI `test-package` action uploads and the `Test Results` job parses).
- Add `jest-junit` to `devDependencies`.
- Remove leftovers from the earlier tap-to-Jest migration: the tap-based `coverage` script and the `tap` config block. Neither worked anymore — `tap` is no longer a dependency — and there are no remaining tap-based tests.
- Ignore `/test-results` in the package `.gitignore`.

### Reason for Changes

scratch-storage runs its tests with Jest, but nothing was configured to emit a JUnit report. The CI `test-package` action only sets `TAP_REPORTER*` env vars (honored by tap, ignored by Jest) and uploads `test-results/*`, so a Jest package with no junit reporter produced no XML and CI had nothing to publish for it. This mirrors the scratch-paint fix in #610.

### Test Coverage

No test changes — this is config only. Verified locally that `npm run test:unit` now writes a well-formed `test-results/junit.xml`, the artifact CI globs via `test-results/**/*.xml`. Confirmed all existing test files already use Jest globals (no tap/tape remnants).
