### PR TITLE
fix: [IPR-1626] New gui middleware per redux store

### DIFF
--- a/packages/scratch-gui/src/exported-reducers.ts
+++ b/packages/scratch-gui/src/exported-reducers.ts
@@ -1,6 +1,13 @@
 import {ScratchPaintReducer} from '@scratch/scratch-paint';
 import LocalesReducer, {localesInitialState, initLocale, selectLocale} from './reducers/locales.js';
-import GuiReducer, {buildInitialState, guiMiddleware, initEmbedded, initFullScreen, initPlayer} from './reducers/gui';
+import GuiReducer, {
+    buildGuiMiddleware,
+    buildInitialState,
+    guiMiddleware,
+    initEmbedded,
+    initFullScreen,
+    initPlayer
+} from './reducers/gui';
 import {setFullScreen, setPlayer, setEmbedded} from './reducers/mode.js';
 import {activateDeck} from './reducers/cards.js';
 import {
@@ -81,6 +88,7 @@ export {
     closeTipsLibrary,
     closeConnectionModal,
     
+    buildGuiMiddleware,
     buildInitialState,
     guiMiddleware,
     initEmbedded,

--- a/packages/scratch-gui/src/lib/editor-state.tsx
+++ b/packages/scratch-gui/src/lib/editor-state.tsx
@@ -70,8 +70,8 @@ export class EditorState {
             const guiRedux = require('../reducers/gui');
             const guiReducer = guiRedux.default;
             const {
+                buildGuiMiddleware,
                 buildInitialState,
-                guiMiddleware,
                 initFullScreen,
                 initPlayer,
                 initTelemetryModal,
@@ -106,7 +106,7 @@ export class EditorState {
                 locales: initializedLocales,
                 scratchGui: initializedGui
             };
-            enhancer = composeEnhancers(guiMiddleware);
+            enhancer = composeEnhancers(buildGuiMiddleware());
         }
         const reducer = combineReducers(reducers);
         this.store = createStore(reducer, initialState, enhancer);

--- a/packages/scratch-gui/src/reducers/gui.ts
+++ b/packages/scratch-gui/src/reducers/gui.ts
@@ -35,7 +35,12 @@ import throttle from 'redux-throttle';
 import decks from '../lib/libraries/decks/index.jsx';
 import {GUIConfig} from '../gui-config';
 
-const guiMiddleware = compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
+const buildGuiMiddleware = () => compose(applyMiddleware(throttle(300, {leading: true, trailing: true})));
+
+/**
+ * @deprecated Call {@link buildGuiMiddleware} once per store instead.
+ */
+const guiMiddleware = buildGuiMiddleware();
 
 const buildInitialState = (config: GUIConfig) => ({
     alerts: alertsInitialState,
@@ -184,6 +189,7 @@ const guiReducer = combineReducers({
 
 export {
     guiReducer as default,
+    buildGuiMiddleware,
     buildInitialState,
     guiMiddleware,
     initEmbedded,


### PR DESCRIPTION
### Resolves

[IPR-1626](https://scratchfoundation.atlassian.net/browse/IPR-1626)

### Proposed Changes

Build the gui middleware per redux store and don't use one instance. `redux-throttle` caches the dispatched actions by type and and when the action is dispatched again from different instance the state of the first initiated reduces is updated.


[IPR-1626]: https://scratchfoundation.atlassian.net/browse/IPR-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ