### PR TITLE
fix(vm): resolve dangling variable references the way the runtime does

### DIFF
--- a/packages/scratch-vm/src/engine/runtime.js
+++ b/packages/scratch-vm/src/engine/runtime.js
@@ -2595,12 +2595,16 @@ class Runtime extends EventEmitter {
      * the global before each target repairs its own references keeps those targets
      * sharing it rather than each minting a private local.
      *
-     * A same-name local on any referencing target is a stronger claim: that target
-     * would have resolved the reference to its own local by name at execution time,
-     * so the id is left for the per-target repair. Likewise when a same-name global
-     * already exists, since the per-target repair remaps to it. Broadcasts are
-     * skipped because they only ever live on the stage, so every target's repair
-     * already coalesces them there.
+     * An id defined on any target in the project does not qualify, even for
+     * targets that cannot see that definition: it is a stale reference to that
+     * target's local (a script once copied to other sprites), and the runtime
+     * would have given each other sprite its own local. A same-name local on any
+     * referencing target is likewise a stronger claim, judged by that target's own
+     * field name and type: it would have resolved the reference to its own local
+     * by name at execution time, so the id is left for the per-target repair. So
+     * is a same-name global, since the per-target repair remaps to it. Broadcasts
+     * are skipped because they only ever live on the stage, so every target's
+     * repair already coalesces them there.
      *
      * Run before `Target.reconcileVariableReferences` on whole-project load.
      * @param {Array<Target>} targets The targets being installed.
@@ -2609,34 +2613,42 @@ class Runtime extends EventEmitter {
         const stage = this.getTargetForStage();
         if (!stage) return;
 
+        const definedIds = new Set();
+        for (const target of targets) {
+            for (const varId in target.variables) {
+                if (Object.prototype.hasOwnProperty.call(target.variables, varId)) definedIds.add(varId);
+            }
+        }
+
+        // Each referring target keeps its own field name and type: two targets may
+        // display the same missing id under different stale names.
         const referrers = Object.create(null);
         for (const target of targets) {
             const references = target.blocks.getAllVariableAndListReferences();
             for (const varId in references) {
-                if (target.lookupVariableById(varId)) continue;
+                if (definedIds.has(varId)) continue;
                 const ref = references[varId][0];
-                if (!referrers[varId]) {
-                    referrers[varId] = {
-                        name: ref.referencingField.value,
-                        type: ref.type,
-                        targets: []
-                    };
-                }
-                referrers[varId].targets.push(target);
+                if (!referrers[varId]) referrers[varId] = [];
+                referrers[varId].push({
+                    target,
+                    name: ref.referencingField.value,
+                    type: ref.type
+                });
             }
         }
 
         for (const varId in referrers) {
-            const {name, type, targets: owners} = referrers[varId];
-            if (owners.length < 2) continue;
+            const refs = referrers[varId];
+            if (refs.length < 2) continue;
             // skipStage: only a local shadows here. (For the stage itself, "local"
             // means the globals, which the next check covers anyway.)
-            if (owners.some(owner => owner.lookupVariableByNameAndType(name, type, true))) continue;
-            if (stage.lookupVariableByNameAndType(name, type)) continue;
+            if (refs.some(({target, name, type}) => target.lookupVariableByNameAndType(name, type, true))) continue;
+            if (refs.some(({name, type}) => stage.lookupVariableByNameAndType(name, type))) continue;
+            const {name, type} = refs[0];
             stage.createVariable(varId, name, type);
             log.warn(
                 `Restored missing shared variable '${varId}' (name '${name}', type '${type}') as a global; ` +
-                `referenced by ${owners.map(owner => `'${owner.getName()}'`).join(', ')}.`
+                `referenced by ${refs.map(({target}) => `'${target.getName()}'`).join(', ')}.`
             );
         }
     }

--- a/packages/scratch-vm/src/engine/runtime.js
+++ b/packages/scratch-vm/src/engine/runtime.js
@@ -104,7 +104,7 @@ const ArgumentTypeMap = (() => {
     };
     map[ArgumentType.IMAGE] = {
         // Inline images are weird because they're not actually "arguments".
-        // They are more analagous to the label on a block.
+        // They are more analogous to the label on a block.
         fieldType: 'field_image'
     };
     return map;
@@ -323,7 +323,7 @@ class Runtime extends EventEmitter {
          */
         this.currentStepTime = null;
 
-        // Set an intial value for this.currentMSecs
+        // Set an initial value for this.currentMSecs
         this.updateCurrentMSecs();
 
         /**
@@ -366,7 +366,7 @@ class Runtime extends EventEmitter {
         const newCloudDataManager = cloudDataManager();
 
         /**
-         * Check wether the runtime has any cloud data.
+         * Check whether the runtime has any cloud data.
          * @type {function}
          * @returns {boolean} Whether or not the runtime currently has any
          * cloud variables.
@@ -1260,7 +1260,7 @@ class Runtime extends EventEmitter {
     }
 
     /**
-     * Helper for _convertPlaceholdes which handles inline images which are a specialized case of block "arguments".
+     * Helper for _convertPlaceholders which handles inline images which are a specialized case of block "arguments".
      * @param {object} argInfo Metadata about the inline image as specified by the extension
      * @returns {object} JSON blob for a scratch-blocks image field.
      * @private
@@ -1981,7 +1981,7 @@ class Runtime extends EventEmitter {
     /**
      * Move a target in the execution order by a relative amount.
      *
-     * A positve number will make the target execute earlier. A negative number
+     * A positive number will make the target execute earlier. A negative number
      * will make the target execute later in the order.
      * @param {Target} executableTarget target to move
      * @param {number} delta number of positions to move target by
@@ -2582,6 +2582,63 @@ class Runtime extends EventEmitter {
             varNames = varNames.concat(targetVarNames);
         }
         return varNames;
+    }
+
+    /**
+     * Restore, as globals on the stage, variables and lists whose definitions are
+     * missing from the project but which are still referenced from more than one
+     * target.
+     *
+     * A definition-dropping bug once left references pointing at ids defined
+     * nowhere. When several targets share such an id they almost certainly shared
+     * one variable, and the shared id is the strongest evidence of that. Restoring
+     * the global before each target repairs its own references keeps those targets
+     * sharing it rather than each minting a private local.
+     *
+     * A same-name local on any referencing target is a stronger claim: that target
+     * would have resolved the reference to its own local by name at execution time,
+     * so the id is left for the per-target repair. Likewise when a same-name global
+     * already exists, since the per-target repair remaps to it. Broadcasts are
+     * skipped because they only ever live on the stage, so every target's repair
+     * already coalesces them there.
+     *
+     * Run before `Target.reconcileVariableReferences` on whole-project load.
+     * @param {Array<Target>} targets The targets being installed.
+     */
+    restoreSharedMissingDefinitions (targets) {
+        const stage = this.getTargetForStage();
+        if (!stage) return;
+
+        const referrers = Object.create(null);
+        for (const target of targets) {
+            const references = target.blocks.getAllVariableAndListReferences();
+            for (const varId in references) {
+                if (target.lookupVariableById(varId)) continue;
+                const ref = references[varId][0];
+                if (!referrers[varId]) {
+                    referrers[varId] = {
+                        name: ref.referencingField.value,
+                        type: ref.type,
+                        targets: []
+                    };
+                }
+                referrers[varId].targets.push(target);
+            }
+        }
+
+        for (const varId in referrers) {
+            const {name, type, targets: owners} = referrers[varId];
+            if (owners.length < 2) continue;
+            // skipStage: only a local shadows here. (For the stage itself, "local"
+            // means the globals, which the next check covers anyway.)
+            if (owners.some(owner => owner.lookupVariableByNameAndType(name, type, true))) continue;
+            if (stage.lookupVariableByNameAndType(name, type)) continue;
+            stage.createVariable(varId, name, type);
+            log.warn(
+                `Restored missing shared variable '${varId}' (name '${name}', type '${type}') as a global; ` +
+                `referenced by ${owners.map(owner => `'${owner.getName()}'`).join(', ')}.`
+            );
+        }
     }
 
     /**

--- a/packages/scratch-vm/src/engine/runtime.js
+++ b/packages/scratch-vm/src/engine/runtime.js
@@ -2628,6 +2628,10 @@ class Runtime extends EventEmitter {
             for (const varId in references) {
                 if (definedIds.has(varId)) continue;
                 const ref = references[varId][0];
+                // A field serialized without an id is collected under the key
+                // "undefined". Two such fields on different targets share nothing but
+                // that accident, so leave them to the per-target repair.
+                if (typeof ref.referencingField.id !== 'string') continue;
                 if (!referrers[varId]) referrers[varId] = [];
                 referrers[varId].push({
                     target,

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -766,8 +766,10 @@ class Target extends EventEmitter {
                         // Only reachable for broadcasts; display the canonical name.
                         conflictNamesToReplace[varId] = existingVar.name;
                     }
-                    const scope = Object.prototype.hasOwnProperty.call(this.variables, existingVar.id) ?
-                        'local' : 'stage';
+                    // On the stage, "this.variables" holds the globals; only a sprite's own
+                    // variable is local.
+                    const isOwnVariable = Object.prototype.hasOwnProperty.call(this.variables, existingVar.id);
+                    const scope = (isOwnVariable && !this.isStage) ? 'local' : 'stage';
                     log.warn(
                         `Reconciled dangling reference on '${this.getName()}': remapped id '${varId}' ` +
                         `(name '${varName}', type '${varType}') to existing ${scope} variable '${existingVar.id}'.`

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -668,13 +668,15 @@ class Target extends EventEmitter {
      * - If the referenced id is not defined anywhere, this target is checked for
      *   a variable with the same name and type, then the stage. If one exists,
      *   the field id is remapped to it. A sprite-local match wins over a global
-     *   one, exactly as it does at execution time.
-     * - Otherwise a new definition is created. By default it is created on this
-     *   target with the referenced name, as the runtime would have on first
-     *   execution. Broadcasts and references on the stage itself are always
-     *   created on the stage. With `createMissingOnStage` set, the new
-     *   definition is instead created on the stage with a non-conflicting name
-     *   and the field name is updated to match.
+     *   one, exactly as it does at execution time. Broadcasts match by name
+     *   case-insensitively, as `lookupBroadcastByInputValue` does.
+     * - Otherwise a new definition is created under the referenced name, as the
+     *   runtime would have on first execution: on this target, or on the stage
+     *   for broadcasts and for references on the stage itself. A same-named
+     *   local on another sprite is an ordinary Scratch configuration and does
+     *   not cause a rename. With `createMissingOnStage` set, the new definition
+     *   is instead created on the stage with a name that collides with nothing
+     *   in the project, and the field name is updated to match.
      *
      * Used during whole-project load to repair projects corrupted by historical
      * bugs that left dangling references, and as the definition-creation phase
@@ -693,13 +695,13 @@ class Target extends EventEmitter {
         const allReferences = this.blocks.getAllVariableAndListReferences(null, true);
         const conflictIdsToReplace = Object.create(null);
         const conflictNamesToReplace = Object.create(null);
-        // When a dangling reference triggers creation of a new stage variable, remember
-        // the original (pre-bump) name so subsequent dangling references with the same
-        // original name and type coalesce to the same stage variable instead of creating
-        // a second one. Scratchers who pasted scripts referencing what they called
-        // "score" twice almost certainly meant one variable, not two.
-        // (Locally-created definitions keep their original name, so later dangling
-        // references to that name coalesce through the by-name lookup instead.)
+        // When a dangling reference triggers creation of a new stage variable with a
+        // bumped name (createMissingOnStage only), remember the original name so
+        // subsequent dangling references with the same original name and type coalesce
+        // to the same stage variable instead of creating a second one. Scratchers who
+        // pasted scripts referencing what they called "score" twice almost certainly
+        // meant one variable, not two. (Definitions created under their original name
+        // need no such bookkeeping: later references find them via the by-name lookup.)
         const createdForOriginalName = Object.create(null);
         const originalNameKey = (name, type) => `${type}\u0000${name}`;
 
@@ -746,10 +748,20 @@ class Target extends EventEmitter {
             const varRef = allReferences[varId][0];
             const varName = varRef.referencingField.value;
             const varType = varRef.type;
-            const existingVar = this.lookupVariableByNameAndType(varName, varType);
+            const isBroadcast = varType === Variable.BROADCAST_MESSAGE_TYPE;
+            // Broadcast names match case-insensitively at runtime (hat matching and
+            // lookupBroadcastByInputValue both ignore case), so match the same way here
+            // rather than creating a second broadcast that differs only in case.
+            const existingVar = isBroadcast ?
+                stage.lookupBroadcastByInputValue(varName) :
+                this.lookupVariableByNameAndType(varName, varType);
             if (existingVar) {
                 if (!conflictIdsToReplace[varId]) {
                     conflictIdsToReplace[varId] = existingVar.id;
+                    if (existingVar.name !== varName) {
+                        // Only reachable for broadcasts; display the canonical name.
+                        conflictNamesToReplace[varId] = existingVar.name;
+                    }
                     const scope = Object.prototype.hasOwnProperty.call(this.variables, existingVar.id) ?
                         'local' : 'stage';
                     log.warn(
@@ -757,25 +769,10 @@ class Target extends EventEmitter {
                         `(name '${varName}', type '${varType}') to existing ${scope} variable '${existingVar.id}'.`
                     );
                 }
-            } else if (
-                !createMissingOnStage &&
-                !this.isStage &&
-                varType !== Variable.BROADCAST_MESSAGE_TYPE
-            ) {
-                // Nothing in scope has this name, so create it here with the referenced
-                // name, as the runtime's lookupOrCreateVariable / lookupOrCreateList would
-                // have on first execution. The name can't collide with anything in scope
-                // (the lookup above just failed), and a same-named local on another
-                // sprite is an ordinary Scratch configuration. Later dangling references
-                // to this name on this target now resolve to it via the by-name lookup.
-                this.createVariable(varId, varName, varType);
-                // Bring any other references to this id into agreement on the name.
-                conflictNamesToReplace[varId] = varName;
-                log.warn(
-                    `Reconciled dangling reference on '${this.getName()}': created local variable ` +
-                    `'${varId}' (name '${varName}', type '${varType}').`
-                );
-            } else {
+            } else if (createMissingOnStage) {
+                // Sprite import / backpack paste: a reference still undefined here was a
+                // global in the source project. Recreate it on the stage under a name
+                // that collides with nothing in this project.
                 const coalesceKey = originalNameKey(varName, varType);
                 const earlierCreated = createdForOriginalName[coalesceKey];
                 if (earlierCreated) {
@@ -809,6 +806,25 @@ class Target extends EventEmitter {
                         );
                     }
                 }
+            } else {
+                // Nothing in scope has this name, so create it under the referenced name,
+                // as the runtime's lookupOrCreateVariable / lookupOrCreateList would have
+                // on first execution: on this target, or on the stage for broadcasts and
+                // for the stage's own references. The name can't collide with anything in
+                // scope (the lookup above just failed). A same-named local on another
+                // sprite is an ordinary Scratch configuration, so no rename is needed, and
+                // renaming would break name-based access such as "i of Stage" in a
+                // sensing block. Later dangling references to this name on this target
+                // resolve to the new definition via the by-name lookup.
+                const owner = isBroadcast ? stage : this;
+                owner.createVariable(varId, varName, varType);
+                // Bring any other references to this id into agreement on the name.
+                conflictNamesToReplace[varId] = varName;
+                const scope = owner.isStage ? 'stage' : 'local';
+                log.warn(
+                    `Reconciled dangling reference on '${this.getName()}': created ${scope} variable ` +
+                    `'${varId}' (name '${varName}', type '${varType}').`
+                );
             }
         }
 

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -672,8 +672,8 @@ class Target extends EventEmitter {
      *   case-insensitively, as `lookupBroadcastByInputValue` does.
      * - Otherwise a new definition is created under the referenced name, as the
      *   runtime would have on first execution: on this target, or on the stage
-     *   for broadcasts, for cloud-prefixed names, and for references on the
-     *   stage itself. A same-named local on another sprite is an ordinary
+     *   for broadcasts, for cloud-prefixed scalar names, and for references on
+     *   the stage itself. A same-named local on another sprite is an ordinary
      *   Scratch configuration and does not cause a rename. With
      *   `createMissingOnStage` set, the new definition is instead created on
      *   the stage with a name that collides with nothing in the project, and
@@ -820,9 +820,12 @@ class Target extends EventEmitter {
                 // renaming would break name-based access such as "i of Stage" in a
                 // sensing block. Later dangling references to this name on this target
                 // resolve to the new definition via the by-name lookup.
-                // A name carrying the cloud prefix belonged to a cloud variable, and those
-                // are always global; a sprite-local "☁ score" would only confuse.
-                const isCloudName = typeof varName === 'string' && varName.startsWith(Variable.CLOUD_PREFIX);
+                // A scalar whose name carries the cloud prefix belonged to a cloud
+                // variable, and those are always global; a sprite-local "☁ score" would
+                // only confuse. Only scalars can be cloud, so a list keeps its scope.
+                const isCloudName = varType === Variable.SCALAR_TYPE &&
+                    typeof varName === 'string' &&
+                    varName.startsWith(Variable.CLOUD_PREFIX);
                 const owner = (isBroadcast || isCloudName) ? stage : this;
                 owner.createVariable(varId, varName, varType);
                 // Bring any other references to this id into agreement on the name.

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -672,8 +672,7 @@ class Target extends EventEmitter {
      *   case-insensitively, as `lookupBroadcastByInputValue` does.
      * - Otherwise a new definition is created under the referenced name, as the
      *   runtime would have on first execution: on this target, or on the stage
-     *   for broadcasts, for cloud-prefixed scalar names, and for references on
-     *   the stage itself. A same-named local on another sprite is an ordinary
+     *   for broadcasts and for references on the stage itself. A same-named local on another sprite is an ordinary
      *   Scratch configuration and does not cause a rename. With
      *   `createMissingOnStage` set, the new definition is instead created on
      *   the stage with a name that collides with nothing in the project, and
@@ -822,13 +821,7 @@ class Target extends EventEmitter {
                 // renaming would break name-based access such as "i of Stage" in a
                 // sensing block. Later dangling references to this name on this target
                 // resolve to the new definition via the by-name lookup.
-                // A scalar whose name carries the cloud prefix belonged to a cloud
-                // variable, and those are always global; a sprite-local "☁ score" would
-                // only confuse. Only scalars can be cloud, so a list keeps its scope.
-                const isCloudName = varType === Variable.SCALAR_TYPE &&
-                    typeof varName === 'string' &&
-                    varName.startsWith(Variable.CLOUD_PREFIX);
-                const owner = (isBroadcast || isCloudName) ? stage : this;
+                const owner = isBroadcast ? stage : this;
                 owner.createVariable(varId, varName, varType);
                 // Bring any other references to this id into agreement on the name.
                 conflictNamesToReplace[varId] = varName;

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -672,11 +672,15 @@ class Target extends EventEmitter {
      *   case-insensitively, as `lookupBroadcastByInputValue` does.
      * - Otherwise a new definition is created under the referenced name, as the
      *   runtime would have on first execution: on this target, or on the stage
-     *   for broadcasts and for references on the stage itself. A same-named
-     *   local on another sprite is an ordinary Scratch configuration and does
-     *   not cause a rename. With `createMissingOnStage` set, the new definition
-     *   is instead created on the stage with a name that collides with nothing
-     *   in the project, and the field name is updated to match.
+     *   for broadcasts, for cloud-prefixed names, and for references on the
+     *   stage itself. A same-named local on another sprite is an ordinary
+     *   Scratch configuration and does not cause a rename. With
+     *   `createMissingOnStage` set, the new definition is instead created on
+     *   the stage with a name that collides with nothing in the project, and
+     *   the field name is updated to match.
+     *
+     * Ids shared by several targets are handled first by
+     * `Runtime.restoreSharedMissingDefinitions` on whole-project load.
      *
      * Used during whole-project load to repair projects corrupted by historical
      * bugs that left dangling references, and as the definition-creation phase
@@ -816,7 +820,10 @@ class Target extends EventEmitter {
                 // renaming would break name-based access such as "i of Stage" in a
                 // sensing block. Later dangling references to this name on this target
                 // resolve to the new definition via the by-name lookup.
-                const owner = isBroadcast ? stage : this;
+                // A name carrying the cloud prefix belonged to a cloud variable, and those
+                // are always global; a sprite-local "☁ score" would only confuse.
+                const isCloudName = typeof varName === 'string' && varName.startsWith(Variable.CLOUD_PREFIX);
+                const owner = (isBroadcast || isCloudName) ? stage : this;
                 owner.createVariable(varId, varName, varType);
                 // Bring any other references to this id into agreement on the name.
                 conflictNamesToReplace[varId] = varName;

--- a/packages/scratch-vm/src/engine/target.js
+++ b/packages/scratch-vm/src/engine/target.js
@@ -105,7 +105,7 @@ class Target extends EventEmitter {
     }
 
     /**
-     * Clear all edge-activaed hat values.
+     * Clear all edge-activated hat values.
      */
     clearEdgeActivatedValues () {
         this._edgeActivatedHatValues = {};
@@ -239,7 +239,7 @@ class Target extends EventEmitter {
      * Search begins for local lists; then look for globals.
      * @param {!string} id Id of the list.
      * @param {!string} name Name of the list.
-     * @returns {!Varible} Variable object representing the found/created list.
+     * @returns {!Variable} Variable object representing the found/created list.
      */
     lookupOrCreateList (id, name) {
         let list = this.lookupVariableById(id);
@@ -655,23 +655,37 @@ class Target extends EventEmitter {
 
     /**
      * Reconciles variable, list, and broadcast references on this target against
-     * the variables actually defined in the project, creating definitions on the
-     * stage for any references whose ids are not defined anywhere. Does not
-     * rename any existing variables.
+     * the variables actually defined in the project, creating definitions for any
+     * references whose ids are not defined anywhere. Does not rename any existing
+     * variables.
      *
-     * For each variable, list, or broadcast referenced by a block on this target:
+     * Resolution mirrors what the runtime's `lookupOrCreateVariable` and
+     * `lookupOrCreateList` do when a block executes, so repairing a project at
+     * load time gives the same result as running it did before the repair
+     * existed. For each variable, list, or broadcast referenced by a block:
      * - If the referenced id is found locally on this sprite or on the stage,
      *   the reference is already correct and nothing happens.
-     * - If the referenced id is not defined anywhere, the stage is checked for a
-     *   variable with the same name and type. If one exists, the field id is
-     *   remapped to that existing global. Otherwise, a new global is created on
-     *   the stage with a non-conflicting name and the field name is updated.
+     * - If the referenced id is not defined anywhere, this target is checked for
+     *   a variable with the same name and type, then the stage. If one exists,
+     *   the field id is remapped to it. A sprite-local match wins over a global
+     *   one, exactly as it does at execution time.
+     * - Otherwise a new definition is created. By default it is created on this
+     *   target with the referenced name, as the runtime would have on first
+     *   execution. Broadcasts and references on the stage itself are always
+     *   created on the stage. With `createMissingOnStage` set, the new
+     *   definition is instead created on the stage with a non-conflicting name
+     *   and the field name is updated to match.
      *
      * Used during whole-project load to repair projects corrupted by historical
      * bugs that left dangling references, and as the definition-creation phase
      * of `fixUpVariableReferences` for sprite import and backpack paste.
+     * @param {boolean} [createMissingOnStage] Create definitions for references
+     * found nowhere as globals on the stage rather than locally. Sprite
+     * import and backpack paste use this, since an exported sprite carries its own
+     * locals and anything still undefined must have been a global in the source
+     * project.
      */
-    reconcileVariableReferences () {
+    reconcileVariableReferences (createMissingOnStage = false) {
         if (!this.runtime) return;
         const stage = this.runtime.getTargetForStage();
         if (!stage || !stage.variables) return;
@@ -684,6 +698,8 @@ class Target extends EventEmitter {
         // original name and type coalesce to the same stage variable instead of creating
         // a second one. Scratchers who pasted scripts referencing what they called
         // "score" twice almost certainly meant one variable, not two.
+        // (Locally-created definitions keep their original name, so later dangling
+        // references to that name coalesce through the by-name lookup instead.)
         const createdForOriginalName = Object.create(null);
         const originalNameKey = (name, type) => `${type}\u0000${name}`;
 
@@ -722,22 +738,43 @@ class Target extends EventEmitter {
                 }
                 continue;
             }
-            // The referenced id is not defined anywhere. Treat this as a reference
-            // to a global from a different project (or from a backpack paste / sprite
-            // import that lost its definition). Look for a same-name same-type global
-            // on the stage; if found, queue an id remap, otherwise create a fresh one.
+            // The referenced id is not defined anywhere. Resolve it the way the runtime
+            // would have when the block executed: by name and type on this target first,
+            // then on the stage. A sprite whose script carries a stale id for its own
+            // local variable (for example, a script pasted across sprites years ago)
+            // keeps sharing that one local with the rest of its scripts.
             const varRef = allReferences[varId][0];
             const varName = varRef.referencingField.value;
             const varType = varRef.type;
-            const existingVar = stage.lookupVariableByNameAndType(varName, varType);
+            const existingVar = this.lookupVariableByNameAndType(varName, varType);
             if (existingVar) {
                 if (!conflictIdsToReplace[varId]) {
                     conflictIdsToReplace[varId] = existingVar.id;
+                    const scope = Object.prototype.hasOwnProperty.call(this.variables, existingVar.id) ?
+                        'local' : 'stage';
                     log.warn(
                         `Reconciled dangling reference on '${this.getName()}': remapped id '${varId}' ` +
-                        `(name '${varName}', type '${varType}') to existing stage variable '${existingVar.id}'.`
+                        `(name '${varName}', type '${varType}') to existing ${scope} variable '${existingVar.id}'.`
                     );
                 }
+            } else if (
+                !createMissingOnStage &&
+                !this.isStage &&
+                varType !== Variable.BROADCAST_MESSAGE_TYPE
+            ) {
+                // Nothing in scope has this name, so create it here with the referenced
+                // name, as the runtime's lookupOrCreateVariable / lookupOrCreateList would
+                // have on first execution. The name can't collide with anything in scope
+                // (the lookup above just failed), and a same-named local on another
+                // sprite is an ordinary Scratch configuration. Later dangling references
+                // to this name on this target now resolve to it via the by-name lookup.
+                this.createVariable(varId, varName, varType);
+                // Bring any other references to this id into agreement on the name.
+                conflictNamesToReplace[varId] = varName;
+                log.warn(
+                    `Reconciled dangling reference on '${this.getName()}': created local variable ` +
+                    `'${varId}' (name '${varName}', type '${varType}').`
+                );
             } else {
                 const coalesceKey = originalNameKey(varName, varType);
                 const earlierCreated = createdForOriginalName[coalesceKey];
@@ -775,15 +812,15 @@ class Target extends EventEmitter {
             }
         }
 
-        // Apply queued id remaps (merge the dangling references with the existing global).
+        // Apply queued id remaps (merge the dangling references with the existing variable).
         for (const conflictId in conflictIdsToReplace) {
             const existingId = conflictIdsToReplace[conflictId];
             const referencesToUpdate = allReferences[conflictId];
             this.mergeVariables(conflictId, existingId, referencesToUpdate);
         }
 
-        // Apply queued field-name updates for newly-created globals whose name was
-        // bumped to avoid a collision.
+        // Apply queued field-name updates so every reference to an id displays the
+        // name of the variable it now resolves to.
         for (const conflictId in conflictNamesToReplace) {
             const newName = conflictNamesToReplace[conflictId];
             const referencesToUpdate = allReferences[conflictId];
@@ -810,7 +847,9 @@ class Target extends EventEmitter {
         if (!stage || !stage.variables) return;
 
         // First, ensure every referenced variable, list, or broadcast has a definition.
-        this.reconcileVariableReferences();
+        // An exported sprite carries its own locals, so anything still undefined was a
+        // global in the project it came from; recreate it as a global here.
+        this.reconcileVariableReferences(true);
 
         // The stage's variables are the global scope; there's no local-vs-global
         // distinction to disambiguate.

--- a/packages/scratch-vm/src/engine/variable.js
+++ b/packages/scratch-vm/src/engine/variable.js
@@ -65,16 +65,6 @@ class Variable {
     static get BROADCAST_MESSAGE_TYPE () {
         return 'broadcast_msg';
     }
-
-    /**
-     * Prefix the editor puts on cloud variable names: the cloud character
-     * followed by a space. The VM does not enforce it, but treats a name that
-     * carries it as belonging to a global when repairing references.
-     * @constant {string}
-     */
-    static get CLOUD_PREFIX () {
-        return '☁ ';
-    }
 }
 
 module.exports = Variable;

--- a/packages/scratch-vm/src/engine/variable.js
+++ b/packages/scratch-vm/src/engine/variable.js
@@ -65,6 +65,16 @@ class Variable {
     static get BROADCAST_MESSAGE_TYPE () {
         return 'broadcast_msg';
     }
+
+    /**
+     * Prefix the editor puts on cloud variable names: the cloud character
+     * followed by a space. The VM does not enforce it, but treats a name that
+     * carries it as belonging to a global when repairing references.
+     * @constant {string}
+     */
+    static get CLOUD_PREFIX () {
+        return '☁ ';
+    }
 }
 
 module.exports = Variable;

--- a/packages/scratch-vm/src/virtual-machine.js
+++ b/packages/scratch-vm/src/virtual-machine.js
@@ -562,9 +562,12 @@ class VirtualMachine extends EventEmitter {
 
             if (wholeProject) {
                 // A loaded project may carry dangling variable, list, or broadcast
-                // references baked in by historical bugs. Reconcile each target so
-                // those references resolve cleanly without renaming any legitimate
-                // local-vs-global name collisions.
+                // references baked in by historical bugs. First restore any
+                // definition that several targets still share, so they keep sharing
+                // it. Then reconcile each target so its remaining references resolve
+                // the way the runtime would have resolved them on execution, without
+                // renaming any legitimate local-vs-global name collisions.
+                this.runtime.restoreSharedMissingDefinitions(targets);
                 targets.forEach(target => target.reconcileVariableReferences());
             } else {
                 this.editingTarget.fixUpVariableReferences();
@@ -1503,7 +1506,7 @@ class VirtualMachine extends EventEmitter {
     }
 
     /**
-     * Reorder the sounds of a target if it exists. Return whether it occured.
+     * Reorder the sounds of a target if it exists. Return whether it occurred.
      * @param {!string} targetId ID of the target which owns the sounds.
      * @param {!number} soundIndex index of the sound to move.
      * @param {!number} newIndex index that the sound should be moved to.

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1447,7 +1447,8 @@ test('reconcileVariableReferences normalizes field values across targets after a
     targetA.blocks.createBlock(makeBlockReferencing('block A', 'shared dangling id', 'shared name'));
     targetB.blocks.createBlock(makeBlockReferencing('block B', 'shared dangling id', 'shared name'));
 
-    // Reconcile each target in turn, as installTargets does, using the stage-creation path.
+    // Reconcile each target in turn on the stage-creation path (the sprite-import
+    // behavior; whole-project load never bumps names, so it cannot hit this case).
     targetA.reconcileVariableReferences(true);
     targetB.reconcileVariableReferences(true);
 
@@ -1746,6 +1747,53 @@ test('reconcileVariableReferences creates a cloud-prefixed missing variable on t
     t.equal(stage.variables['lost cloud id'].name, cloudName);
     t.equal(stage.variables['lost cloud id'].isCloud, false, 'not registered as a live cloud variable');
     t.equal(Object.keys(target.variables).length, 0, 'nothing created on the sprite');
+
+    t.end();
+});
+
+test('reconcileVariableReferences keeps a cloud-prefixed missing list on the sprite', t => {
+    // Only scalars can be cloud variables. A list whose name happens to start with
+    // the cloud prefix is an ordinary list and stays local, as lookupOrCreateList
+    // would have made it.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    const listName = `${Variable.CLOUD_PREFIX}items`;
+    target.blocks.createBlock({
+        id: 'a block',
+        opcode: 'data_listcontents',
+        inputs: {},
+        fields: {
+            LIST: {
+                name: 'LIST',
+                id: 'lost list id',
+                value: listName,
+                variableType: Variable.LIST_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 0, 'nothing created on the stage');
+    t.same(Object.keys(target.variables), ['lost list id'], 'list created on the sprite');
+    t.equal(target.variables['lost list id'].name, listName);
+    t.equal(target.variables['lost list id'].type, Variable.LIST_TYPE);
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1724,8 +1724,10 @@ test('reconcileVariableReferences matches a dangling broadcast reference case-in
     t.end();
 });
 
-test('reconcileVariableReferences creates a cloud-prefixed missing variable on the stage', t => {
-    // Cloud variables are always global; a sprite-local "☁ score" would only confuse.
+test('reconcileVariableReferences keeps a cloud-prefixed missing variable on the sprite', t => {
+    // The cloud prefix is an editor naming convention, not scope metadata. The
+    // loader deliberately keeps a cloud-marked sprite-local as a regular local,
+    // and lookupOrCreateVariable creates locally regardless of the name.
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -1738,62 +1740,14 @@ test('reconcileVariableReferences creates a cloud-prefixed missing variable on t
 
     runtime.targets = [stage, target];
 
-    const cloudName = `${Variable.CLOUD_PREFIX}score`;
-    target.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'lost cloud id', cloudName));
-
-    target.reconcileVariableReferences();
-
-    t.same(Object.keys(stage.variables), ['lost cloud id'], 'created on the stage');
-    t.equal(stage.variables['lost cloud id'].name, cloudName);
-    t.equal(stage.variables['lost cloud id'].isCloud, false, 'not registered as a live cloud variable');
-    t.equal(Object.keys(target.variables).length, 0, 'nothing created on the sprite');
-
-    t.end();
-});
-
-test('reconcileVariableReferences keeps a cloud-prefixed missing list on the sprite', t => {
-    // Only scalars can be cloud variables. A list whose name happens to start with
-    // the cloud prefix is an ordinary list and stays local, as lookupOrCreateList
-    // would have made it.
-    const runtime = new Runtime();
-
-    const stage = new Target(runtime);
-    stage.isStage = true;
-    stage.getName = () => 'Stage';
-
-    const target = new Target(runtime);
-    target.isStage = false;
-    target.getName = () => 'Target';
-
-    runtime.targets = [stage, target];
-
-    const listName = `${Variable.CLOUD_PREFIX}items`;
-    target.blocks.createBlock({
-        id: 'a block',
-        opcode: 'data_listcontents',
-        inputs: {},
-        fields: {
-            LIST: {
-                name: 'LIST',
-                id: 'lost list id',
-                value: listName,
-                variableType: Variable.LIST_TYPE
-            }
-        },
-        next: null,
-        topLevel: true,
-        parent: null,
-        shadow: false,
-        x: 0,
-        y: 0
-    });
+    target.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'lost cloud id', '☁ score'));
 
     target.reconcileVariableReferences();
 
     t.equal(Object.keys(stage.variables).length, 0, 'nothing created on the stage');
-    t.same(Object.keys(target.variables), ['lost list id'], 'list created on the sprite');
-    t.equal(target.variables['lost list id'].name, listName);
-    t.equal(target.variables['lost list id'].type, Variable.LIST_TYPE);
+    t.same(Object.keys(target.variables), ['lost cloud id'], 'created on the sprite');
+    t.equal(target.variables['lost cloud id'].name, '☁ score');
+    t.equal(target.variables['lost cloud id'].isCloud, false);
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1723,6 +1723,33 @@ test('reconcileVariableReferences matches a dangling broadcast reference case-in
     t.end();
 });
 
+test('reconcileVariableReferences creates a cloud-prefixed missing variable on the stage', t => {
+    // Cloud variables are always global; a sprite-local "☁ score" would only confuse.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    const cloudName = `${Variable.CLOUD_PREFIX}score`;
+    target.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'lost cloud id', cloudName));
+
+    target.reconcileVariableReferences();
+
+    t.same(Object.keys(stage.variables), ['lost cloud id'], 'created on the stage');
+    t.equal(stage.variables['lost cloud id'].name, cloudName);
+    t.equal(stage.variables['lost cloud id'].isCloud, false, 'not registered as a live cloud variable');
+    t.equal(Object.keys(target.variables).length, 0, 'nothing created on the sprite');
+
+    t.end();
+});
+
 test('reconcileVariableReferences does not log on clean references', t => {
     const runtime = new Runtime();
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -1626,6 +1626,103 @@ test('fixUpVariableReferences remaps a dangling reference to a same-name sprite-
     t.end();
 });
 
+test('reconcileVariableReferences on the stage keeps the original name despite a same-named sprite local', t => {
+    // A stage script with a dangling "i" while some sprite owns a local "i". The
+    // runtime would have created a global "i" on first execution; bumping it to "i2"
+    // would break name-based access such as a sensing block reading "i of Stage".
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const sprite = new Target(runtime);
+    sprite.isStage = false;
+    sprite.getName = () => 'Sprite';
+    sprite.createVariable('sprite i id', 'i', Variable.SCALAR_TYPE);
+
+    runtime.targets = [stage, sprite];
+
+    stage.blocks.createBlock(makeVariableFieldBlock('block A', 'data_variable', 'dangling A', 'i'));
+    stage.blocks.createBlock(makeVariableFieldBlock('block B', 'data_variable', 'dangling B', 'i'));
+
+    stage.reconcileVariableReferences();
+
+    t.same(Object.keys(stage.variables), ['dangling A'], 'one global created, keeping the first id');
+    t.equal(stage.variables['dangling A'].name, 'i', 'global keeps the original name');
+    t.equal(sprite.variables['sprite i id'].name, 'i', 'sprite local untouched');
+
+    const fieldA = stage.blocks.getBlock('block A').fields.VARIABLE;
+    const fieldB = stage.blocks.getBlock('block B').fields.VARIABLE;
+    t.equal(fieldA.id, 'dangling A');
+    t.equal(fieldB.id, 'dangling A', 'second dangling ref coalesces to the created global by name');
+    t.equal(fieldA.value, 'i');
+    t.equal(fieldB.value, 'i');
+
+    t.end();
+});
+
+test('reconcileVariableReferences with createMissingOnStage still bumps past a same-named sprite local', t => {
+    // Sprite import keeps the historical behavior: a leftover reference becomes a
+    // global whose name collides with nothing in the project.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const otherSprite = new Target(runtime);
+    otherSprite.isStage = false;
+    otherSprite.getName = () => 'Other';
+    otherSprite.createVariable('other i id', 'i', Variable.SCALAR_TYPE);
+
+    const imported = new Target(runtime);
+    imported.isStage = false;
+    imported.getName = () => 'Imported';
+
+    runtime.targets = [stage, otherSprite, imported];
+
+    imported.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'dangling id', 'i'));
+
+    imported.reconcileVariableReferences(true);
+
+    t.same(Object.keys(stage.variables), ['dangling id'], 'global created');
+    t.equal(stage.variables['dangling id'].name, 'i2', 'name bumped past the other sprite\'s local');
+    t.equal(imported.blocks.getBlock('a block').fields.VARIABLE.value, 'i2', 'field shows the bumped name');
+    t.equal(Object.keys(imported.variables).length, 0, 'nothing created on the imported sprite');
+
+    t.end();
+});
+
+test('reconcileVariableReferences matches a dangling broadcast reference case-insensitively', t => {
+    // Broadcast names are matched case-insensitively at runtime, so a dangling
+    // "my message" should resolve to an existing "My Message" rather than create a
+    // second broadcast that differs only in case.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    stage.createVariable('existing broadcast id', 'My Message', Variable.BROADCAST_MESSAGE_TYPE);
+    addBroadcastBlocksTo(target);
+
+    target.reconcileVariableReferences();
+
+    t.same(Object.keys(stage.variables), ['existing broadcast id'], 'no second broadcast created');
+    const field = target.blocks.getBlock('boadcast shadow').fields.BROADCAST_OPTION;
+    t.equal(field.id, 'existing broadcast id', 'reference remapped to the existing broadcast');
+    t.equal(field.value, 'My Message', 'field displays the existing broadcast\'s name');
+
+    t.end();
+});
+
 test('reconcileVariableReferences does not log on clean references', t => {
     const runtime = new Runtime();
 

--- a/packages/scratch-vm/test/unit/engine_target.js
+++ b/packages/scratch-vm/test/unit/engine_target.js
@@ -408,7 +408,7 @@ test('duplicateVariables duplicates all variables', t => {
     t.equal(Object.prototype.hasOwnProperty.call(duplicateVariables, 'var ID 1'), true);
     t.equal(Object.prototype.hasOwnProperty.call(duplicateVariables, 'var ID 1'), true);
 
-    // Values of the duplicate varaiables should match the value of the original values at the time of duplication
+    // Values of the duplicate variables should match the value of the original values at the time of duplication
     t.equal(target.variables['var ID 1'].value, duplicateVariables['var ID 1'].value);
     t.equal(duplicateVariables['var ID 1'].value, 3);
     t.equal(target.variables['var ID 2'].value, duplicateVariables['var ID 2'].value);
@@ -967,7 +967,9 @@ test('fixUpVariableReferences on the stage creates broadcasts for undefined refe
     t.end();
 });
 
-test('reconcileVariableReferences creates a stage variable for an undefined variable reference', t => {
+test('reconcileVariableReferences creates a sprite-local variable for an undefined variable reference', t => {
+    // Project load: match what lookupOrCreateVariable would have done when the block
+    // first executed, which is to create the variable on the sprite under its own name.
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -986,6 +988,39 @@ test('reconcileVariableReferences creates a stage variable for an undefined vari
 
     target.reconcileVariableReferences();
 
+    t.equal(Object.keys(stage.variables).length, 0, 'no variable created on stage');
+    t.equal(Object.keys(target.variables).length, 1, 'variable created on the sprite');
+    const newVar = target.variables['mock var id'];
+    t.ok(newVar, 'variable preserves the original id');
+    t.equal(newVar.name, 'a mock variable');
+    t.equal(newVar.type, Variable.SCALAR_TYPE);
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'mock var id');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.value, 'a mock variable');
+
+    t.end();
+});
+
+test('reconcileVariableReferences with createMissingOnStage creates a stage variable', t => {
+    // Sprite import and backpack paste: an exported sprite carries its own locals, so an
+    // undefined reference must have been a global in the project it came from.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(adapter(events.mockVariableBlock)[0]);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+    t.equal(Object.keys(target.variables).length, 0);
+
+    target.reconcileVariableReferences(true);
+
     t.equal(Object.keys(stage.variables).length, 1, 'variable created on stage');
     const newVar = stage.variables['mock var id'];
     t.ok(newVar, 'variable preserves the original id');
@@ -997,7 +1032,7 @@ test('reconcileVariableReferences creates a stage variable for an undefined vari
     t.end();
 });
 
-test('reconcileVariableReferences creates a stage list for an undefined list reference', t => {
+test('reconcileVariableReferences creates a sprite-local list for an undefined list reference', t => {
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -1017,11 +1052,41 @@ test('reconcileVariableReferences creates a stage list for an undefined list ref
 
     target.reconcileVariableReferences();
 
+    t.equal(Object.keys(stage.variables).length, 0, 'no list created on stage');
+    t.equal(Object.keys(target.variables).length, 1, 'list created on the sprite');
+    const newList = target.variables['mock list id'];
+    t.ok(newList, 'list preserves the original id');
+    t.equal(newList.name, 'a mock list');
+    t.equal(newList.type, Variable.LIST_TYPE);
+    t.equal(target.blocks.getBlock('another block').fields.LIST.id, 'mock list id');
+
+    t.end();
+});
+
+test('reconcileVariableReferences with createMissingOnStage creates a stage list', t => {
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(adapter(events.mockListBlock)[0]);
+
+    t.equal(Object.keys(stage.variables).length, 0);
+
+    target.reconcileVariableReferences(true);
+
     t.equal(Object.keys(stage.variables).length, 1, 'list created on stage');
     const newList = stage.variables['mock list id'];
     t.ok(newList, 'list preserves the original id');
     t.equal(newList.name, 'a mock list');
     t.equal(newList.type, Variable.LIST_TYPE);
+    t.equal(Object.keys(target.variables).length, 0, 'no list on the sprite');
     t.equal(target.blocks.getBlock('another block').fields.LIST.id, 'mock list id');
 
     t.end();
@@ -1252,6 +1317,7 @@ test('reconcileVariableReferences coalesces same-original-name dangling refs to 
     // already uses it), the second ref must coalesce with the first rather than
     // create a second stage variable. A Scratcher who pasted two scripts referencing
     // what they called "score" almost certainly meant one variable, not two.
+    // Bumping only happens on the createMissingOnStage (sprite import) path.
     const runtime = new Runtime();
 
     const stage = new Target(runtime);
@@ -1309,7 +1375,7 @@ test('reconcileVariableReferences coalesces same-original-name dangling refs to 
         y: 0
     });
 
-    target.reconcileVariableReferences();
+    target.reconcileVariableReferences(true);
 
     const stageVars = Object.values(stage.variables);
     t.equal(stageVars.length, 1, 'exactly one new stage variable was created');
@@ -1342,7 +1408,7 @@ test('reconcileVariableReferences normalizes field values across targets after a
     stage.isStage = true;
     stage.getName = () => 'Stage';
 
-    // External collision forces unusedName to bump.
+    // External collision forces unusedName to bump (createMissingOnStage path only).
     const otherSprite = new Target(runtime);
     otherSprite.isStage = false;
     otherSprite.getName = () => 'Other';
@@ -1381,9 +1447,9 @@ test('reconcileVariableReferences normalizes field values across targets after a
     targetA.blocks.createBlock(makeBlockReferencing('block A', 'shared dangling id', 'shared name'));
     targetB.blocks.createBlock(makeBlockReferencing('block B', 'shared dangling id', 'shared name'));
 
-    // Match what installTargets does on whole-project load: reconcile each target in turn.
-    targetA.reconcileVariableReferences();
-    targetB.reconcileVariableReferences();
+    // Reconcile each target in turn, as installTargets does, using the stage-creation path.
+    targetA.reconcileVariableReferences(true);
+    targetB.reconcileVariableReferences(true);
 
     const stageVars = Object.values(stage.variables);
     t.equal(stageVars.length, 1, 'one stage variable created across both targets');
@@ -1394,6 +1460,168 @@ test('reconcileVariableReferences normalizes field values across targets after a
     const fieldB = targetB.blocks.getBlock('block B').fields.VARIABLE;
     t.equal(fieldA.value, created.name, 'target A field value matches the resolved variable name');
     t.equal(fieldB.value, created.name, 'target B field value matches the resolved variable name');
+
+    t.end();
+});
+
+const makeVariableFieldBlock = (blockId, opcode, fieldId, fieldValue) => ({
+    id: blockId,
+    opcode,
+    inputs: {},
+    fields: {
+        VARIABLE: {
+            name: 'VARIABLE',
+            id: fieldId,
+            value: fieldValue,
+            variableType: Variable.SCALAR_TYPE
+        }
+    },
+    next: null,
+    topLevel: true,
+    parent: null,
+    shadow: false,
+    x: 0,
+    y: 0
+});
+
+test('reconcileVariableReferences remaps a dangling reference to a same-name sprite-local variable', t => {
+    // Regression for scratchfoundation/scratch-editor#601. A sprite has a local "i"
+    // and a "for each" block whose variable field carries a stale id but the name "i".
+    // Before the repair-on-load existed, lookupOrCreateVariable resolved that field to
+    // the local "i" by name at execution time. The repair must do the same rather
+    // than minting a global "i2" and rewriting only the stale field to use it, which
+    // left the loop counting "i2" while the loop body read "i".
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    // Another sprite also has a local "i", so a stage-side creation would have
+    // had to bump the name (which is how "i2" appeared in the report).
+    const otherSprite = new Target(runtime);
+    otherSprite.isStage = false;
+    otherSprite.getName = () => 'Other';
+    otherSprite.createVariable('other i id', 'i', Variable.SCALAR_TYPE);
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'BSP';
+    target.createVariable('local i id', 'i', Variable.SCALAR_TYPE);
+
+    runtime.targets = [stage, otherSprite, target];
+
+    target.blocks.createBlock(makeVariableFieldBlock('for each', 'control_for_each', 'stale i id', 'i'));
+    target.blocks.createBlock(makeVariableFieldBlock('body', 'data_variable', 'local i id', 'i'));
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 0, 'no global created');
+    t.same(Object.keys(target.variables), ['local i id'], 'no new local created');
+    t.equal(target.variables['local i id'].name, 'i', 'local not renamed');
+    t.equal(otherSprite.variables['other i id'].name, 'i', 'other sprite local not renamed');
+
+    const loopField = target.blocks.getBlock('for each').fields.VARIABLE;
+    const bodyField = target.blocks.getBlock('body').fields.VARIABLE;
+    t.equal(loopField.id, 'local i id', 'stale reference remapped to the local');
+    t.equal(loopField.value, 'i', 'loop field still displays "i"');
+    t.equal(bodyField.id, 'local i id', 'clean reference untouched');
+    t.equal(bodyField.value, 'i', 'body field still displays "i"');
+
+    t.end();
+});
+
+test('reconcileVariableReferences prefers a same-name sprite-local over a same-name global', t => {
+    // Same precedence as lookupVariableByNameAndType: locals first, then the stage.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+    stage.createVariable('global score id', 'score', Variable.SCALAR_TYPE);
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+    target.createVariable('local score id', 'score', Variable.SCALAR_TYPE);
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'stale score id', 'score'));
+
+    target.reconcileVariableReferences();
+
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'local score id',
+        'stale reference remapped to the local, not the global');
+    t.equal(Object.keys(stage.variables).length, 1, 'no new global');
+    t.equal(Object.keys(target.variables).length, 1, 'no new local');
+
+    t.end();
+});
+
+test('reconcileVariableReferences creates a local even when another sprite has a same-named local', t => {
+    // Same-named locals on different sprites are an ordinary Scratch configuration,
+    // so a locally-created definition keeps its name rather than being bumped.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const otherSprite = new Target(runtime);
+    otherSprite.isStage = false;
+    otherSprite.getName = () => 'Other';
+    otherSprite.createVariable('other i id', 'i', Variable.SCALAR_TYPE);
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+
+    runtime.targets = [stage, otherSprite, target];
+
+    target.blocks.createBlock(makeVariableFieldBlock('block A', 'data_variable', 'dangling A', 'i'));
+    target.blocks.createBlock(makeVariableFieldBlock('block B', 'data_variable', 'dangling B', 'i'));
+
+    target.reconcileVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 0, 'no global created');
+    t.same(Object.keys(target.variables), ['dangling A'], 'one local created, keeping the first id');
+    t.equal(target.variables['dangling A'].name, 'i', 'name not bumped');
+
+    const fieldA = target.blocks.getBlock('block A').fields.VARIABLE;
+    const fieldB = target.blocks.getBlock('block B').fields.VARIABLE;
+    t.equal(fieldA.id, 'dangling A');
+    t.equal(fieldB.id, 'dangling A', 'second dangling ref coalesces to the created local by name');
+    t.equal(fieldA.value, 'i');
+    t.equal(fieldB.value, 'i');
+
+    t.end();
+});
+
+test('fixUpVariableReferences remaps a dangling reference to a same-name sprite-local variable', t => {
+    // The sprite-import path shares the by-name resolution; only the create-when-missing
+    // location differs.
+    const runtime = new Runtime();
+
+    const stage = new Target(runtime);
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+
+    const target = new Target(runtime);
+    target.isStage = false;
+    target.getName = () => 'Target';
+    target.createVariable('local i id', 'i', Variable.SCALAR_TYPE);
+
+    runtime.targets = [stage, target];
+
+    target.blocks.createBlock(makeVariableFieldBlock('a block', 'data_variable', 'stale i id', 'i'));
+
+    target.fixUpVariableReferences();
+
+    t.equal(Object.keys(stage.variables).length, 0, 'no global created');
+    t.same(Object.keys(target.variables), ['local i id'], 'no new local created');
+    t.equal(target.variables['local i id'].name, 'i', 'local not renamed');
+    t.equal(target.blocks.getBlock('a block').fields.VARIABLE.id, 'local i id', 'remapped to the local');
 
     t.end();
 });

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -1151,10 +1151,84 @@ test('installTargets repairs dangling variable references on whole-project load'
 
     const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
     vm.installTargets([stage, sprite], extensions, true).then(() => {
-        t.equal(Object.keys(stage.variables).length, 2, 'variable and broadcast created on stage');
-        t.ok(stage.variables['mock var id'], 'dangling variable reference reconciled');
+        // Match the runtime's lookupOrCreateVariable: an undefined variable is created on
+        // the sprite that references it, while broadcasts always live on the stage.
+        t.equal(Object.keys(stage.variables).length, 1, 'broadcast created on stage');
         t.ok(stage.variables['mock broadcast message id'], 'dangling broadcast reference reconciled');
-        t.equal(Object.keys(sprite.variables).length, 0, 'no spurious sprite-local variables');
+        t.equal(Object.keys(sprite.variables).length, 1, 'variable created on the sprite');
+        t.ok(sprite.variables['mock var id'], 'dangling variable reference reconciled');
+        t.equal(sprite.variables['mock var id'].name, 'a mock variable');
+
+        t.end();
+    });
+});
+
+test('installTargets resolves a dangling reference to the sprite\'s own same-name local on whole-project load', t => {
+    // Regression for scratchfoundation/scratch-editor#601: two sprites each own a local
+    // "i", the stage owns a global "total", and one sprite's "for each" block carries a
+    // stale id with the name "i". Loading must resolve that field to the sprite's own "i"
+    // and leave every other variable, on every target, untouched.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+
+    const stageSprite = new Sprite(null, runtime);
+    const stage = stageSprite.createClone();
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+    stage.createVariable('global total id', 'total', Variable.SCALAR_TYPE);
+
+    const makeSprite = name => {
+        const sprite = new Sprite(null, runtime);
+        const target = sprite.createClone();
+        target.isStage = false;
+        target.getName = () => name;
+        return target;
+    };
+    const makeVariableBlock = (blockId, opcode, fieldId, fieldValue) => ({
+        id: blockId,
+        opcode,
+        inputs: {},
+        fields: {
+            VARIABLE: {
+                name: 'VARIABLE',
+                id: fieldId,
+                value: fieldValue,
+                variableType: Variable.SCALAR_TYPE
+            }
+        },
+        next: null,
+        topLevel: true,
+        parent: null,
+        shadow: false,
+        x: 0,
+        y: 0
+    });
+
+    const setup = makeSprite('Setup');
+    setup.createVariable('setup i id', 'i', Variable.SCALAR_TYPE);
+    setup.blocks.createBlock(makeVariableBlock('setup loop', 'control_for_each', 'setup i id', 'i'));
+
+    const bsp = makeSprite('BSP');
+    bsp.createVariable('bsp i id', 'i', Variable.SCALAR_TYPE);
+    bsp.blocks.createBlock(makeVariableBlock('bsp loop', 'control_for_each', 'stale i id', 'i'));
+    bsp.blocks.createBlock(makeVariableBlock('bsp body', 'data_variable', 'bsp i id', 'i'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, setup, bsp], extensions, true).then(() => {
+        t.same(Object.keys(stage.variables), ['global total id'], 'no global created');
+        t.equal(stage.variables['global total id'].name, 'total', 'global not renamed');
+        t.same(Object.keys(setup.variables), ['setup i id'], 'other sprite untouched');
+        t.equal(setup.variables['setup i id'].name, 'i', 'other sprite local not renamed');
+        t.equal(setup.blocks.getBlock('setup loop').fields.VARIABLE.id, 'setup i id');
+        t.same(Object.keys(bsp.variables), ['bsp i id'], 'no new local on the affected sprite');
+        t.equal(bsp.variables['bsp i id'].name, 'i', 'affected sprite local not renamed');
+
+        const loopField = bsp.blocks.getBlock('bsp loop').fields.VARIABLE;
+        const bodyField = bsp.blocks.getBlock('bsp body').fields.VARIABLE;
+        t.equal(loopField.id, 'bsp i id', 'stale loop reference resolved to the sprite\'s own local');
+        t.equal(loopField.value, 'i');
+        t.equal(bodyField.id, 'bsp i id');
+        t.equal(bodyField.value, 'i');
 
         t.end();
     });

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -1234,6 +1234,144 @@ test('installTargets resolves a dangling reference to the sprite\'s own same-nam
     });
 });
 
+// Helpers for the shared-missing-definition tests below.
+const makeSpriteTarget = (runtime, name) => {
+    const sprite = new Sprite(null, runtime);
+    const target = sprite.createClone();
+    target.isStage = false;
+    target.getName = () => name;
+    return target;
+};
+const makeStageTarget = runtime => {
+    const sprite = new Sprite(null, runtime);
+    const stage = sprite.createClone();
+    stage.isStage = true;
+    stage.getName = () => 'Stage';
+    return stage;
+};
+const makeDanglingVariableBlock = (blockId, fieldId, fieldValue) => ({
+    id: blockId,
+    opcode: 'data_variable',
+    inputs: {},
+    fields: {
+        VARIABLE: {
+            name: 'VARIABLE',
+            id: fieldId,
+            value: fieldValue,
+            variableType: Variable.SCALAR_TYPE
+        }
+    },
+    next: null,
+    topLevel: true,
+    parent: null,
+    shadow: false,
+    x: 0,
+    y: 0
+});
+
+test('installTargets restores a missing global shared by several sprites on whole-project load', t => {
+    // The definition-dropping bug left a global's references intact on every sprite
+    // that used it. They shared one variable, so restore one global rather than
+    // giving each sprite a private local.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', 'lost global id', 'score'));
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', 'lost global id', 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB], extensions, true).then(() => {
+        t.same(Object.keys(stage.variables), ['lost global id'], 'one global restored under the shared id');
+        t.equal(stage.variables['lost global id'].name, 'score');
+        t.equal(Object.keys(spriteA.variables).length, 0, 'no local on A');
+        t.equal(Object.keys(spriteB.variables).length, 0, 'no local on B');
+        t.equal(spriteA.blocks.getBlock('block A').fields.VARIABLE.id, 'lost global id');
+        t.equal(spriteB.blocks.getBlock('block B').fields.VARIABLE.id, 'lost global id');
+        t.end();
+    });
+});
+
+test('installTargets leaves a shared missing id to per-sprite repair when a sprite owns a same-name local', t => {
+    // A same-name local on one referencing sprite is the #601 shape: that sprite
+    // would have resolved by name to its own local, so no global is restored. The
+    // other sprite falls back to creating its own local, as the runtime would have.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    spriteA.createVariable('a score id', 'score', Variable.SCALAR_TYPE);
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', 'stale id', 'score'));
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', 'stale id', 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB], extensions, true).then(() => {
+        t.equal(Object.keys(stage.variables).length, 0, 'no global restored');
+        t.same(Object.keys(spriteA.variables), ['a score id'], 'A keeps only its own local');
+        t.equal(spriteA.blocks.getBlock('block A').fields.VARIABLE.id, 'a score id', 'A resolved to its local');
+        t.same(Object.keys(spriteB.variables), ['stale id'], 'B created its own local');
+        t.equal(spriteB.variables['stale id'].name, 'score');
+        t.end();
+    });
+});
+
+test('installTargets remaps a shared missing id to an existing same-name global', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    stage.createVariable('existing score id', 'score', Variable.SCALAR_TYPE);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', 'lost global id', 'score'));
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', 'lost global id', 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB], extensions, true).then(() => {
+        t.same(Object.keys(stage.variables), ['existing score id'], 'no second global');
+        t.equal(spriteA.blocks.getBlock('block A').fields.VARIABLE.id, 'existing score id');
+        t.equal(spriteB.blocks.getBlock('block B').fields.VARIABLE.id, 'existing score id');
+        t.equal(Object.keys(spriteA.variables).length + Object.keys(spriteB.variables).length, 0, 'no locals');
+        t.end();
+    });
+});
+
+test('installTargets restores a missing global shared by the stage and a sprite', t => {
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const sprite = makeSpriteTarget(runtime, 'A');
+    stage.blocks.createBlock(makeDanglingVariableBlock('stage block', 'lost global id', 'score'));
+    sprite.blocks.createBlock(makeDanglingVariableBlock('sprite block', 'lost global id', 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, sprite], extensions, true).then(() => {
+        t.same(Object.keys(stage.variables), ['lost global id'], 'global restored');
+        t.equal(Object.keys(sprite.variables).length, 0, 'no local on the sprite');
+        t.equal(sprite.blocks.getBlock('sprite block').fields.VARIABLE.id, 'lost global id');
+        t.end();
+    });
+});
+
+test('installTargets on sprite import does not run the shared-definition restore', t => {
+    // Import reconciles only the imported sprite; there is nothing to share with.
+    // Its leftover reference still becomes a global via fixUpVariableReferences.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    runtime.targets = [stage];
+    const imported = makeSpriteTarget(runtime, 'Imported');
+    imported.blocks.createBlock(makeDanglingVariableBlock('a block', 'lost global id', 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([imported], extensions, false).then(() => {
+        t.same(Object.keys(stage.variables), ['lost global id'], 'global created by the import path');
+        t.equal(Object.keys(imported.variables).length, 0, 'no local on the imported sprite');
+        t.end();
+    });
+});
+
 test('installTargets does NOT rename clean local-vs-global name collisions on whole-project load', t => {
     // Regression guard: a project saved with a sprite-local variable that name-collides with
     // a stage global must load unchanged. The fixUpVariableReferences rename behavior is

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -1372,6 +1372,57 @@ test('installTargets on sprite import does not run the shared-definition restore
     });
 });
 
+test('installTargets does not restore a shared id that another sprite defines locally', t => {
+    // Sprite A owns the id as a local; B and C carry stale references to it from a
+    // script copied out of A long ago. That is not a lost global. The runtime gave
+    // B and C their own locals on execution, so the per-sprite repair does the same.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    const spriteC = makeSpriteTarget(runtime, 'C');
+    spriteA.createVariable('a local id', 'i', Variable.SCALAR_TYPE);
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', 'a local id', 'i'));
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', 'a local id', 'i'));
+    spriteC.blocks.createBlock(makeDanglingVariableBlock('block C', 'a local id', 'i'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB, spriteC], extensions, true).then(() => {
+        t.equal(Object.keys(stage.variables).length, 0, 'no global created');
+        t.same(Object.keys(spriteA.variables), ['a local id'], 'A untouched');
+        t.same(Object.keys(spriteB.variables), ['a local id'], 'B has its own local under the id');
+        t.same(Object.keys(spriteC.variables), ['a local id'], 'C has its own local under the id');
+        t.not(spriteB.variables['a local id'], spriteA.variables['a local id'], 'B\'s local is distinct from A\'s');
+        t.not(spriteC.variables['a local id'], spriteB.variables['a local id'], 'C\'s local is distinct from B\'s');
+        t.end();
+    });
+});
+
+test('installTargets judges a shadowing local by each referring sprite\'s own field name', t => {
+    // Two sprites reference the same missing id under different stale names, and
+    // one of them owns a local matching its own name. That sprite would have
+    // resolved to its local by name, so no global is restored.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', 'missing id', 'score'));
+    spriteB.createVariable('b points id', 'points', Variable.SCALAR_TYPE);
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', 'missing id', 'points'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB], extensions, true).then(() => {
+        t.equal(Object.keys(stage.variables).length, 0, 'no global restored');
+        t.equal(spriteB.blocks.getBlock('block B').fields.VARIABLE.id, 'b points id', 'B resolved to its local');
+        t.same(Object.keys(spriteB.variables), ['b points id'], 'B has only its own local');
+        t.same(Object.keys(spriteA.variables), ['missing id'], 'A created its own local');
+        t.equal(spriteA.variables['missing id'].name, 'score');
+        t.end();
+    });
+});
+
 test('installTargets does NOT rename clean local-vs-global name collisions on whole-project load', t => {
     // Regression guard: a project saved with a sprite-local variable that name-collides with
     // a stage global must load unchanged. The fixUpVariableReferences rename behavior is

--- a/packages/scratch-vm/test/unit/virtual-machine.js
+++ b/packages/scratch-vm/test/unit/virtual-machine.js
@@ -1399,6 +1399,32 @@ test('installTargets does not restore a shared id that another sprite defines lo
     });
 });
 
+test('installTargets does not merge id-less references from different sprites', t => {
+    // A field serialized as a one-element array has no id, and the reference
+    // collector files every such field under the key "undefined". Two sprites with
+    // id-less fields share nothing, so each keeps the per-sprite behavior.
+    const vm = new VirtualMachine();
+    const runtime = vm.runtime;
+    const stage = makeStageTarget(runtime);
+    const spriteA = makeSpriteTarget(runtime, 'A');
+    const spriteB = makeSpriteTarget(runtime, 'B');
+    spriteA.blocks.createBlock(makeDanglingVariableBlock('block A', undefined, 'score'));
+    spriteB.blocks.createBlock(makeDanglingVariableBlock('block B', undefined, 'score'));
+
+    const extensions = {extensionIDs: new Set(), extensionURLs: new Map()};
+    vm.installTargets([stage, spriteA, spriteB], extensions, true).then(() => {
+        t.equal(Object.keys(stage.variables).length, 0, 'no global created');
+        const aVars = Object.values(spriteA.variables);
+        const bVars = Object.values(spriteB.variables);
+        t.equal(aVars.length, 1, 'A has its own variable');
+        t.equal(bVars.length, 1, 'B has its own variable');
+        t.equal(aVars[0].name, 'score');
+        t.equal(bVars[0].name, 'score');
+        t.not(aVars[0], bVars[0], 'the two are distinct');
+        t.end();
+    });
+});
+
 test('installTargets judges a shadowing local by each referring sprite\'s own field name', t => {
     // Two sprites reference the same missing id under different stale names, and
     // one of them owns a local matching its own name. That sprite would have


### PR DESCRIPTION
### Resolves

- Resolves scratchfoundation/scratch-editor#601
- Refs scratchfoundation/scratch-editor#533

### Proposed Changes

`Target.reconcileVariableReferences` now resolves a variable, list, or broadcast reference whose id is defined nowhere the same way the runtime's `lookupOrCreateVariable` does when a block executes: by name and type on the sprite first, then on the stage. A sprite-local match wins over a same-named global. Broadcasts match case-insensitively, as the runtime's hat matching does. If nothing in scope has the name, project load creates the variable under that name on the sprite (or on the stage for broadcasts and for references in the stage's own scripts). No name is ever bumped on the project-load path.

Sprite import and backpack paste pass a new `createMissingOnStage` argument to `reconcileVariableReferences`, so a reference still undefined after the by-name lookup is created as a global with a non-colliding name, as before. An exported sprite carries its own locals, so anything left over was a global in the source project.

A new `Runtime.restoreSharedMissingDefinitions` runs before the per-target repair on whole-project load. For any variable or list id referenced from more than one target and defined on no target, it recreates the global on the stage under the referenced name, unless a referencing target owns a local matching its own field name or a same-name global already exists. Fields serialized without an id are skipped. Sprite import does not run it.

The commits are independent and may be easier to review one at a time. Later commits address review feedback.

### Reason for Changes

Since scratchfoundation/scratch-editor#555, whole-project load resolved dangling references against the stage only. A sprite that owned a local `i` and had a `for each` block carrying a stale id but the name `i` got a new global `i2` instead, and only the stale field was rewritten to use it. The loop then counted `i2` while its body read `i`, silently breaking projects (and all their remixes) that had run correctly for years. Before the load-time repair existed, execution-time lookup resolved such fields by name on the sprite first, so this change restores what those projects were built against.

Verified against the project linked from the issue: the stale `for each` fields in the Setup and BSP sprites now resolve to each sprite's own local `i`, and no `i2` global is created.

Not bumping names on the load path keeps name-based access working. A stage script with a dangling `i` while some sprite owns a local `i` used to become `i2`, which broke a sensing block reading "i of Stage". A global and a sprite-local sharing a name is an ordinary Scratch configuration, and scratch-blocks loads both into the workspace without complaint.

The shared-id pre-pass covers the corruption scratchfoundation/scratch-editor#555 was written for. When a global's definition was dropped but several targets still reference its id, they shared one variable, and the shared id is the strongest evidence of that. Repairing each target on its own would give each a private local and silently end that sharing. An id that any target still defines is not a lost global but a stale reference to that target's local, and a same-name local on a referencing sprite is likewise the stronger claim, so the shape reported in scratchfoundation/scratch-editor#601 still resolves locally.

A missing variable whose name carries the cloud prefix is created locally like any other. The prefix is an editor naming convention rather than scope metadata, the loader deliberately keeps cloud-marked sprite-locals as regular locals, and a lost cloud variable used by several sprites is already restored as a global by the pre-pass.

### Test Coverage

New Tap tests in `packages/scratch-vm/test/unit/engine_target.js`:

- a stale reference remaps to a same-name sprite-local, with another sprite also owning an `i` so the old code would have bumped the name
- a same-name local wins over a same-name global
- local creation keeps its name when another sprite has a same-named local, and a second dangling reference to that name coalesces to it
- the same by-name remap through `fixUpVariableReferences`
- a stage script's dangling reference keeps its original name despite a same-named sprite local
- `createMissingOnStage` still bumps past a same-named sprite local
- a dangling broadcast reference matches an existing broadcast case-insensitively
- a cloud-prefixed missing variable stays on the sprite

New Tap tests in `packages/scratch-vm/test/unit/virtual-machine.js`:

- a whole-project load with two sprites plus a global where only the stale field changes
- a missing global shared by several sprites is restored as one global
- a shared missing id is left to per-sprite repair when a sprite owns a same-name local
- a shared missing id remaps to an existing same-name global
- a missing global shared by the stage and a sprite is restored
- sprite import does not run the shared-definition restore
- a shared id that another sprite defines locally is not restored as a global
- a shadowing local is judged by each referring sprite's own field name
- id-less references on different sprites are not merged

Existing tests that asserted stage-side creation on project load were split into project-load and `createMissingOnStage` variants. The `project_*changed_state*` unit tests fail locally on this branch and on `develop` alike because the workspace copy of `@scratch/scratch-storage` has no built `dist`; CI covers them.

https://claude.ai/code/session_01TErdgwd5CzBV3hqX2mseXH
