### PR TITLE
Take avatarBadge prop into account

### DIFF
--- a/packages/scratch-gui/src/components/gui/gui.jsx
+++ b/packages/scratch-gui/src/components/gui/gui.jsx
@@ -201,6 +201,7 @@ const GUIComponent = props => {
         tipsLibraryVisible,
         useExternalPeripheralList,
         username,
+        avatarBadge,
         userOwnsProject,
         hideTutorialProjects,
         vm,
@@ -369,6 +370,7 @@ const GUIComponent = props => {
                             onToggleLoginOpen={onToggleLoginOpen}
                             userOwnsProject={userOwnsProject}
                             username={username}
+                            avatarBadge={avatarBadge}
                             accountMenuOptions={accountMenuOptions}
                         />
                     </MenuRefProvider>
@@ -662,6 +664,7 @@ GUIComponent.propTypes = {
     tipsLibraryVisible: PropTypes.bool,
     useExternalPeripheralList: PropTypes.bool, // true for CDM, false for normal Scratch Link
     username: PropTypes.string,
+    avatarBadge: PropTypes.number,
     userOwnsProject: PropTypes.bool,
     hideTutorialProjects: PropTypes.bool,
     vm: PropTypes.instanceOf(VM).isRequired

--- a/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
+++ b/packages/scratch-gui/src/components/menu-bar/menu-bar.jsx
@@ -737,7 +737,7 @@ const mapStateToProps = (state, ownProps) => {
         loginMenuOpen: loginMenuOpen(state),
         projectTitle: state.scratchGui.projectTitle,
         username: ownProps.username ?? (user ? user.username : null),
-        avatarBadge: user ? user.membership_avatar_badge : null,
+        avatarBadge: ownProps.avatarBadge ?? (user ? user.membership_avatar_badge : null),
         userIsEducator: permissions && permissions.educator,
         vm: state.scratchGui.vm,
         mode220022BC: isTimeTravel220022BC(state),

--- a/packages/scratch-gui/src/containers/gui.jsx
+++ b/packages/scratch-gui/src/containers/gui.jsx
@@ -163,6 +163,7 @@ GUI.propTypes = {
     shouldStopProject: PropTypes.bool,
     telemetryModalVisible: PropTypes.bool,
     username: PropTypes.string,
+    avatarBadge: PropTypes.number,
     userOwnsProject: PropTypes.bool,
     // TODO: Is this unused?
     hideTutorialProjects: PropTypes.bool,


### PR DESCRIPTION
### Resolves

Needed for [IPR-1895 Disable membership integration and make benefits available to all users](https://scratchfoundation.atlassian.net/browse/IPR-1895)

### Proposed Changes

The editor accepts `avatarBadge` prop, which is passed to the menu bar. However, it is then ignored in `mapStateToProps` and the session state is used. We'd like to first check if the prop is available, and only if missing to default to the session state.

### Reason for Changes

We need a way to instruct the editor to display the current user avatar badge in NGP.

### Test Coverage

🙈 