### PR TITLE
Fix keyboard events dropped after selecting sprite in UI

### DIFF
--- a/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
+++ b/packages/scratch-gui/src/lib/vm-listener-hoc.jsx
@@ -98,14 +98,9 @@ const vmListenerHOC = function (WrappedComponent) {
             }
         }
         handleKeyDown (e) {
-            // Don't capture keys intended for HTML inputs (e.g. project title).
-            // The Blockly workspace is rendered as SVG, so SVG-targeted events
-            // should always reach the VM for key-sensing — even when a block has
-            // Blockly focus — so that game controls are never silently dropped
-            // while the user is on the Code tab.
-            if (e.target !== document && e.target !== document.body) {
-                if (!(e.target instanceof SVGElement)) return;
-            }
+            // Don't capture keys intended for Blockly inputs.
+            if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement ||
+                e.target.isContentEditable) return;
 
             const key = (!e.key || e.key === 'Dead') ? e.keyCode : e.key;
             this.props.vm.postIOData('keyboard', {

--- a/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
+++ b/packages/scratch-gui/test/unit/util/vm-listener-hoc.test.jsx
@@ -168,15 +168,12 @@ describe('VMListenerHOC', () => {
             />
         );
 
-        // keydown with an HTML target (e.g. project title input) should not be forwarded to VM
-        const inputEl = document.createElement('input');
-        eventTriggers.keydown({key: 'A', target: inputEl});
+        // keyboard events in text inputs are ignored
+        eventTriggers.keydown({key: 'A', target: document.createElement('input')});
         expect(vm.postIOData).not.toHaveBeenLastCalledWith('keyboard', {key: 'A', isDown: true});
 
-        // keydown with an SVG target (Blockly workspace) should always be forwarded to VM
-        // even when a block has Blockly focus, so game controls work from the Code tab
-        const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        eventTriggers.keydown({key: 'A', target: svgEl});
+        // keydown with other non-input targets are sent to the vm via postIOData
+        eventTriggers.keydown({key: 'A', target: document.createElement('div')});
         expect(vm.postIOData).toHaveBeenLastCalledWith('keyboard', {key: 'A', isDown: true});
 
         // keydown/up with target as the document are sent to the vm via postIOData


### PR DESCRIPTION
## Summary
- Forward keydown events to the VM unless the event target is a text input, textarea, or contentEditable element
- Replaces the previous check that dropped keys for any non-document/SVG target, which caused key-sensing blocks (e.g. "when space key pressed") to stop working after clicking a sprite in the sprite selector

Fixes the same root cause reported in scratchfoundation/scratch-gui#10047 (that repo is archived; this monorepo is the active home for scratch-gui).

## Test plan
- [ ] Add a "when space key pressed" block and confirm space still triggers it after clicking a sprite in the sprite list
- [ ] Confirm Blockly number/text field inputs still accept typing without forwarding keys to the VM
- [ ] Run `npm test -- --testPathPattern=vm-listener-hoc` in `packages/scratch-gui`


Made with [Cursor](https://cursor.com)