### PR TITLE
chore: add CLAUDE.md bridge so Claude Code loads AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### Resolves

Not a bug fix; no associated issue. Small tooling change. Follows the convention added to the org `AGENTS.md` template in scratchfoundation/.github#9.

### Proposed Changes

Add a one-line `CLAUDE.md` whose only content is the import directive `@AGENTS.md`.

### Reason for Changes

Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so this repo's existing agent guide does not load on its own, especially when the repo is opened from a parent directory that holds several Scratch repos. A `CLAUDE.md` that imports `AGENTS.md` bridges that gap. A plain import file is used rather than a symlink, because a committed symlink does not survive Windows checkouts. Other agent tools keep reading `AGENTS.md` directly, so no content is duplicated.

### Test Coverage

No code change. Verified against the installed Claude Code (2.1.158) that a `CLAUDE.md` containing `@AGENTS.md` loads the imported content, while a directory with only `AGENTS.md` does not.