### PR TITLE
Make sure the dist/ folder in scratch-storage is packed

### DIFF
--- a/packages/scratch-paint/package.json
+++ b/packages/scratch-paint/package.json
@@ -17,6 +17,12 @@
   },
   "main": "./dist/web/scratch-paint.js",
   "browser": "./src/index.js",
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "TRADEMARK"
+  ],
   "scripts": {
     "build": "npm run clean && webpack --progress --bail",
     "clean": "rimraf ./dist && mkdirp dist && rimraf ./playground && mkdirp playground",

--- a/packages/scratch-storage/package.json
+++ b/packages/scratch-storage/package.json
@@ -11,6 +11,12 @@
   "main": "./dist/node/scratch-storage.js",
   "browser": "./dist/web/scratch-storage.js",
   "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "LICENSE",
+    "TRADEMARK"
+  ],
   "scripts": {
     "build": "npm run clean && webpack --mode=production",
     "clean": "rimraf dist",


### PR DESCRIPTION
### Resolves

Currently the `/dist` folder in `scratch-storage` is not being packed, because it's globally ignored in the `.gitignore` file on root level, which causes `npm pack` to ignore it by default as well. However, the `/dist` folder includes the `scratch-storage` types, which NGP uses.

When `scratch-storage` was not part of the monorepo, this was fine, because there was no global `.gitignore`, which caused the `/dist` folder to get ignored. 

### Proposed Changes

Add "files" which would get packed both for `scratch-storage` and `scratch-paint`. The same files are packed for the other packages in the monorepo, it looks like this is everything that's needed by consumers.

### Test Coverage

Running` npm pack --dry-run` now includes the `/dist` folder