### PR TITLE
feat: allow library asset url to be set and passed as a prop

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -48,6 +48,7 @@ import {setTheme} from '../../reducers/settings.js';
 import {PLATFORM} from '../../lib/platform.js';
 import {MenuRefProvider} from '../../contexts/menu-ref-context.jsx';
 import {ModalFocusProvider} from '../../contexts/modal-focus-context.jsx';
+import {LibraryAssetConfigProvider} from '../../contexts/library-asset-config-context.jsx';
 
 const ariaMessages = defineMessages({
     menuBar: {
@@ -203,6 +204,7 @@ const GUIComponent = props => {
         username,
         userOwnsProject,
         hideTutorialProjects,
+        libraryAssetUrlTemplate,
         vm,
         ...componentProps
     } = omit(props, 'dispatch', 'setPlatform');
@@ -270,307 +272,313 @@ const GUIComponent = props => {
             </StageWrapper>
         ) : (
             <ModalFocusProvider>
-                <Box
-                    className={styles.pageWrapper}
-                    dir={isRtl ? 'rtl' : 'ltr'}
-                    {...componentProps}
+                <LibraryAssetConfigProvider
+                    libraryAssetUrlTemplate={libraryAssetUrlTemplate}
                 >
-                    {telemetryModalVisible ? (
-                        <TelemetryModal
-                            isRtl={isRtl}
-                            isTelemetryEnabled={isTelemetryEnabled}
-                            onCancel={onTelemetryModalCancel}
-                            onOptIn={onTelemetryModalOptIn}
-                            onOptOut={onTelemetryModalOptOut}
-                            onRequestClose={onRequestCloseTelemetryModal}
-                            onShowPrivacyPolicy={onShowPrivacyPolicy}
-                        />
-                    ) : null}
-                    {loading ? (
-                        <Loader />
-                    ) : null}
-                    {isCreating ? (
-                        <Loader messageId="gui.loader.creating" />
-                    ) : null}
-                    {isRendererSupported ? null : (
-                        <WebGlModal isRtl={isRtl} />
-                    )}
-                    {tipsLibraryVisible ? (
-                        <TipsLibrary
-                            hideTutorialProjects={hideTutorialProjects}
-                            onTutorialSelect={onTutorialSelect}
-                        />
-                    ) : null}
-                    {cardsVisible ? (
-                        <Cards />
-                    ) : null}
-                    {alertsVisible ? (
-                        <Alerts className={styles.alertsContainer} />
-                    ) : null}
-                    {connectionModalVisible ? (
-                        <ConnectionModal
-                            useExternalPeripheralList={useExternalPeripheralList}
-                            vm={vm}
-                        />
-                    ) : null}
-                    {costumeLibraryVisible ? (
-                        <CostumeLibrary
-                            vm={vm}
-                            onRequestClose={onRequestCloseCostumeLibrary}
-                        />
-                    ) : null}
-                    {<DebugModal
-                        isOpen={debugModalVisible}
-                        onClose={onCloseDebugModal}
-                    />}
-                    {backdropLibraryVisible ? (
-                        <BackdropLibrary
-                            vm={vm}
-                            onRequestClose={onRequestCloseBackdropLibrary}
-                        />
-                    ) : null}
-                    {/* TODO - in case of moving MenuRefProvider which seems likely,
-                    make sure to move it from tests as well */}
-                    {!menuBarHidden && <MenuRefProvider>
-                        <MenuBar
-                            ariaRole="banner"
-                            ariaLabel={intl.formatMessage(ariaMessages.menuBar)}
-                            authorId={authorId}
-                            authorThumbnailUrl={authorThumbnailUrl}
-                            authorUsername={authorUsername}
-                            authorAvatarBadge={authorAvatarBadge}
-                            canChangeLanguage={canChangeLanguage}
-                            canChangeColorMode={canChangeColorMode}
-                            canChangeTheme={canChangeTheme}
-                            canCreateCopy={canCreateCopy}
-                            canCreateNew={canCreateNew}
-                            canEditTitle={canEditTitle}
-                            canManageFiles={canManageFiles}
-                            canRemix={canRemix}
-                            canSave={canSave}
-                            canShare={canShare}
-                            className={styles.menuBarPosition}
-                            enableCommunity={enableCommunity}
-                            hasActiveMembership={hasActiveMembership}
-                            isShared={isShared}
-                            isTotallyNormal={isTotallyNormal}
-                            logo={logo}
-                            renderLogin={renderLogin}
-                            showComingSoon={showComingSoon}
-                            onClickAbout={onClickAbout}
-                            onClickLogo={onClickLogo}
-                            onLogOut={onLogOut}
-                            onClickLogin={onClickLogin}
-                            onOpenRegistration={onOpenRegistration}
-                            onProjectTelemetryEvent={onProjectTelemetryEvent}
-                            onSeeCommunity={onSeeCommunity}
-                            onShare={onShare}
-                            onStartSelectingFileUpload={onStartSelectingFileUpload}
-                            onToggleLoginOpen={onToggleLoginOpen}
-                            userOwnsProject={userOwnsProject}
-                            username={username}
-                            accountMenuOptions={accountMenuOptions}
-                        />
-                    </MenuRefProvider>
-                    }
-                    <Box className={classNames(boxStyles, styles.flexWrapper)}>
-                        <Box
-                            role="main"
-                            aria-label={intl.formatMessage(ariaMessages.editor)}
-                            className={styles.editorWrapper}
-                            element="main"
-                        >
-                            <Tabs
-                                forceRenderTabPanel
-                                className={tabClassNames.tabs}
-                                selectedIndex={activeTabIndex}
-                                selectedTabClassName={tabClassNames.tabSelected}
-                                selectedTabPanelClassName={tabClassNames.tabPanelSelected}
-                                onSelect={onActivateTab}
-
-                                // TODO: focusTabOnClick should be true for accessibility, but currently conflicts
-                                // with nudge operations in the paint editor. We'll likely need to manage focus
-                                // differently within the paint editor before we can turn this back on.
-                                // Repro steps:
-                                // 1. Click the Costumes tab
-                                // 2. Select something in the paint editor (say, the cat's face)
-                                // 3. Press the left or right arrow key
-                                // Desired behavior: the face should nudge left or right
-                                // Actual behavior: the Code or Sounds tab is now focused
-                                focusTabOnClick={false}
-                            >
-                                <Box
-                                    role="region"
-                                    aria-label={intl.formatMessage(ariaMessages.tabList)}
-                                >
-                                    <TabList
-                                        className={tabClassNames.tabList}
-                                        role="tablist"
-                                    >
-                                        <Tab
-                                            className={tabClassNames.tab}
-                                            tabIndex="0"
-                                            role="tab"
-                                        >
-                                            <img
-                                                draggable={false}
-                                                src={codeIcon}
-                                            />
-                                            <FormattedMessage
-                                                defaultMessage="Code"
-                                                description="Button to get to the code panel"
-                                                id="gui.gui.codeTab"
-                                            />
-                                        </Tab>
-                                        <Tab
-                                            className={tabClassNames.tab}
-                                            onClick={onActivateCostumesTab}
-                                            role="tab"
-                                            tabIndex="0"
-                                        >
-                                            <img
-                                                draggable={false}
-                                                src={costumesIcon}
-                                            />
-                                            {targetIsStage ? (
-                                                <FormattedMessage
-                                                    defaultMessage="Backdrops"
-                                                    description="Button to get to the backdrops panel"
-                                                    id="gui.gui.backdropsTab"
-                                                />
-                                            ) : (
-                                                <FormattedMessage
-                                                    defaultMessage="Costumes"
-                                                    description="Button to get to the costumes panel"
-                                                    id="gui.gui.costumesTab"
-                                                />
-                                            )}
-                                        </Tab>
-                                        <Tab
-                                            className={tabClassNames.tab}
-                                            onClick={onActivateSoundsTab}
-                                            role="tab"
-                                            tabIndex="0"
-                                        >
-                                            <img
-                                                draggable={false}
-                                                src={soundsIcon}
-                                            />
-                                            <FormattedMessage
-                                                defaultMessage="Sounds"
-                                                description="Button to get to the sounds panel"
-                                                id="gui.gui.soundsTab"
-                                            />
-                                        </Tab>
-                                    </TabList>
-                                </Box>
-                                <TabPanel
-                                    className={tabClassNames.tabPanel}
-                                    role="tabpanel"
-                                >
-                                    <Box
-                                        className={styles.blocksWrapper}
-                                        role="region"
-                                        aria-label={intl.formatMessage(ariaMessages.codePanel)}
-                                        element="section"
-                                    >
-                                        <Blocks
-                                            key={`${blocksId}/${colorMode}/${theme}`}
-                                            canUseCloud={canUseCloud}
-                                            grow={1}
-                                            isVisible={blocksTabVisible}
-                                            options={{
-                                                media: `${basePath}static/${colorModeMap[colorMode].blocksMediaFolder}/`
-                                            }}
-                                            stageSize={stageSize}
-                                            theme={theme}
-                                            vm={vm}
-                                            colorMode={colorMode}
-                                        />
-                                    </Box>
-                                    <ExtensionsButton
-                                        intl={intl}
-                                        onExtensionButtonClick={onExtensionButtonClick}
-                                    />
-                                    <Box className={styles.watermark}>
-                                        <Watermark />
-                                    </Box>
-                                </TabPanel>
-                                <TabPanel
-                                    className={tabClassNames.tabPanel}
-                                    role="tabpanel"
-                                >
-                                    {costumesTabVisible ? <CostumeTab
-                                        ariaLabel={targetIsStage ? intl.formatMessage(ariaMessages.backdropsPanel) :
-                                            intl.formatMessage(ariaMessages.costumesPanel)}
-                                        ariaRole="region"
-                                        vm={vm}
-                                        onNewLibraryBackdropClick={onNewLibraryBackdropClick}
-                                        onNewLibraryCostumeClick={onNewLibraryCostumeClick}
-                                    /> : null}
-                                </TabPanel>
-                                <TabPanel
-                                    className={tabClassNames.tabPanel}
-                                    role="tabpanel"
-                                >
-                                    {soundsTabVisible ?
-                                        <SoundTab
-                                            ariaLabel={intl.formatMessage(ariaMessages.soundsPanel)}
-                                            ariaRole="region"
-                                            vm={vm}
-                                        /> : null}
-                                </TabPanel>
-                            </Tabs>
-                            {backpackVisible && backpackConfigured ? (
-                                <Backpack
-                                    host={backpackHost}
-                                    ariaRole="region"
-                                    ariaLabel={intl.formatMessage(ariaMessages.backpack)}
-                                />
-                            ) : null}
-                        </Box>
-
-                        <Box
-                            role="complementary"
-                            aria-label={intl.formatMessage(ariaMessages.stageAndTarget)}
-                            className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}
-                            element="aside"
-                        >
-                            <StageWrapper
-                                isFullScreen={isFullScreen}
-                                isRendererSupported={isRendererSupported}
+                    <Box
+                        className={styles.pageWrapper}
+                        dir={isRtl ? 'rtl' : 'ltr'}
+                        {...componentProps}
+                    >
+                        {telemetryModalVisible ? (
+                            <TelemetryModal
                                 isRtl={isRtl}
-                                isCreating={isCreating}
-                                stageSize={stageSize}
+                                isTelemetryEnabled={isTelemetryEnabled}
+                                onCancel={onTelemetryModalCancel}
+                                onOptIn={onTelemetryModalOptIn}
+                                onOptOut={onTelemetryModalOptOut}
+                                onRequestClose={onRequestCloseTelemetryModal}
+                                onShowPrivacyPolicy={onShowPrivacyPolicy}
+                            />
+                        ) : null}
+                        {loading ? (
+                            <Loader />
+                        ) : null}
+                        {isCreating ? (
+                            <Loader messageId="gui.loader.creating" />
+                        ) : null}
+                        {isRendererSupported ? null : (
+                            <WebGlModal isRtl={isRtl} />
+                        )}
+                        {tipsLibraryVisible ? (
+                            <TipsLibrary
+                                hideTutorialProjects={hideTutorialProjects}
+                                onTutorialSelect={onTutorialSelect}
+                            />
+                        ) : null}
+                        {cardsVisible ? (
+                            <Cards />
+                        ) : null}
+                        {alertsVisible ? (
+                            <Alerts className={styles.alertsContainer} />
+                        ) : null}
+                        {connectionModalVisible ? (
+                            <ConnectionModal
+                                useExternalPeripheralList={useExternalPeripheralList}
                                 vm={vm}
-                                ariaRole="region"
-                                ariaLabel={intl.formatMessage(ariaMessages.stage)}
-                                manuallySaveThumbnails={manuallySaveThumbnails}
-                                onSetManualThumbnail={onSetManualThumbnail}
-                                onSetManualThumbnailButtonClick={onSetManualThumbnailButtonClick}
-                                loading={loading}
-                                showNewFeatureCallouts={showNewFeatureCallouts}
+                            />
+                        ) : null}
+                        {costumeLibraryVisible ? (
+                            <CostumeLibrary
+                                vm={vm}
+                                onRequestClose={onRequestCloseCostumeLibrary}
+                            />
+                        ) : null}
+                        {<DebugModal
+                            isOpen={debugModalVisible}
+                            onClose={onCloseDebugModal}
+                        />}
+                        {backdropLibraryVisible ? (
+                            <BackdropLibrary
+                                vm={vm}
+                                onRequestClose={onRequestCloseBackdropLibrary}
+                            />
+                        ) : null}
+                        {/* TODO - in case of moving MenuRefProvider which seems likely,
+                    make sure to move it from tests as well */}
+                        {!menuBarHidden && <MenuRefProvider>
+                            <MenuBar
+                                ariaRole="banner"
+                                ariaLabel={intl.formatMessage(ariaMessages.menuBar)}
+                                authorId={authorId}
+                                authorThumbnailUrl={authorThumbnailUrl}
+                                authorUsername={authorUsername}
+                                authorAvatarBadge={authorAvatarBadge}
+                                canChangeLanguage={canChangeLanguage}
+                                canChangeColorMode={canChangeColorMode}
+                                canChangeTheme={canChangeTheme}
+                                canCreateCopy={canCreateCopy}
+                                canCreateNew={canCreateNew}
+                                canEditTitle={canEditTitle}
+                                canManageFiles={canManageFiles}
+                                canRemix={canRemix}
+                                canSave={canSave}
+                                canShare={canShare}
+                                className={styles.menuBarPosition}
+                                enableCommunity={enableCommunity}
+                                hasActiveMembership={hasActiveMembership}
+                                isShared={isShared}
+                                isTotallyNormal={isTotallyNormal}
+                                logo={logo}
+                                renderLogin={renderLogin}
+                                showComingSoon={showComingSoon}
+                                onClickAbout={onClickAbout}
+                                onClickLogo={onClickLogo}
+                                onLogOut={onLogOut}
+                                onClickLogin={onClickLogin}
+                                onOpenRegistration={onOpenRegistration}
+                                onProjectTelemetryEvent={onProjectTelemetryEvent}
+                                onSeeCommunity={onSeeCommunity}
+                                onShare={onShare}
+                                onStartSelectingFileUpload={onStartSelectingFileUpload}
+                                onToggleLoginOpen={onToggleLoginOpen}
                                 userOwnsProject={userOwnsProject}
                                 username={username}
-                                onUpdateProjectThumbnail={onUpdateProjectThumbnail}
+                                accountMenuOptions={accountMenuOptions}
                             />
+                        </MenuRefProvider>
+                        }
+                        <Box className={classNames(boxStyles, styles.flexWrapper)}>
                             <Box
-                                className={styles.targetWrapper}
-                                role="region"
-                                aria-label={intl.formatMessage(ariaMessages.targetPane)}
-                                element="section"
+                                role="main"
+                                aria-label={intl.formatMessage(ariaMessages.editor)}
+                                className={styles.editorWrapper}
+                                element="main"
                             >
-                                <TargetPane
+                                <Tabs
+                                    forceRenderTabPanel
+                                    className={tabClassNames.tabs}
+                                    selectedIndex={activeTabIndex}
+                                    selectedTabClassName={tabClassNames.tabSelected}
+                                    selectedTabPanelClassName={tabClassNames.tabPanelSelected}
+                                    onSelect={onActivateTab}
+
+                                    // TODO: focusTabOnClick should be true for accessibility, but currently conflicts
+                                    // with nudge operations in the paint editor. We'll likely need to manage focus
+                                    // differently within the paint editor before we can turn this back on.
+                                    // Repro steps:
+                                    // 1. Click the Costumes tab
+                                    // 2. Select something in the paint editor (say, the cat's face)
+                                    // 3. Press the left or right arrow key
+                                    // Desired behavior: the face should nudge left or right
+                                    // Actual behavior: the Code or Sounds tab is now focused
+                                    focusTabOnClick={false}
+                                >
+                                    <Box
+                                        role="region"
+                                        aria-label={intl.formatMessage(ariaMessages.tabList)}
+                                    >
+                                        <TabList
+                                            className={tabClassNames.tabList}
+                                            role="tablist"
+                                        >
+                                            <Tab
+                                                className={tabClassNames.tab}
+                                                tabIndex="0"
+                                                role="tab"
+                                            >
+                                                <img
+                                                    draggable={false}
+                                                    src={codeIcon}
+                                                />
+                                                <FormattedMessage
+                                                    defaultMessage="Code"
+                                                    description="Button to get to the code panel"
+                                                    id="gui.gui.codeTab"
+                                                />
+                                            </Tab>
+                                            <Tab
+                                                className={tabClassNames.tab}
+                                                onClick={onActivateCostumesTab}
+                                                role="tab"
+                                                tabIndex="0"
+                                            >
+                                                <img
+                                                    draggable={false}
+                                                    src={costumesIcon}
+                                                />
+                                                {targetIsStage ? (
+                                                    <FormattedMessage
+                                                        defaultMessage="Backdrops"
+                                                        description="Button to get to the backdrops panel"
+                                                        id="gui.gui.backdropsTab"
+                                                    />
+                                                ) : (
+                                                    <FormattedMessage
+                                                        defaultMessage="Costumes"
+                                                        description="Button to get to the costumes panel"
+                                                        id="gui.gui.costumesTab"
+                                                    />
+                                                )}
+                                            </Tab>
+                                            <Tab
+                                                className={tabClassNames.tab}
+                                                onClick={onActivateSoundsTab}
+                                                role="tab"
+                                                tabIndex="0"
+                                            >
+                                                <img
+                                                    draggable={false}
+                                                    src={soundsIcon}
+                                                />
+                                                <FormattedMessage
+                                                    defaultMessage="Sounds"
+                                                    description="Button to get to the sounds panel"
+                                                    id="gui.gui.soundsTab"
+                                                />
+                                            </Tab>
+                                        </TabList>
+                                    </Box>
+                                    <TabPanel
+                                        className={tabClassNames.tabPanel}
+                                        role="tabpanel"
+                                    >
+                                        <Box
+                                            className={styles.blocksWrapper}
+                                            role="region"
+                                            aria-label={intl.formatMessage(ariaMessages.codePanel)}
+                                            element="section"
+                                        >
+                                            <Blocks
+                                                key={`${blocksId}/${colorMode}/${theme}`}
+                                                canUseCloud={canUseCloud}
+                                                grow={1}
+                                                isVisible={blocksTabVisible}
+                                                options={{
+                                                    media: `${basePath}static/${
+                                                        colorModeMap[colorMode].blocksMediaFolder
+                                                    }/`
+                                                }}
+                                                stageSize={stageSize}
+                                                theme={theme}
+                                                vm={vm}
+                                                colorMode={colorMode}
+                                            />
+                                        </Box>
+                                        <ExtensionsButton
+                                            intl={intl}
+                                            onExtensionButtonClick={onExtensionButtonClick}
+                                        />
+                                        <Box className={styles.watermark}>
+                                            <Watermark />
+                                        </Box>
+                                    </TabPanel>
+                                    <TabPanel
+                                        className={tabClassNames.tabPanel}
+                                        role="tabpanel"
+                                    >
+                                        {costumesTabVisible ? <CostumeTab
+                                            ariaLabel={targetIsStage ? intl.formatMessage(ariaMessages.backdropsPanel) :
+                                                intl.formatMessage(ariaMessages.costumesPanel)}
+                                            ariaRole="region"
+                                            vm={vm}
+                                            onNewLibraryBackdropClick={onNewLibraryBackdropClick}
+                                            onNewLibraryCostumeClick={onNewLibraryCostumeClick}
+                                        /> : null}
+                                    </TabPanel>
+                                    <TabPanel
+                                        className={tabClassNames.tabPanel}
+                                        role="tabpanel"
+                                    >
+                                        {soundsTabVisible ?
+                                            <SoundTab
+                                                ariaLabel={intl.formatMessage(ariaMessages.soundsPanel)}
+                                                ariaRole="region"
+                                                vm={vm}
+                                            /> : null}
+                                    </TabPanel>
+                                </Tabs>
+                                {backpackVisible && backpackConfigured ? (
+                                    <Backpack
+                                        host={backpackHost}
+                                        ariaRole="region"
+                                        ariaLabel={intl.formatMessage(ariaMessages.backpack)}
+                                    />
+                                ) : null}
+                            </Box>
+
+                            <Box
+                                role="complementary"
+                                aria-label={intl.formatMessage(ariaMessages.stageAndTarget)}
+                                className={classNames(styles.stageAndTargetWrapper, styles[stageSize])}
+                                element="aside"
+                            >
+                                <StageWrapper
+                                    isFullScreen={isFullScreen}
+                                    isRendererSupported={isRendererSupported}
+                                    isRtl={isRtl}
+                                    isCreating={isCreating}
                                     stageSize={stageSize}
                                     vm={vm}
-                                    onNewSpriteClick={onNewSpriteClick}
-                                    onNewBackdropClick={onNewLibraryBackdropClick}
+                                    ariaRole="region"
+                                    ariaLabel={intl.formatMessage(ariaMessages.stage)}
+                                    manuallySaveThumbnails={manuallySaveThumbnails}
+                                    onSetManualThumbnail={onSetManualThumbnail}
+                                    onSetManualThumbnailButtonClick={onSetManualThumbnailButtonClick}
+                                    loading={loading}
+                                    showNewFeatureCallouts={showNewFeatureCallouts}
+                                    userOwnsProject={userOwnsProject}
+                                    username={username}
+                                    onUpdateProjectThumbnail={onUpdateProjectThumbnail}
                                 />
+                                <Box
+                                    className={styles.targetWrapper}
+                                    role="region"
+                                    aria-label={intl.formatMessage(ariaMessages.targetPane)}
+                                    element="section"
+                                >
+                                    <TargetPane
+                                        stageSize={stageSize}
+                                        vm={vm}
+                                        onNewSpriteClick={onNewSpriteClick}
+                                        onNewBackdropClick={onNewLibraryBackdropClick}
+                                    />
+                                </Box>
                             </Box>
                         </Box>
+                        <DragLayer />
                     </Box>
-                    <DragLayer />
-                </Box>
+                </LibraryAssetConfigProvider>
             </ModalFocusProvider>
         );
     }}</MediaQuery>);
@@ -664,6 +672,7 @@ GUIComponent.propTypes = {
     username: PropTypes.string,
     userOwnsProject: PropTypes.bool,
     hideTutorialProjects: PropTypes.bool,
+    libraryAssetUrlTemplate: PropTypes.string,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -11,6 +11,8 @@ import Divider from '../divider/divider.jsx';
 import Filter from '../filter/filter.jsx';
 import TagButton from '../../containers/tag-button.jsx';
 import {legacyConfig} from '../../legacy-config';
+import {buildLibraryAssetServiceUri} from '../../lib/library-asset-url.js';
+import {LibraryAssetConfigContext} from '../../contexts/library-asset-config-context.jsx';
 import Spinner from '../spinner/spinner.jsx';
 import {CATEGORIES} from '../../../src/lib/libraries/decks/index.jsx';
 
@@ -89,12 +91,13 @@ const getAssetTypeForFileExtension = function (fileExtension) {
  * Otherwise it'll return just one `imageSource`.
  * @param {object} item - either a library item or one of a library item's costumes.
  *   The latter is used internally as part of processing an animated thumbnail.
+ * @param {string} libraryAssetUrlTemplate - URL template for library thumbnail assets.
  * @returns {LibraryItem.PropTypes.icons} - an `imageSource` or array of them
  */
-const getItemIcons = function (item) {
+const getItemIcons = function (item, libraryAssetUrlTemplate) {
     const costumes = (item.json && item.json.costumes) || item.costumes;
     if (costumes) {
-        return costumes.map(getItemIcons);
+        return costumes.map(costume => getItemIcons(costume, libraryAssetUrlTemplate));
     }
 
     if (item.rawURL) {
@@ -107,7 +110,11 @@ const getItemIcons = function (item) {
         return {
             assetId: item.assetId,
             assetType: getAssetTypeForFileExtension(item.dataFormat),
-            assetServiceUri: `https://cdn.assets.scratch.mit.edu/internalapi/asset/${item.assetId}.${item.dataFormat}/get/`
+            assetServiceUri: buildLibraryAssetServiceUri(
+                libraryAssetUrlTemplate,
+                item.assetId,
+                item.dataFormat
+            )
         };
     }
 
@@ -117,7 +124,7 @@ const getItemIcons = function (item) {
         return {
             assetId: assetId,
             assetType: getAssetTypeForFileExtension(fileExtension),
-            assetServiceUri: `https://cdn.assets.scratch.mit.edu/internalapi/asset/${md5ext}/get/`
+            assetServiceUri: buildLibraryAssetServiceUri(libraryAssetUrlTemplate, md5ext)
         };
     }
 };
@@ -274,28 +281,34 @@ class LibraryComponent extends React.Component {
     }
     renderElement (data) {
         const key = this.constructKey(data);
-        const icons = getItemIcons(data);
-        return (<LibraryItem
-            bluetoothRequired={data.bluetoothRequired}
-            collaborator={data.collaborator}
-            description={data.description}
-            disabled={data.disabled}
-            extensionId={data.extensionId}
-            featured={data.featured}
-            hidden={data.hidden}
-            icons={icons}
-            id={key}
-            insetIconURL={data.insetIconURL}
-            internetConnectionRequired={data.internetConnectionRequired}
-            isPlaying={this.state.playingItem === key}
-            key={key}
-            name={data.name}
-            showPlayButton={this.props.showPlayButton}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-            onSelect={this.handleSelect}
-            isMemberOnly={data.isMemberOnly}
-        />);
+        return (
+            <LibraryAssetConfigContext.Consumer>
+                {({libraryAssetUrlTemplate}) => {
+                    const icons = getItemIcons(data, libraryAssetUrlTemplate);
+                    return (<LibraryItem
+                        bluetoothRequired={data.bluetoothRequired}
+                        collaborator={data.collaborator}
+                        description={data.description}
+                        disabled={data.disabled}
+                        extensionId={data.extensionId}
+                        featured={data.featured}
+                        hidden={data.hidden}
+                        icons={icons}
+                        id={key}
+                        insetIconURL={data.insetIconURL}
+                        internetConnectionRequired={data.internetConnectionRequired}
+                        isPlaying={this.state.playingItem === key}
+                        key={key}
+                        name={data.name}
+                        showPlayButton={this.props.showPlayButton}
+                        onMouseEnter={this.handleMouseEnter}
+                        onMouseLeave={this.handleMouseLeave}
+                        onSelect={this.handleSelect}
+                        isMemberOnly={data.isMemberOnly}
+                    />);
+                }}
+            </LibraryAssetConfigContext.Consumer>
+        );
     }
     renderData (data) {
         if (this.state.selectedTag !== ALL_TAG.tag || !this.props.withCategories) {

--- a/packages/scratch-gui/src/containers/gui.jsx
+++ b/packages/scratch-gui/src/containers/gui.jsx
@@ -126,6 +126,7 @@ GUI.propTypes = {
     storage: GUIStoragePropType,
     accountMenuOptions: AccountMenuOptionsPropTypes,
     assetHost: PropTypes.string,
+    libraryAssetUrlTemplate: PropTypes.string,
     children: PropTypes.node,
     cloudHost: PropTypes.string,
     dynamicAssets: PropTypes.shape({

--- a/packages/scratch-gui/src/contexts/library-asset-config-context.jsx
+++ b/packages/scratch-gui/src/contexts/library-asset-config-context.jsx
@@ -1,0 +1,43 @@
+import React, {createContext, useMemo} from 'react';
+import PropTypes from 'prop-types';
+
+import {DEFAULT_LIBRARY_ASSET_URL_TEMPLATE} from '../lib/library-asset-url.js';
+
+export const defaultLibraryAssetConfig = {
+    libraryAssetUrlTemplate: DEFAULT_LIBRARY_ASSET_URL_TEMPLATE
+};
+
+export const LibraryAssetConfigContext = createContext(defaultLibraryAssetConfig);
+
+/**
+ * Supplies library asset URL template for all library modals.
+ * Values are expected to be fixed for the editor session (set once by the embedder).
+ * @param {object} props Component props.
+ * @param {React.ReactNode} props.children Child components.
+ * @param {string} [props.libraryAssetUrlTemplate] Full URL template with placeholders such as
+ *   `{assetPath}`. When omitted, defaults to DEFAULT_LIBRARY_ASSET_URL_TEMPLATE
+ *   (`https://cdn.assets.scratch.mit.edu/internalapi/asset/{assetPath}/get/`).
+ * @returns {React.ReactElement} Context provider.
+ */
+export const LibraryAssetConfigProvider = ({
+    children,
+    libraryAssetUrlTemplate
+}) => {
+    const value = useMemo(
+        () => ({
+            libraryAssetUrlTemplate: libraryAssetUrlTemplate || DEFAULT_LIBRARY_ASSET_URL_TEMPLATE
+        }),
+        [libraryAssetUrlTemplate]
+    );
+
+    return (
+        <LibraryAssetConfigContext.Provider value={value}>
+            {children}
+        </LibraryAssetConfigContext.Provider>
+    );
+};
+
+LibraryAssetConfigProvider.propTypes = {
+    children: PropTypes.node,
+    libraryAssetUrlTemplate: PropTypes.string
+};

--- a/packages/scratch-gui/src/lib/library-asset-url.js
+++ b/packages/scratch-gui/src/lib/library-asset-url.js
@@ -1,0 +1,39 @@
+/**
+ * Placeholder substituted in library asset URL templates.
+ * @type {string}
+ */
+export const LIBRARY_ASSET_PATH_PLACEHOLDER = '{assetPath}';
+
+/**
+ * Default library thumbnail URL template (MIT Scratch asset service shape).
+ * Embedders may override via the `libraryAssetUrlTemplate` GUI prop; when unset,
+ * LibraryAssetConfigProvider uses this value. Substitute `{assetPath}` only
+ * (e.g. `cd21514d0531fdffb22204e0ec5ed84a.svg`).
+ * @type {string}
+ * @example
+ * // assetId "abc123", dataFormat "png" →
+ * // https://cdn.assets.scratch.mit.edu/internalapi/asset/abc123.png/get/
+ */
+export const DEFAULT_LIBRARY_ASSET_URL_TEMPLATE =
+    `https://cdn.assets.scratch.mit.edu/internalapi/asset/${LIBRARY_ASSET_PATH_PLACEHOLDER}/get/`;
+
+const resolveLibraryAssetPath = function (assetId, dataFormat) {
+    return dataFormat ?
+        `${assetId}.${dataFormat}` :
+        assetId;
+};
+
+/**
+ * Build a library thumbnail GET URL from a template and asset identifiers.
+ * @param {string} libraryAssetUrlTemplate - URL template from LibraryAssetConfigContext
+ *   (same shape as DEFAULT_LIBRARY_ASSET_URL_TEMPLATE), e.g.
+ *   `https://cdn.assets.scratch.mit.edu/internalapi/asset/{assetPath}/get/`.
+ * @param {string} assetId - Asset id or full md5ext (e.g. "abc123" or "abc123.png")
+ * @param {string} [dataFormat] - File extension when assetId is not md5ext
+ * @returns {string} Full asset service URI
+ */
+export const buildLibraryAssetServiceUri = function (libraryAssetUrlTemplate, assetId, dataFormat) {
+    const template = libraryAssetUrlTemplate || DEFAULT_LIBRARY_ASSET_URL_TEMPLATE;
+    const assetPath = resolveLibraryAssetPath(assetId, dataFormat);
+    return template.split(LIBRARY_ASSET_PATH_PLACEHOLDER).join(assetPath);
+};

--- a/packages/scratch-gui/test/unit/contexts/library-asset-config-context.test.jsx
+++ b/packages/scratch-gui/test/unit/contexts/library-asset-config-context.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+import {
+    LibraryAssetConfigContext,
+    LibraryAssetConfigProvider
+} from '../../../src/contexts/library-asset-config-context.jsx';
+import {DEFAULT_LIBRARY_ASSET_URL_TEMPLATE} from '../../../src/lib/library-asset-url';
+
+const ConfigConsumer = () => (
+    <LibraryAssetConfigContext.Consumer>
+        {({libraryAssetUrlTemplate}) => (
+            <span data-testid="template">{libraryAssetUrlTemplate}</span>
+        )}
+    </LibraryAssetConfigContext.Consumer>
+);
+
+describe('LibraryAssetConfigContext', () => {
+    test('consumer uses default config without a provider', () => {
+        render(<ConfigConsumer />);
+        expect(screen.getByTestId('template').textContent).toBe(
+            DEFAULT_LIBRARY_ASSET_URL_TEMPLATE
+        );
+    });
+
+    test('provider supplies custom URL template', () => {
+        render(
+            <LibraryAssetConfigProvider
+                libraryAssetUrlTemplate="https://cdn.example.com/assets/{assetPath}"
+            >
+                <ConfigConsumer />
+            </LibraryAssetConfigProvider>
+        );
+        expect(screen.getByTestId('template').textContent).toBe(
+            'https://cdn.example.com/assets/{assetPath}'
+        );
+    });
+
+    test('provider defaults to MIT template when prop is unset', () => {
+        render(
+            <LibraryAssetConfigProvider>
+                <ConfigConsumer />
+            </LibraryAssetConfigProvider>
+        );
+        expect(screen.getByTestId('template').textContent).toBe(
+            DEFAULT_LIBRARY_ASSET_URL_TEMPLATE
+        );
+    });
+
+    test('provider value reference is stable when props are unchanged', () => {
+        const seen = [];
+        const captureContextValue = function (value) {
+            seen.push(value);
+            return null;
+        };
+        const Capture = () => (
+            <LibraryAssetConfigContext.Consumer>
+                {captureContextValue}
+            </LibraryAssetConfigContext.Consumer>
+        );
+        const {rerender} = render(
+            <LibraryAssetConfigProvider
+                libraryAssetUrlTemplate="https://api.example.com/{assetPath}"
+            >
+                <Capture />
+            </LibraryAssetConfigProvider>
+        );
+        const first = seen[0];
+        rerender(
+            <LibraryAssetConfigProvider
+                libraryAssetUrlTemplate="https://api.example.com/{assetPath}"
+            >
+                <Capture />
+            </LibraryAssetConfigProvider>
+        );
+        expect(seen[1]).toBe(first);
+    });
+});

--- a/packages/scratch-gui/test/unit/lib/library-asset-url.test.js
+++ b/packages/scratch-gui/test/unit/lib/library-asset-url.test.js
@@ -1,0 +1,56 @@
+import {
+    DEFAULT_LIBRARY_ASSET_URL_TEMPLATE,
+    LIBRARY_ASSET_PATH_PLACEHOLDER,
+    buildLibraryAssetServiceUri
+} from '../../../src/lib/library-asset-url';
+
+const MIT_SHAPED_TEMPLATE =
+    'http://localhost:3009/api/scratch/assets/internalapi/asset/{assetPath}/get/';
+
+describe('buildLibraryAssetServiceUri', () => {
+    test('builds URL with default MIT-shaped template', () => {
+        expect(buildLibraryAssetServiceUri(
+            DEFAULT_LIBRARY_ASSET_URL_TEMPLATE,
+            'abc123',
+            'png'
+        )).toBe(
+            'https://cdn.assets.scratch.mit.edu/internalapi/asset/abc123.png/get/'
+        );
+    });
+
+    test('builds URL with custom MIT-shaped template', () => {
+        expect(buildLibraryAssetServiceUri(
+            MIT_SHAPED_TEMPLATE,
+            'cd21514d0531fdffb22204e0ec5ed84a',
+            'svg'
+        )).toBe(
+            'http://localhost:3009/api/scratch/assets/internalapi/asset/cd21514d0531fdffb22204e0ec5ed84a.svg/get/'
+        );
+    });
+
+    test('builds URL with full md5ext', () => {
+        expect(buildLibraryAssetServiceUri(
+            MIT_SHAPED_TEMPLATE,
+            'cd21514d0531fdffb22204e0ec5ed84a.svg'
+        )).toBe(
+            'http://localhost:3009/api/scratch/assets/internalapi/asset/cd21514d0531fdffb22204e0ec5ed84a.svg/get/'
+        );
+    });
+
+    test('supports alternate URL shapes using {assetPath}', () => {
+        expect(buildLibraryAssetServiceUri(
+            'https://editor-assets.raspberrypi.org/files/{assetPath}',
+            'test_image_1',
+            'png'
+        )).toBe(
+            'https://editor-assets.raspberrypi.org/files/test_image_1.png'
+        );
+    });
+
+    test('exports expected default template and placeholder', () => {
+        expect(LIBRARY_ASSET_PATH_PLACEHOLDER).toBe('{assetPath}');
+        expect(DEFAULT_LIBRARY_ASSET_URL_TEMPLATE).toBe(
+            'https://cdn.assets.scratch.mit.edu/internalapi/asset/{assetPath}/get/'
+        );
+    });
+});


### PR DESCRIPTION
### Proposed Changes

Adds a `libraryAssetUrlTemplate` prop to scratch-gui so embedders can control **how library thumbnail URLs are built** (sprite, costume, backdrop, and sound libraries).

- New `libraryAssetUrlTemplate` prop on the GUI container/component
- `LibraryAssetConfigProvider` context to pass the template into library modals
- `buildLibraryAssetServiceUri()` helper that substitutes `{assetPath}` into the template
- Library components use this when resolving thumbnail/asset URLs

The template controls the **full URL shape**, not only the hostname. Embedders can match whatever asset API they run (path segments, trailing slashes, etc.), as long as they include the `{assetPath}` placeholder where the asset id (and extension when needed) should go.

**Default (unchanged when the prop is omitted):**

```
https://cdn.assets.scratch.mit.edu/internalapi/asset/{assetPath}/get/
```

Example: asset `abc123` with format `png` → `{assetPath}` becomes `abc123.png`:

```
https://cdn.assets.scratch.mit.edu/internalapi/asset/abc123.png/get/
```

**Example embedder override** (same placeholder, different service shape):

```
https://assets.example.com/v1/library/{assetPath}
```

→ `https://assets.example.com/v1/library/abc123.png`

When the prop is omitted, behaviour is unchanged and library assets still load from the standard Scratch CDN (`cdn.assets.scratch.mit.edu`).

### Reason for Changes

Scratch is often embedded in other products (classroom platforms, LMSs, custom editors). Those hosts may need library assets served from **their own infrastructure** instead of the public Scratch CDN — for example:

- Serving assets from the same origin as the host app (CSP, cookies, or auth requirements)
- Routing library requests through a proxy or internal API
- Environments where the default CDN is blocked or inappropriate

Today, library thumbnail URLs are effectively fixed to the Scratch asset service. Project assets can already be configured by embedders via storage/host settings, but library browsing does not have an equivalent hook.

A URL **template** (rather than a fixed host or path prefix) lets each embedder align library requests with their own asset API contract while keeping scratch-gui agnostic of each host's URL layout. This change closes that gap with a small, optional prop and no impact on the default Scratch experience.

### Test Coverage

Unit tests added for:

- `test/unit/lib/library-asset-url.test.js` — URL building from templates, `{assetPath}` substitution, custom URL shapes, and default fallback to the MIT CDN template
- `test/unit/contexts/library-asset-config-context.test.jsx` — context provider supplies the template to consumers and falls back to the default when unset