### PR TITLE
fix(vm): missing check for thread status after executing hats and typo of stackFrames in retireThread

### DIFF
--- a/packages/scratch-vm/src/engine/runtime.js
+++ b/packages/scratch-vm/src/engine/runtime.js
@@ -1926,6 +1926,10 @@ class Runtime extends EventEmitter {
         // threads are stepped. See ScratchRuntime.as for original implementation
         newThreads.forEach(thread => {
             execute(this.sequencer, thread);
+            if (thread.status === Thread.STATUS_DONE) {
+                // Thread might be done after `execute`.
+                return;
+            }
             thread.goToNextBlock();
         });
         return newThreads;

--- a/packages/scratch-vm/src/engine/sequencer.js
+++ b/packages/scratch-vm/src/engine/sequencer.js
@@ -352,7 +352,7 @@ class Sequencer {
      */
     retireThread (thread) {
         thread.stack = [];
-        thread.stackFrame = [];
+        thread.stackFrames = [];
         thread.requestScriptGlowInFrame = false;
         thread.status = Thread.STATUS_DONE;
     }

--- a/packages/scratch-vm/src/engine/thread.js
+++ b/packages/scratch-vm/src/engine/thread.js
@@ -251,7 +251,7 @@ class Thread {
     /**
      * Reset the stack frame for use by the next block.
      * (avoids popping and re-pushing a new stack frame - keeps the warpmode the same
-     * @param {string} blockId Block ID to push to stack.
+     * @param {string | null} blockId Block ID to push to stack.
      */
     reuseStackForNextBlock (blockId) {
         this.stack[this.stack.length - 1] = blockId;


### PR DESCRIPTION
### Resolves

Resolves #685 

- Typo of `thread.stackFrames` in `Sequencer.retireThread`, leading to uncleared stack frames.
- Thread status should be checked before invoking `Thread.goToNextBlock` in `startHats`, since the thread maybe done after calling `execute` and `thead.goToNextBlock()` will raise an error if the above typo is fixed.

### Proposed Changes

- Fix typo of `thread.stackFrames` in `Sequencer.retireThread`.
- Check thread status before calling `thead.goToNextBlock()`. Thread will only go to next block iff it hasn't been done.
- Allow param of `reuseStackForNextBlock` to be null in jsdoc.

### Reason for Changes

Stackframes is not cleared when thread is retired due to typo error. To fix that typo, thread status must be checked before invoking `thread.goToNextBlock()` in `startHats`. Previously, when calling `goToNextBlock`, `thread.stack` is empty and `thread.stackFrames` is not empty, then the following code:

https://github.com/scratchfoundation/scratch-editor/blob/a54b373f5e265283ff533d277f00329f9dd8ea03/packages/scratch-vm/src/engine/thread.js#L256-L259

will execute as normal, since `thread.stack[-1] = null;` is valid in javascript. It will assign null value to property '-1', and `thread.stack.length` will keep 0.

### Test Coverage

pass `vm/integration/stack-click.js`
