### PR TITLE
[UEPR-625] Fix stop button not stopping sounds

### DIFF
--- a/packages/scratch-gui/src/components/stop-all/stop-all.jsx
+++ b/packages/scratch-gui/src/components/stop-all/stop-all.jsx
@@ -28,7 +28,6 @@ const StopAllComponent = function (props) {
             className={styles.stopAllButton}
             onClick={onClick}
             aria-label={intl.formatMessage(stopProjectMessage)}
-            disabled={!active}
             data-focusable={isFullScreen || null}
             {...componentProps}
         >


### PR DESCRIPTION
### Resolves

[UEPR-625](https://scratchfoundation.atlassian.net/browse/UEPR-625)

### Proposed Changes

- Do not actually disable the Stop All button when a project is not active

### Reason for Changes

There may be sounds playing due to a "Start Sound" block, that should be stopped when pressing the "Stop All" button, even if there are no actively running blocks at that moment

[UEPR-625]: https://scratchfoundation.atlassian.net/browse/UEPR-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ