### PR TITLE
[UEPR-546] Make library asset host configurable

### DIFF
--- a/packages/scratch-gui/src/components/library/library.jsx
+++ b/packages/scratch-gui/src/components/library/library.jsx
@@ -11,6 +11,8 @@ import Divider from '../divider/divider.jsx';
 import Filter from '../filter/filter.jsx';
 import TagButton from '../../containers/tag-button.jsx';
 import {legacyConfig} from '../../legacy-config';
+import {GUIStoragePropType} from '../../gui-config';
+import {buildLibraryAssetUrl} from '../../lib/legacy-library-asset-url';
 import Spinner from '../spinner/spinner.jsx';
 import {CATEGORIES} from '../../../src/lib/libraries/decks/index.jsx';
 
@@ -84,17 +86,35 @@ const getAssetTypeForFileExtension = function (fileExtension) {
 };
 
 /**
+ * Build the URL a library thumbnail is fetched from. Storage implementations decide how
+ * assets are addressed, so the host and the path both come from there. Implementations that
+ * predate `getLibraryAssetUrl` get the public Scratch asset service.
+ * @param {GUIStorage} [storage] - the active storage implementation.
+ * @param {string} assetId - the md5 of the asset.
+ * @param {string} dataFormat - the asset's file extension.
+ * @returns {string} - the URL to fetch the thumbnail from.
+ */
+const getLibraryAssetUrl = function (storage, assetId, dataFormat) {
+    if (!storage || typeof storage.getLibraryAssetUrl !== 'function') {
+        return buildLibraryAssetUrl(assetId, dataFormat);
+    }
+
+    return storage.getLibraryAssetUrl(assetId, dataFormat);
+};
+
+/**
  * Figure out one or more icon(s) for a library item.
  * If it's an animated thumbnail, this will return an array of `imageSource`.
  * Otherwise it'll return just one `imageSource`.
  * @param {object} item - either a library item or one of a library item's costumes.
  *   The latter is used internally as part of processing an animated thumbnail.
+ * @param {GUIStorage} [storage] - the active storage implementation.
  * @returns {LibraryItem.PropTypes.icons} - an `imageSource` or array of them
  */
-const getItemIcons = function (item) {
+const getItemIcons = function (item, storage) {
     const costumes = (item.json && item.json.costumes) || item.costumes;
     if (costumes) {
-        return costumes.map(getItemIcons);
+        return costumes.map(costume => getItemIcons(costume, storage));
     }
 
     if (item.rawURL) {
@@ -107,7 +127,7 @@ const getItemIcons = function (item) {
         return {
             assetId: item.assetId,
             assetType: getAssetTypeForFileExtension(item.dataFormat),
-            assetServiceUri: `https://cdn.assets.scratch.mit.edu/internalapi/asset/${item.assetId}.${item.dataFormat}/get/`
+            assetServiceUri: getLibraryAssetUrl(storage, item.assetId, item.dataFormat)
         };
     }
 
@@ -117,7 +137,7 @@ const getItemIcons = function (item) {
         return {
             assetId: assetId,
             assetType: getAssetTypeForFileExtension(fileExtension),
-            assetServiceUri: `https://cdn.assets.scratch.mit.edu/internalapi/asset/${md5ext}/get/`
+            assetServiceUri: getLibraryAssetUrl(storage, assetId, fileExtension)
         };
     }
 };
@@ -274,7 +294,7 @@ class LibraryComponent extends React.Component {
     }
     renderElement (data) {
         const key = this.constructKey(data);
-        const icons = getItemIcons(data);
+        const icons = getItemIcons(data, this.props.storage);
         return (<LibraryItem
             bluetoothRequired={data.bluetoothRequired}
             collaborator={data.collaborator}
@@ -422,6 +442,7 @@ LibraryComponent.propTypes = {
     onRequestClose: PropTypes.func,
     setStopHandler: PropTypes.func,
     showPlayButton: PropTypes.bool,
+    storage: GUIStoragePropType,
     tags: PropTypes.arrayOf(PropTypes.shape(TagButton.propTypes)),
     title: PropTypes.string.isRequired
 };

--- a/packages/scratch-gui/src/containers/backdrop-library.jsx
+++ b/packages/scratch-gui/src/containers/backdrop-library.jsx
@@ -11,6 +11,7 @@ import mergeDynamicAssets from '../lib/merge-dynamic-assets.js';
 import backdropLibraryContent from '../lib/libraries/backdrops.json';
 import backdropTags from '../lib/libraries/backdrop-tags';
 import LibraryComponent from '../components/library/library.jsx';
+import {GUIStoragePropType} from '../gui-config';
 
 const messages = defineMessages({
     libraryTitle: {
@@ -58,6 +59,7 @@ class BackdropLibrary extends React.Component {
             <LibraryComponent
                 data={mergedAssets}
                 id="backdropLibrary"
+                storage={this.props.storage}
                 tags={backdropTags}
                 title={this.props.intl.formatMessage(messages.libraryTitle)}
                 onItemSelected={this.handleItemSelect}
@@ -68,13 +70,15 @@ class BackdropLibrary extends React.Component {
 };
 
 const mapStateToProps = state => ({
-    dynamicBackdrops: state.scratchGui.dynamicAssets.backdrops
+    dynamicBackdrops: state.scratchGui.dynamicAssets.backdrops,
+    storage: state.scratchGui.config.storage
 });
 
 BackdropLibrary.propTypes = {
     dynamicBackdrops: PropTypes.arrayOf(costumeShape),
     intl: intlShape.isRequired,
     onRequestClose: PropTypes.func,
+    storage: GUIStoragePropType,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/packages/scratch-gui/src/containers/costume-library.jsx
+++ b/packages/scratch-gui/src/containers/costume-library.jsx
@@ -11,6 +11,7 @@ import mergeDynamicAssets from '../lib/merge-dynamic-assets.js';
 import costumeLibraryContent from '../lib/libraries/costumes.json';
 import spriteTags from '../lib/libraries/sprite-tags';
 import LibraryComponent from '../components/library/library.jsx';
+import {GUIStoragePropType} from '../gui-config';
 
 const messages = defineMessages({
     libraryTitle: {
@@ -56,6 +57,7 @@ class CostumeLibrary extends React.PureComponent {
             <LibraryComponent
                 data={data}
                 id="costumeLibrary"
+                storage={this.props.storage}
                 tags={spriteTags}
                 title={this.props.intl.formatMessage(messages.libraryTitle)}
                 onItemSelected={this.handleItemSelected}
@@ -66,13 +68,15 @@ class CostumeLibrary extends React.PureComponent {
 };
 
 const mapStateToProps = state => ({
-    dynamicCostumes: state.scratchGui.dynamicAssets.costumes
+    dynamicCostumes: state.scratchGui.dynamicAssets.costumes,
+    storage: state.scratchGui.config.storage
 });
 
 CostumeLibrary.propTypes = {
     dynamicCostumes: PropTypes.arrayOf(costumeShape),
     intl: intlShape.isRequired,
     onRequestClose: PropTypes.func,
+    storage: GUIStoragePropType,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/packages/scratch-gui/src/containers/sprite-library.jsx
+++ b/packages/scratch-gui/src/containers/sprite-library.jsx
@@ -13,6 +13,7 @@ import randomizeSpritePosition from '../lib/randomize-sprite-position';
 import spriteTags from '../lib/libraries/sprite-tags';
 
 import LibraryComponent from '../components/library/library.jsx';
+import {GUIStoragePropType} from '../gui-config';
 
 const messages = defineMessages({
     libraryTitle: {
@@ -54,6 +55,7 @@ class SpriteLibrary extends React.PureComponent {
             <LibraryComponent
                 data={data}
                 id="spriteLibrary"
+                storage={this.props.storage}
                 tags={spriteTags}
                 title={this.props.intl.formatMessage(messages.libraryTitle)}
                 onItemSelected={this.handleItemSelect}
@@ -64,7 +66,8 @@ class SpriteLibrary extends React.PureComponent {
 }
 
 const mapStateToProps = state => ({
-    dynamicSprites: state.scratchGui.dynamicAssets.sprites
+    dynamicSprites: state.scratchGui.dynamicAssets.sprites,
+    storage: state.scratchGui.config.storage
 });
 
 SpriteLibrary.propTypes = {
@@ -72,6 +75,7 @@ SpriteLibrary.propTypes = {
     intl: intlShape.isRequired,
     onActivateBlocksTab: PropTypes.func.isRequired,
     onRequestClose: PropTypes.func,
+    storage: GUIStoragePropType,
     vm: PropTypes.instanceOf(VM).isRequired
 };
 

--- a/packages/scratch-gui/src/gui-config.ts
+++ b/packages/scratch-gui/src/gui-config.ts
@@ -21,6 +21,15 @@ export interface GUIStorage {
     setTranslatorFunction?(formatMessageFn: TranslatorFunction): void;
     setBackpackHost?(host: string): void;
 
+    /**
+     * Constructs the complete URL for fetching a library asset thumbnail to use as an image source.
+     * This method builds the full URL rather than just the host, since different implementations
+     * may address assets differently.
+     *
+     * If not provided, asset thumbnails default to being fetched from the legacy Scratch asset service.
+     */
+    getLibraryAssetUrl?(assetId: string, dataFormat: string): string;
+
     saveProject(
         projectId: ProjectId | null | undefined,
         vmState: string,
@@ -207,6 +216,8 @@ export const GUIStoragePropType = PropTypes.shape({
     setAssetHost: PropTypes.func,
     setTranslatorFunction: PropTypes.func,
     setBackpackHost: PropTypes.func,
+
+    getLibraryAssetUrl: PropTypes.func,
 
     saveProject: PropTypes.func.isRequired,
 

--- a/packages/scratch-gui/src/lib/legacy-library-asset-url.ts
+++ b/packages/scratch-gui/src/lib/legacy-library-asset-url.ts
@@ -1,0 +1,17 @@
+/** Host serving library assets when no library asset host is configured. */
+const LEGACY_LIBRARY_ASSET_HOST = 'https://cdn.assets.scratch.mit.edu';
+
+/**
+ * Build the URL a library asset is fetched from, in the shape Scratch's asset service uses.
+ * @param {string} assetId - the md5 of the asset.
+ * @param {string} dataFormat - the asset's file extension.
+ * @param {string} [host] - the host serving the assets, without a trailing slash.
+ *   When omitted or empty, the public Scratch asset service is used.
+ * @returns {string} - the URL to fetch the asset from.
+ */
+export const buildLibraryAssetUrl = (assetId: string, dataFormat: string, host?: string): string => {
+    if (!host) {
+        return `${LEGACY_LIBRARY_ASSET_HOST}/internalapi/asset/${assetId}.${dataFormat}/get/`;
+    }
+    return `${host}/internalapi/asset/${assetId}.${dataFormat}/get/`;
+};

--- a/packages/scratch-gui/src/lib/legacy-storage.ts
+++ b/packages/scratch-gui/src/lib/legacy-storage.ts
@@ -6,6 +6,7 @@ import {LegacyBackpackStorage} from './legacy-backpack-storage';
 import CloudProvider from './cloud-provider';
 
 import saveProjectToServer from '../lib/save-project-to-server';
+import {buildLibraryAssetUrl} from './legacy-library-asset-url';
 
 export class LegacyStorage implements GUIStorage {
     private projectHost?: string;
@@ -65,6 +66,13 @@ export class LegacyStorage implements GUIStorage {
 
     setAssetHost (host: string): void {
         this.assetHost = host;
+    }
+
+    getLibraryAssetUrl (assetId: string, dataFormat: string): string {
+        // Currently defaults to the legacy library asset host.
+        // Consider changing this to use the asset host if we want to start serving library assets
+        // from the asset host instead
+        return buildLibraryAssetUrl(assetId, dataFormat);
     }
 
     setTranslatorFunction (translator: TranslatorFunction): void {


### PR DESCRIPTION
### Resolves

[UEPR-546](https://scratchfoundation.atlassian.net/browse/UEPR-546)

### Proposed Changes

- Add `getLibraryAssetUrl` method in the `GUIStorage` configuration
- Make the legacy storage default to the currently used URL to avoid any regressions

### Reason for Changes
Library thumbnail URLs were hardcoded to `https://cdn.assets.scratch.mit.edu`, making the asset host non-configurable for other platforms. 

[UEPR-546]: https://scratchfoundation.atlassian.net/browse/UEPR-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ